### PR TITLE
fix: layout legacy footer

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -6,7 +6,6 @@
   import Back from "$lib/components/Back.svelte";
 
   export let back = false;
-  export let modern = true;
 
   let sticky: boolean;
   let open: boolean;
@@ -33,21 +32,5 @@
     <slot name="menu-items" />
   </Menu>
 
-  <main class:nns={!modern}>
-    <slot />
-  </main>
+  <slot />
 </SplitPane>
-
-<style lang="scss">
-  @use "../styles/mixins/media";
-
-  .nns {
-    margin: inherit;
-    padding: inherit;
-    max-width: inherit;
-
-    @include media.min-width(medium) {
-      padding: inherit;
-    }
-  }
-</style>

--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -12,7 +12,9 @@
 
 <div class="split-pane">
   <slot name="menu" />
-  <div class="content"><slot /></div>
+  <div class="content">
+    <div class="scrollable-content"><slot /></div>
+  </div>
 </div>
 
 <style lang="scss">
@@ -32,12 +34,13 @@
   .content {
     position: relative;
     width: 100%;
+  }
+
+  .scrollable-content {
+    height: 100%;
 
     overflow-x: hidden;
     overflow-y: auto;
-
-    display: flex;
-    justify-content: center;
   }
 
   @include media.min-width(xlarge) {

--- a/src/lib/styles/global/layout.scss
+++ b/src/lib/styles/global/layout.scss
@@ -13,16 +13,6 @@ main {
   @include media.min-width(medium) {
     padding: var(--padding-4x);
   }
-
-  &.legacy {
-    margin: inherit;
-    padding: inherit;
-    max-width: inherit;
-
-    @include media.min-width(medium) {
-      padding: inherit;
-    }
-  }
 }
 
 header {

--- a/src/lib/styles/global/layout.scss
+++ b/src/lib/styles/global/layout.scss
@@ -4,12 +4,24 @@ main {
   height: fit-content;
   width: 100%;
 
+  margin: 0 auto;
+
   padding: var(--padding-4x) var(--padding-2x);
   max-width: var(--max-main-content-width);
   box-sizing: border-box;
 
   @include media.min-width(medium) {
     padding: var(--padding-4x);
+  }
+
+  &.nns {
+    margin: inherit;
+    padding: inherit;
+    max-width: inherit;
+
+    @include media.min-width(medium) {
+      padding: inherit;
+    }
   }
 }
 
@@ -31,4 +43,11 @@ header {
   color: var(--primary-gradient-contrast);
 
   --toolbar-pointer-events: all;
+}
+
+footer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }

--- a/src/lib/styles/global/layout.scss
+++ b/src/lib/styles/global/layout.scss
@@ -14,7 +14,7 @@ main {
     padding: var(--padding-4x);
   }
 
-  &.nns {
+  &.legacy {
     margin: inherit;
     padding: inherit;
     max-width: inherit;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -23,7 +23,9 @@
 
   <DocsMenu slot="menu-items" on:click />
 
-  <slot />
+  <main>
+    <slot />
+  </main>
 </Layout>
 
 <style lang="scss" global>

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -41,7 +41,7 @@ Layout component is used to create the layout of a dapp. It renders the `<Toolba
 
 Although the default slot accepts any type of elements, to implement a responsive layout, it is recommended to use a `main` element that will be styled by the library.
 
-Likewise, if you wish to display some footer action, it is also recommended to use a `footer` element that is automatically positioned too.
+Likewise, if you wish to display some footer action, it is also recommended to use a `footer` element that is automatically absolutely positioned too.
 
 Example 1:
 

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -1,6 +1,6 @@
 # Layout
 
-Layout component is used to create the main layout of a dapp. It renders the `<Toolbar />`, a `<Menu />` (sticky on wide screen, overlay on mobile) and a slotted content.
+Layout component is used to create the layout of a dapp. It renders the `<Toolbar />`, a `<Menu />` (sticky on wide screen, overlay on mobile) and a slotted content.
 
 ```javascript
 <Layout>
@@ -15,7 +15,9 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
     </MenuItem>
   </svelte:fragment>
 
-  <slot />
+  <main>
+    <slot />
+  </main>
 </Layout>
 ```
 
@@ -30,7 +32,48 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 
 | Slot name     | Description                                               |
 | ------------- |-----------------------------------------------------------|
-| Defautl slot  | The content.                                              |
+| Defautl slot  | The content. See note about composition here under.       |
 | `title`       | The title of the page displayed centered in the toolbar.  |
 | `menu-items`  | The items of the menu - i.e. the links of the menu.       |
 | `toolbar-end` | An element that can be added to the `end` of the toolbar. |
+
+### Composition
+
+Although the default slot accepts any type of elements, to implement a responsive layout, it is recommended to use a `main` element that will be styled by the library.
+
+Likewise, if you wish to display some footer action, it is also recommended to use a `footer` element that is automatically positioned too.
+
+Example 1:
+
+```html
+<!-- Your dapp _layout.svelte -->
+<Layout>
+  <Title slot="title">My dapp page</Title>
+  
+  <slot />
+</Layout>
+
+<!-- Your dapp index.svelte -->
+<main>Hello</main>
+<footer><button>Action</button></footer>
+```
+
+Example 2:
+
+
+```html
+<!-- Your dapp _layout.svelte -->
+<Layout>
+  <Title slot="title">My dapp page</Title>
+  
+  <main>
+      <slot />
+  </main>
+    
+  <footer><slot name="footer" /></footer>  
+</Layout>
+
+<!-- Your dapp index.svelte -->
+Hello
+<button slot="footer">Action</button>
+```

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -31,7 +31,7 @@ Layout component is used to create the layout of a dapp. It renders the `<Toolba
 ## Slots
 
 | Slot name     | Description                                               |
-| ------------- |-----------------------------------------------------------|
+| ------------- | --------------------------------------------------------- |
 | Defautl slot  | The content. See note about composition here under.       |
 | `title`       | The title of the page displayed centered in the toolbar.  |
 | `menu-items`  | The items of the menu - i.e. the links of the menu.       |
@@ -48,8 +48,8 @@ Example 1:
 ```html
 <!-- Your dapp _layout.svelte -->
 <Layout>
-  <Title slot="title">My dapp page</Title>
-  
+  <title slot="title">My dapp page</title>
+
   <slot />
 </Layout>
 
@@ -60,17 +60,16 @@ Example 1:
 
 Example 2:
 
-
 ```html
 <!-- Your dapp _layout.svelte -->
 <Layout>
-  <Title slot="title">My dapp page</Title>
-  
+  <title slot="title">My dapp page</title>
+
   <main>
-      <slot />
+    <slot />
   </main>
-    
-  <footer><slot name="footer" /></footer>  
+
+  <footer><slot name="footer" /></footer>
 </Layout>
 
 <!-- Your dapp index.svelte -->

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -1,6 +1,6 @@
 # Layout
 
-Layout component is used to create the main layout of a dapp. It renders the `<Toolbar />`, a `<Menu />` (sticky on wide screen, overlay on mobile) and encapsulates the `<main />` content.
+Layout component is used to create the main layout of a dapp. It renders the `<Toolbar />`, a `<Menu />` (sticky on wide screen, overlay on mobile) and a slotted content.
 
 ```javascript
 <Layout>
@@ -29,8 +29,8 @@ Layout component is used to create the main layout of a dapp. It renders the `<T
 ## Slots
 
 | Slot name     | Description                                               |
-| ------------- | --------------------------------------------------------- |
-| Defautl slot  | The default main section content.                         |
+| ------------- |-----------------------------------------------------------|
+| Defautl slot  | The content.                                              |
 | `title`       | The title of the page displayed centered in the toolbar.  |
 | `menu-items`  | The items of the menu - i.e. the links of the menu.       |
 | `toolbar-end` | An element that can be added to the `end` of the toolbar. |


### PR DESCRIPTION
# Motivation

The footer of the legacy layout is broken - i.e. is not sticky anymore.

# Changes

- defer the responsibility to the consumer to use the `main` and `footer` elements
- add a `scrollable-content` to the split pane (otherwise footers position absolute won't be sticky)
- rename `nns` option in `legacy`
