### PR TITLE
build: package first and then update version

### DIFF
--- a/scripts/package-next
+++ b/scripts/package-next
@@ -3,8 +3,9 @@ set -eux
 
 npm ci
 
-: Update the version to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
+: Package first
+npm run package
+
+: Then update the version in the package to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
 node ./scripts/update-version.mjs
 
-: Now we can package
-npm run package

--- a/scripts/package-next
+++ b/scripts/package-next
@@ -8,4 +8,3 @@ npm run package
 
 : Then update the version in the package to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
 node ./scripts/update-version.mjs
-

--- a/scripts/package-next
+++ b/scripts/package-next
@@ -3,7 +3,7 @@ set -eux
 
 npm ci
 
-: Package first
+: Package first the library
 npm run package
 
 : Then update the version to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02

--- a/scripts/package-next
+++ b/scripts/package-next
@@ -6,5 +6,5 @@ npm ci
 : Package first
 npm run package
 
-: Then update the version in the package to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
+: Then update the version to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
 node ./scripts/update-version.mjs


### PR DESCRIPTION
# Motivation

The modified version is overwritten by the package step. We should first package and then update the version number. This is different than in nns-dapp or ic-js.
