### PR TITLE
build: next

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: Next Publication
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Package next
+        run: ./scripts/package-next
+      - name: Set up npm
+        run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
+      - name: Publish
+        run: npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          working-directory: ./package

--- a/scripts/package-next
+++ b/scripts/package-next
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eux
+
+npm ci
+
+: Update the version to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
+node ./scripts/update-version.mjs
+
+: Now we can package
+npm run package

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const updateVersion = () => {
+  const packagePath = join(process.cwd(), "package", "package.json");
+
+  if (!existsSync(packagePath)) {
+    console.log(`Target ${packagePath} does not exist.`);
+    return;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+  packageJson.version = `${packageJson.version}-next-${new Date()
+    .toISOString()
+    .slice(0, 16)}`;
+  writeFileSync(packagePath, JSON.stringify(packageJson, null, 2), "utf-8");
+};
+
+updateVersion();


### PR DESCRIPTION
# Motivation

Package and publish to npm a next version.

# Note

- I called it `next` and not `nightly` even though this PR builds the library at midnight. We might have the need to build it twice a day, therefore though about using `next` which is more generic.

- @bitdivine this PR need the npm `NODE_AUTH_TOKEN` to be added to the repo, can you do so at the same time that you review the PR?

# Changes

- add scripts to package and publish to npm
