### PR TITLE
style: fix grid article height

### DIFF
--- a/src/lib/styles/global/grid.scss
+++ b/src/lib/styles/global/grid.scss
@@ -14,7 +14,9 @@
     grid-template-columns: 1fr 1fr 1fr;
   }
 
-  :global(article) {
+  :global(article:first-of-type) {
     margin: 0;
+    height: 100%;
+    box-sizing: border-box;
   }
 }


### PR DESCRIPTION
# Motivation

article height in grid are not correctly inherited and not strech neither.

# Screenshots

is:

<img width="1510" alt="Capture d’écran 2022-08-15 à 17 05 18" src="https://user-images.githubusercontent.com/16886711/184662368-088d82ac-c90b-474b-a3b1-6943d04ecb17.png">


will be fixed has:

<img width="1510" alt="Capture d’écran 2022-08-15 à 17 12 53" src="https://user-images.githubusercontent.com/16886711/184662486-09e7a6ab-0334-4b94-9bca-d6a5e4e7f525.png">

