### PR TITLE
style: links text-decoration and docs

### DIFF
--- a/src/docs/styles/docs-global.scss
+++ b/src/docs/styles/docs-global.scss
@@ -27,3 +27,50 @@ table {
     font-size: var(--font-size-small);
   }
 }
+
+// Spacing and font-size of the content
+main {
+  & > h1:first-of-type {
+    font-size: var(--font-size-huge);
+  }
+
+  & > h2,
+  & > .grid {
+    margin-top: var(--padding-4x);
+
+    &:not(:first-of-type) {
+      margin-top: var(--padding-6x);
+    }
+  }
+
+  & > h3,
+  & > ul {
+    margin-top: var(--padding-3x);
+  }
+
+  table,
+  pre[class*="language-"] {
+    margin: var(--padding-3x) 0;
+  }
+}
+
+// Code fonts
+p code {
+  font-size: var(--font-size-small);
+  background: #2d2d2d;
+  padding: var(--padding-0_5x);
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+}
+
+// Content link color
+main {
+  a {
+    font-size: inherit;
+    text-decoration: underline;
+
+    &:focus,
+    &:hover {
+      color: var(--primary);
+    }
+  }
+}

--- a/src/lib/components/MenuItem.svelte
+++ b/src/lib/components/MenuItem.svelte
@@ -24,6 +24,11 @@
     text-decoration: none;
     outline: none;
 
+    &:focus,
+    &:hover {
+      text-decoration: none;
+    }
+
     padding: var(--padding-2x);
 
     &.selected {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -29,48 +29,4 @@
   @import "../lib/styles/global.scss";
   @import "../../node_modules/prismjs/themes/prism-tomorrow.css";
   @import "../docs/styles/docs-global.scss";
-
-  // Custom sizes for docs
-
-  main {
-    & > h1:first-of-type {
-      font-size: var(--font-size-huge);
-    }
-
-    & > h2,
-    & > .grid {
-      margin-top: var(--padding-4x);
-
-      &:not(:first-of-type) {
-        margin-top: var(--padding-6x);
-      }
-    }
-
-    & > h3,
-    & > ul {
-      margin-top: var(--padding-3x);
-    }
-
-    table,
-    pre[class*="language-"] {
-      margin: var(--padding-3x) 0;
-    }
-  }
-
-  a {
-    font-size: inherit;
-    text-decoration: underline;
-
-    &:focus,
-    &:hover {
-      color: var(--primary);
-    }
-  }
-
-  p code {
-    font-size: var(--font-size-small);
-    background: #2d2d2d;
-    padding: var(--padding-0_5x);
-    font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-  }
 </style>

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -6,7 +6,7 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 <Layout>
   <h4 slot="title">My dapp page</h4>
 
-  <svelte:fragment slot="menu">
+  <svelte:fragment slot="menu-items">
     <MenuItem href="/" on:click>
       Home
     </MenuItem>


### PR DESCRIPTION
# Motivation

In the docs showcase the links in the menu were displayed with a primary color and text-decoration underline if hovered.
This is is not the expected behavior - i.e. no text-decoration and no color change.

This PR also fix a typo in the docs for the menu-items slot name.

# Changes

- fix style colors in `docs` menu
- ensure `text-decoration` in `<MenuItems />`
- correct `menu-items` slot name in docs
- reorg style from `docs` layout to global scss
