### PR TITLE
feat: infinite scroll grid option

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -6,6 +6,7 @@
   } from "$lib/constants/constants";
 
   export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
+  export let layout: "list" | "grid" = "list";
 
   // IntersectionObserverInit is not recognized by the linter
   // eslint-disable-next-line no-undef
@@ -94,7 +95,7 @@
   onDestroy(() => observer.disconnect());
 </script>
 
-<ul bind:this={container}>
+<ul bind:this={container} class:layout>
   <slot />
 </ul>
 

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -18,7 +18,7 @@ It sets the reference after each re-render of the list. **Pay attention to not t
 ## Properties
 
 | Property    | Description                                                              | Type             | Detail                              |
-|-------------|--------------------------------------------------------------------------|------------------|-------------------------------------|
+| ----------- | ------------------------------------------------------------------------ | ---------------- | ----------------------------------- |
 | `pageLimit` | How many items each pagination group contains?                           | `number`         | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
 | `layout`    | Display of the rendered items. Defined by a class set on `ul` container. | `list` or `grid` | `list`                              |
 

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -17,9 +17,10 @@ It sets the reference after each re-render of the list. **Pay attention to not t
 
 ## Properties
 
-| Property    | Description                                    | Type     | Detail                              |
-| ----------- | ---------------------------------------------- | -------- | ----------------------------------- |
-| `pageLimit` | How many items each pagination group contains? | `number` | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
+| Property    | Description                                                              | Type             | Detail                              |
+|-------------|--------------------------------------------------------------------------|------------------|-------------------------------------|
+| `pageLimit` | How many items each pagination group contains?                           | `number`         | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
+| `layout`    | Display of the rendered items. Defined by a class set on `ul` container. | `list` or `grid` | `list`                              |
 
 ## Events
 


### PR DESCRIPTION
# Motivation

In the new ui we will have to use the infinite scroll as grid too.

# Changes

- add a `layout` property to `<InfiniteScroll />` component (`list` or `grid`)
