### PR TITLE
style: fix layout overflow-y

### DIFF
--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -32,6 +32,12 @@
   .content {
     position: relative;
     width: 100%;
+
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    display: flex;
+    justify-content: center;
   }
 
   @include media.min-width(xlarge) {

--- a/src/lib/styles/global/layout.scss
+++ b/src/lib/styles/global/layout.scss
@@ -2,10 +2,8 @@
 
 main {
   height: 100%;
-  overflow-y: auto;
-  overflow-x: hidden;
+  width: 100%;
 
-  margin: 0 auto;
   padding: var(--padding-4x) var(--padding-2x);
   max-width: var(--max-main-content-width);
   box-sizing: border-box;


### PR DESCRIPTION
# Motivation

The layout overflow-y scrollbar of the new design is incorrectly displayed within the viewport.

# Changes

- overflow `content` instead of `main`

# Screenshots

Is:

<img width="1491" alt="Capture d’écran 2022-08-10 à 12 27 47" src="https://user-images.githubusercontent.com/16886711/183880260-65b677e7-b8d6-4dba-a5b3-d17e627ba7ce.png">

After this PR:

<img width="1510" alt="Capture d’écran 2022-08-10 à 12 29 03" src="https://user-images.githubusercontent.com/16886711/183880297-a6e8b056-98de-4ed6-9c31-9efcbbc8a5c4.png">

