### PR TITLE
feat: menu close action if not sticky

### DIFF
--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import Backdrop from "./Backdrop.svelte";
   import { cubicOut } from "svelte/easing";
+  import { i18n } from "../stores/i18n";
+  import IconClose from "../icons/IconClose.svelte";
 
   // Type is not exposed by Svelte
   type SvelteTransitionConfig = {
@@ -41,6 +43,15 @@
     {/if}
 
     <div class="inner" transition:transition on:click={() => (open = false)}>
+      {#if !sticky}
+        <button
+          on:click={() => (open = false)}
+          aria-label={$i18n.core.close}
+          data-tid="menu-close"
+          class="close icon-only"><IconClose /></button
+        >
+      {/if}
+
       <slot />
     </div>
   </div>
@@ -89,5 +100,16 @@
     padding: var(--padding-4x) 0 0;
 
     overflow-y: auto;
+  }
+
+  .close {
+    align-self: flex-start;
+    display: flex;
+    margin: 0 var(--padding-0_5x) var(--padding);
+
+    :global(svg) {
+      width: var(--padding-6x);
+      height: var(--padding-6x);
+    }
   }
 </style>

--- a/src/lib/icons/IconClose.svelte
+++ b/src/lib/icons/IconClose.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let size: string = "24px";
+  export let size = "24px";
 </script>
 
 <!-- source: https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Aclose%3A -->

--- a/src/lib/icons/IconClose.svelte
+++ b/src/lib/icons/IconClose.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let size: string = "24px";
+</script>
+
+<!-- source: https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Aclose%3A -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  height={size}
+  viewBox="0 0 24 24"
+  width={size}
+  fill="currentColor"
+  ><path d="M0 0h24v24H0z" fill="none" /><path
+    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+  /></svg
+>

--- a/src/tests/components/Menu.spec.ts
+++ b/src/tests/components/Menu.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {render, type RenderResult, waitFor} from "@testing-library/svelte";
+import { render, type RenderResult, waitFor } from "@testing-library/svelte";
 import Menu from "$lib/components/Menu.svelte";
 import MenuTest from "./MenuTest.svelte";
 
@@ -34,7 +34,7 @@ describe("Menu", () => {
     });
 
     const backdrop: HTMLDivElement | null =
-        container.querySelector("div.backdrop");
+      container.querySelector("div.backdrop");
 
     expect(backdrop).not.toBeNull();
   });
@@ -47,7 +47,7 @@ describe("Menu", () => {
     });
 
     const backdrop: HTMLDivElement | null =
-        container.querySelector("div.backdrop");
+      container.querySelector("div.backdrop");
 
     expect(backdrop).toBeNull();
   });

--- a/src/tests/components/Menu.spec.ts
+++ b/src/tests/components/Menu.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import Menu from "$lib/components/Menu.svelte";
+
+describe("Menu", () => {
+  it("menu should be closed per default", () => {
+    const { getByRole } = render(Menu);
+    expect(() => getByRole("menu")).toThrow();
+  });
+
+  it("menu should be open", () => {
+    const { getByRole } = render(Menu, { props: { open: true } });
+    expect(getByRole("menu")).toBeInTheDocument();
+  });
+});

--- a/src/tests/components/Menu.spec.ts
+++ b/src/tests/components/Menu.spec.ts
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { render } from "@testing-library/svelte";
+import {render, type RenderResult, waitFor} from "@testing-library/svelte";
 import Menu from "$lib/components/Menu.svelte";
+import MenuTest from "./MenuTest.svelte";
 
 describe("Menu", () => {
   it("menu should be closed per default", () => {
@@ -11,8 +12,49 @@ describe("Menu", () => {
     expect(() => getByRole("menu")).toThrow();
   });
 
-  it("menu should be open", () => {
-    const { getByRole } = render(Menu, { props: { open: true } });
-    expect(getByRole("menu")).toBeInTheDocument();
+  const openMenu = async ({ getByRole }: RenderResult) => {
+    await waitFor(() => expect(getByRole("menu")).not.toBeNull());
+  };
+
+  it("should be open", async () => {
+    const renderResult = render(Menu, {
+      props: {
+        open: true,
+      },
+    });
+
+    await openMenu(renderResult);
+  });
+
+  it("should render a backdrop", () => {
+    const { container } = render(Menu, {
+      props: {
+        open: true,
+      },
+    });
+
+    const backdrop: HTMLDivElement | null =
+        container.querySelector("div.backdrop");
+
+    expect(backdrop).not.toBeNull();
+  });
+
+  it("should not render a backdrop if sticky", () => {
+    const { container } = render(Menu, {
+      props: {
+        sticky: true,
+      },
+    });
+
+    const backdrop: HTMLDivElement | null =
+        container.querySelector("div.backdrop");
+
+    expect(backdrop).toBeNull();
+  });
+
+  it("should render slotted content", () => {
+    const { getByTestId } = render(MenuTest);
+
+    expect(getByTestId("menu-test-slot")).not.toBeNull();
   });
 });


### PR DESCRIPTION
# Motivation

When the menu is not sticky, a "close" button is displayed within the overlay menu as 

# Changes

- copy "close" icon and action as in nns-dapp

# Screenshots

<img width="1066" alt="Capture d’écran 2022-08-09 à 07 56 59" src="https://user-images.githubusercontent.com/16886711/183575671-425d642a-575a-45e6-885c-f4747a3c7945.png">

