### PR TITLE
build: fix npm missing user

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@ jobs:
         run: ./scripts/package-next
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
+        working-directory: ./package
       - name: Publish
         run: npm publish --tag next
         working-directory: ./package


### PR DESCRIPTION
# Motivation

The publish to npm is failing (see https://github.com/dfinity/gix-components/runs/7750678770?check_suite_focus=true). Most probably because the token is set to the root and not the working directory `package`.

# Changes

- set `npmrc` in working dir
