### PR TITLE
feat: toolbar end and back button

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -24,7 +24,7 @@
 
       <slot name="title" />
 
-      <slot name="more" slot="end" />
+      <slot name="toolbar-end" slot="end" />
     </Toolbar>
   </header>
 

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -22,6 +22,8 @@
       </svelte:fragment>
 
       <slot name="title" />
+
+      <slot name="more" slot="end" />
     </Toolbar>
   </header>
 

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -3,6 +3,7 @@
   import Menu from "$lib/components/Menu.svelte";
   import Toolbar from "$lib/components/Toolbar.svelte";
   import MenuButton from "$lib/components/MenuButton.svelte";
+  import Back from "$lib/components/Back.svelte";
 
   export let back = false;
 
@@ -15,7 +16,7 @@
     <Toolbar>
       <svelte:fragment slot="start">
         {#if back}
-          <slot name="back" />
+          <Back slot="back" on:nnsBack />
         {:else}
           <MenuButton bind:open />
         {/if}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Layout from "$lib/components/Layout.svelte";
   import DocsMenu from "$docs/components/DocsMenu.svelte";
-  import Back from "$lib/components/Back.svelte";
   import { page } from "$app/stores";
   import { goto, afterNavigate } from "$app/navigation";
 
@@ -18,9 +17,7 @@
   $: back = ($page.routeId ?? "").includes("/");
 </script>
 
-<Layout {back}>
-  <Back slot="back" on:nnsBack={async () => await goBack()} />
-
+<Layout {back} on:nnsBack={async () => await goBack()}>
   <h4 slot="title">GIX Components</h4>
 
   <DocsMenu slot="menu-items" on:click />

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -3,14 +3,17 @@
   import DocsMenu from "$docs/components/DocsMenu.svelte";
   import Back from "$lib/components/Back.svelte";
   import { page } from "$app/stores";
-  import { goto } from "$app/navigation";
+  import { goto, afterNavigate } from "$app/navigation";
 
+  let navHistory: { from: URL | null; to: URL }[] = [];
   let back = false;
 
-  const goBack = async (defaultRoute = "/") => {
-    const { referrer } = document;
-    return goto(referrer.length > 0 ? referrer : defaultRoute);
-  };
+  const goBack = async (defaultRoute = "/") =>
+    navHistory.length === 1
+      ? goto(defaultRoute, { replaceState: true })
+      : history.back();
+
+  afterNavigate((navigation) => (navHistory = [navigation, ...navHistory]));
 
   $: back = ($page.routeId ?? "").includes("/");
 </script>

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -21,12 +21,18 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 
 ## Properties
 
-None.
+| Property | Description                        | Type      | Default |
+|----------|------------------------------------|-----------|---------|
+| `back`   | Enable to use the `back` slot. (*) | `boolean` | `false` |
+
+(*) Svelte cannot currently render slot dynamically based on others slot
 
 ## Slots
 
-| Slot name    | Description                                              |
-| ------------ | -------------------------------------------------------- |
-| Defautl slot | The default main section content.                        |
-| `title`      | The title of the page displayed centered in the toolbar. |
-| `menu-items` | The items of the menu - i.e. the links of the menu.      |
+| Slot name    | Description                                                                                                       |
+|--------------|-------------------------------------------------------------------------------------------------------------------|
+| Defautl slot | The default main section content.                                                                                 |
+| `title`      | The title of the page displayed centered in the toolbar.                                                          |
+| `menu-items` | The items of the menu - i.e. the links of the menu.                                                               |
+| `back`       | Can be use to add a back button action to the layout's toolbar. Has to be used together with the `back` property. |
+| `more`       | Addition options display on the right side of the toolbar.                                                        |

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -22,14 +22,14 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 ## Properties
 
 | Property | Description                                                     | Type      | Default |
-|----------|-----------------------------------------------------------------|-----------|---------|
+| -------- | --------------------------------------------------------------- | --------- | ------- |
 | `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false` |
 
 ## Slots
 
-| Slot name    | Description                                                                                                       |
-|--------------|-------------------------------------------------------------------------------------------------------------------|
-| Defautl slot | The default main section content.                                                                                 |
-| `title`      | The title of the page displayed centered in the toolbar.                                                          |
-| `menu-items` | The items of the menu - i.e. the links of the menu.                                                               |
-| `more`       | Addition options display on the right side of the toolbar.                                                        |
+| Slot name    | Description                                                |
+| ------------ | ---------------------------------------------------------- |
+| Defautl slot | The default main section content.                          |
+| `title`      | The title of the page displayed centered in the toolbar.   |
+| `menu-items` | The items of the menu - i.e. the links of the menu.        |
+| `more`       | Addition options display on the right side of the toolbar. |

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -6,7 +6,7 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 <Layout>
   <h4 slot="title">My dapp page</h4>
 
-  <svelte:fragment slot="menu">
+  <svelte:fragment slot="menu-items">
     <MenuItem href="/" on:click>
       Home
     </MenuItem>
@@ -21,11 +21,9 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 
 ## Properties
 
-| Property | Description                        | Type      | Default |
-|----------|------------------------------------|-----------|---------|
-| `back`   | Enable to use the `back` slot. (*) | `boolean` | `false` |
-
-(*) Svelte cannot currently render slot dynamically based on others slot
+| Property | Description                                                     | Type      | Default |
+|----------|-----------------------------------------------------------------|-----------|---------|
+| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false` |
 
 ## Slots
 
@@ -34,5 +32,4 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 | Defautl slot | The default main section content.                                                                                 |
 | `title`      | The title of the page displayed centered in the toolbar.                                                          |
 | `menu-items` | The items of the menu - i.e. the links of the menu.                                                               |
-| `back`       | Can be use to add a back button action to the layout's toolbar. Has to be used together with the `back` property. |
 | `more`       | Addition options display on the right side of the toolbar.                                                        |

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -27,9 +27,9 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 
 ## Slots
 
-| Slot name    | Description                                                |
-| ------------ | ---------------------------------------------------------- |
-| Defautl slot | The default main section content.                          |
-| `title`      | The title of the page displayed centered in the toolbar.   |
-| `menu-items` | The items of the menu - i.e. the links of the menu.        |
-| `more`       | Addition options display on the right side of the toolbar. |
+| Slot name     | Description                                               |
+| ------------- | --------------------------------------------------------- |
+| Defautl slot  | The default main section content.                         |
+| `title`       | The title of the page displayed centered in the toolbar.  |
+| `menu-items`  | The items of the menu - i.e. the links of the menu.       |
+| `toolbar-end` | An element that can be added to the `end` of the toolbar. |


### PR DESCRIPTION
# Motivation

Components:

- The layout should redirect the toolbar `end` slot  so that the consumer can use it - e.g. to display a user button
- Simplify the usage of the back action. Instead of passing a slot, add the `<Back />` component in the layout

Docs:
- While developing this noticed there was an issue in the `docs` website regarding the back button

# Changes

Components:

- add a `slot=toolbar-end` in the layout that target the `toolbar=end` (exposing "end" felt a bit generic so I gave it another name in the layout)
- include back button in layout
- modify docs accordingly

Docs:

- fix back action in the docs website