### PR TITLE
fix: class layout

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -95,7 +95,7 @@
   onDestroy(() => observer.disconnect());
 </script>
 
-<ul bind:this={container} class:layout>
+<ul bind:this={container} class={layout}>
   <slot />
 </ul>
 


### PR DESCRIPTION
# Motivation

The class should receive the value of the prop.

# Changes

- `class:layout` renders `class="layout" we want `class={layout}` to render the value