### PR TITLE
style: fix card height in grid

### DIFF
--- a/src/lib/styles/global/grid.scss
+++ b/src/lib/styles/global/grid.scss
@@ -14,7 +14,7 @@
     grid-template-columns: 1fr 1fr 1fr;
   }
 
-  :global(article:first-of-type) {
+  :global(.card) {
     margin: 0;
     height: 100%;
     box-sizing: border-box;


### PR DESCRIPTION
# Motivation

The selector was valid for infinite scroll grid but not normal grid.

# Changes

- update card selector in grid to apply margin and height

# Screenshots

is:

<img width="1510" alt="Capture d’écran 2022-08-16 à 07 44 32" src="https://user-images.githubusercontent.com/16886711/184807352-ac33f6ea-8b9e-4038-ba8c-5107646f2d50.png">

fixed:

<img width="1510" alt="Capture d’écran 2022-08-16 à 07 44 48" src="https://user-images.githubusercontent.com/16886711/184807384-e44b9599-95b2-4c2d-853f-fab4e6d57670.png">

