### PR TITLE
build: fix ci working dir

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,6 @@ jobs:
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
         run: npm publish --tag next
+        working-directory: ./package
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          working-directory: ./package


### PR DESCRIPTION
# Motivation

To publish to npm the job needs to find place in sub-folder `package`

# Changes

- working dir property was not set correctly

