### PR TITLE
feat: support for deprecated layout

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -5,6 +5,7 @@
   import MenuButton from "$lib/components/MenuButton.svelte";
 
   export let back = false;
+  export let modern = true;
 
   let sticky: boolean;
   let open: boolean;
@@ -29,7 +30,21 @@
     <slot name="menu-items" />
   </Menu>
 
-  <main>
+  <main class:nns={!modern}>
     <slot />
   </main>
 </SplitPane>
+
+<style lang="scss">
+  @use "../styles/mixins/media";
+
+  .nns {
+    margin: inherit;
+    padding: inherit;
+    max-width: inherit;
+
+    @include media.min-width(medium) {
+      padding: inherit;
+    }
+  }
+</style>

--- a/src/lib/styles/global.scss
+++ b/src/lib/styles/global.scss
@@ -1,7 +1,7 @@
 @import "./global/variables";
 @import "./global/fonts.scss";
 @import "./global/theme.scss";
-@import "./global/layout";
+@import "./global/layout.scss";
 @import "./global/button.scss";
 @import "./global/link.scss";
 @import "./global/modal.scss";

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -22,7 +22,7 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 ## Properties
 
 | Property | Description                                                                | Type      | Default |
-|----------|----------------------------------------------------------------------------| --------- |---------|
+| -------- | -------------------------------------------------------------------------- | --------- | ------- |
 | `modern` | Backwards compatibility for deprecated layout. Will ultimately be removed. | `boolean` | `true`  |
 
 ## Slots

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -6,7 +6,7 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 <Layout>
   <h4 slot="title">My dapp page</h4>
 
-  <svelte:fragment slot="menu">
+  <svelte:fragment slot="menu-items">
     <MenuItem href="/" on:click>
       Home
     </MenuItem>
@@ -21,12 +21,15 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 
 ## Properties
 
-None.
+| Property | Description                                                                | Type      | Default |
+|----------|----------------------------------------------------------------------------| --------- |---------|
+| `modern` | Backwards compatibility for deprecated layout. Will ultimately be removed. | `boolean` | `true`  |
 
 ## Slots
 
-| Slot name    | Description                                              |
-| ------------ | -------------------------------------------------------- |
-| Defautl slot | The default main section content.                        |
-| `title`      | The title of the page displayed centered in the toolbar. |
-| `menu-items` | The items of the menu - i.e. the links of the menu.      |
+| Slot name     | Description                                               |
+| ------------- | --------------------------------------------------------- |
+| Defautl slot  | The default main section content.                         |
+| `title`       | The title of the page displayed centered in the toolbar.  |
+| `menu-items`  | The items of the menu - i.e. the links of the menu.       |
+| `toolbar-end` | An element that can be added to the `end` of the toolbar. |


### PR DESCRIPTION
# Motivation

For backwards compatibility, the design system needs to support the old layout as well.

# Changes

- add property `modern=true` to `<Layout />` and unset padding and margin on `main` element if old layout
