### PR TITLE
Chore: Add GIX Team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # The codebase is owned by the Governance & Identity Experience team at DFINITY
 # For questions, reach out to: <gix@dfinity.org>
+* @dfinity/gix


### PR DESCRIPTION
# Motivation

Add GIX Team to Codeowners file.

# Changes

Add GIX Team to Codeowners file.