### PR TITLE
feat: cards mixins and style

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -53,6 +53,7 @@
   @use "../styles/mixins/interaction";
   @use "../styles/mixins/media";
   @use "../styles/mixins/display";
+  @use "../styles/mixins/card";
 
   article {
     text-decoration: none;
@@ -124,15 +125,6 @@
   }
 
   div {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
-    @include media.min-width(small) {
-      @include display.space-between;
-      flex-direction: row;
-
-      margin: 0 0 var(--padding);
-    }
+    @include card.meta;
   }
 </style>

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -56,6 +56,9 @@
   @use "../styles/mixins/card";
 
   article {
+    display: flex;
+    flex-direction: column;
+
     text-decoration: none;
 
     background: var(--card-background);
@@ -68,6 +71,7 @@
     border-radius: var(--border-radius);
 
     outline: 2px solid transparent;
+
     &.selected {
       outline: 2px solid var(--primary);
     }

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -95,7 +95,7 @@
   onDestroy(() => observer.disconnect());
 </script>
 
-<ul bind:this={container} class:layout>
+<ul bind:this={container} class={layout}>
   <slot />
 </ul>
 

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -6,6 +6,7 @@
   } from "$lib/constants/constants";
 
   export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
+  export let layout: "list" | "grid" = "list";
 
   // IntersectionObserverInit is not recognized by the linter
   // eslint-disable-next-line no-undef
@@ -94,7 +95,7 @@
   onDestroy(() => observer.disconnect());
 </script>
 
-<ul bind:this={container}>
+<ul bind:this={container} class:layout>
   <slot />
 </ul>
 

--- a/src/lib/styles/mixins/_card.scss
+++ b/src/lib/styles/mixins/_card.scss
@@ -1,0 +1,54 @@
+@use "./text";
+@use "./media";
+@use "./display";
+
+@mixin stacked-title {
+  display: grid;
+  flex-direction: column;
+
+  margin: 0 0 var(--padding);
+  max-width: 100%;
+
+  &:global(~ div) {
+    margin: 0 0 var(--padding);
+  }
+}
+
+@mixin list {
+  list-style-type: none;
+  padding: 0;
+  margin-bottom: var(--padding-2x);
+  display: flex;
+  flex-direction: column;
+  gap: var(--padding);
+}
+
+@mixin list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+@mixin title {
+  line-height: var(--line-height-standard);
+  margin: 0 var(--padding) 0 0;
+
+  @include text.truncate;
+}
+
+@mixin meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  @include media.min-width(small) {
+    @include display.space-between;
+    flex-direction: row;
+
+    margin: 0 0 var(--padding);
+  }
+
+  :global(.value:last-of-type) {
+    text-align: right;
+  }
+}

--- a/src/lib/styles/mixins/_card.scss
+++ b/src/lib/styles/mixins/_card.scss
@@ -38,15 +38,9 @@
 
 @mixin meta {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  @include display.space-between;
 
-  @include media.min-width(small) {
-    @include display.space-between;
-    flex-direction: row;
-
-    margin: 0 0 var(--padding);
-  }
+  margin: 0 0 var(--padding);
 
   :global(.value:last-of-type) {
     text-align: right;

--- a/src/routes/components.svelte
+++ b/src/routes/components.svelte
@@ -29,6 +29,12 @@
     <p>A grid based columns container to spread content.</p>
   </Card>
 
+  <Card role="link" on:click={() => goto("/components/card")}>
+    <h2 class="title" slot="start">Card</h2>
+
+    <p>Cards are surfaces that display content and optionally actions on a single topic.</p>
+  </Card>
+
   <Card role="link" on:click={() => goto("/components/infinite-scroll")}>
     <h2 class="title" slot="start">Infinite Scroll</h2>
 
@@ -39,7 +45,6 @@
 <p>TODO docs:</p>
 
 <ul>
-  <li>Card</li>
   <li>
     Back, menu, menubutton, menuitem, splitpane (maybe, included in layout)
   </li>

--- a/src/routes/components/card.md
+++ b/src/routes/components/card.md
@@ -1,3 +1,7 @@
+<script lang="ts">
+    import Card from "$lib/components/Card.svelte";
+</script>
+
 # Card
 
 Cards are surfaces that display content and optionally actions on a single topic. They often serve as an entry point to more detailed information.
@@ -39,3 +43,30 @@ Cards are surfaces that display content and optionally actions on a single topic
 
 ## Showcase
 
+<div class="grid" style="margin-top: var(--padding)">
+    <Card>
+        <h2 slot="start">Start</h2>
+        <h3 slot="end">End</h3>
+
+        <p>A basic card.</p>
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card selected>
+        <h3>Selected</h3>
+        
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card highlighted>
+        <h3>Highlighted</h3>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card withArrow>
+        <h3>Arrow</h3>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+</div>

--- a/src/routes/components/card.md
+++ b/src/routes/components/card.md
@@ -8,17 +8,20 @@ Cards are surfaces that display content and optionally actions on a single topic
 
 ```html
 <Card>
-    <h2 slot="start">Everything</h2>
-    <h3 slot="end">on-chain</h3>
-    
-    <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+  <h2 slot="start">Everything</h2>
+  <h3 slot="end">on-chain</h3>
+
+  <p>
+    Advanced smart contracts process HTTP requests, control other chains, and
+    scale infinitely
+  </p>
 </Card>
 ```
 
 ## Properties
 
 | Property      | Description                                                                                    | Type                                            | Default     |
-|---------------|------------------------------------------------------------------------------------------------|-------------------------------------------------|-------------|
+| ------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------- | ----------- |
 | `role`        | The semantic role of the `article` that will be rendered in the DOM when using this component. | `link` or `button` or `checkbox` or `undefined` | `undefined` |
 | `ariaLabel`   | An accessible label for the card.                                                              | `string` or `undefined`                         | `undefined` |
 | `selected`    | Display the surface as `selected`. Useful if used as a on/off call to action.                  | `boolean`                                       | `false`     |
@@ -30,7 +33,7 @@ Cards are surfaces that display content and optionally actions on a single topic
 ## Slots
 
 | Slot name    | Description                                                                                          |
-|--------------|------------------------------------------------------------------------------------------------------|
+| ------------ | ---------------------------------------------------------------------------------------------------- |
 | Default slot | The content of the card.                                                                             |
 | `start`      | A heading title or content displayed at the top left side of the card.                               |
 | `end`        | A heading title or content displayed stacked or at the top right side of the card (on wider screen). |
@@ -38,7 +41,7 @@ Cards are surfaces that display content and optionally actions on a single topic
 ## Events
 
 | Event   | Description                                | Detail    |
-|---------|--------------------------------------------|-----------|
+| ------- | ------------------------------------------ | --------- |
 | `click` | Propagated click event (if not `disabled`. | Inherited |
 
 ## Showcase
@@ -54,7 +57,7 @@ Cards are surfaces that display content and optionally actions on a single topic
 
     <Card selected>
         <h3>Selected</h3>
-        
+
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 
@@ -69,4 +72,5 @@ Cards are surfaces that display content and optionally actions on a single topic
 
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
+
 </div>

--- a/src/routes/components/card.md
+++ b/src/routes/components/card.md
@@ -48,10 +48,9 @@ Cards are surfaces that display content and optionally actions on a single topic
 
 <div class="grid" style="margin-top: var(--padding)">
     <Card>
-        <h2 slot="start">Start</h2>
-        <h3 slot="end">End</h3>
+        <h3 slot="start">A basic</h3>
+        <h3 slot="end">Card</h3>
 
-        <p>A basic card.</p>
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 

--- a/src/routes/components/card.md
+++ b/src/routes/components/card.md
@@ -1,0 +1,41 @@
+# Card
+
+Cards are surfaces that display content and optionally actions on a single topic. They often serve as an entry point to more detailed information.
+
+```html
+<Card>
+    <h2 slot="start">Everything</h2>
+    <h3 slot="end">on-chain</h3>
+    
+    <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+</Card>
+```
+
+## Properties
+
+| Property      | Description                                                                                    | Type                                            | Default     |
+|---------------|------------------------------------------------------------------------------------------------|-------------------------------------------------|-------------|
+| `role`        | The semantic role of the `article` that will be rendered in the DOM when using this component. | `link` or `button` or `checkbox` or `undefined` | `undefined` |
+| `ariaLabel`   | An accessible label for the card.                                                              | `string` or `undefined`                         | `undefined` |
+| `selected`    | Display the surface as `selected`. Useful if used as a on/off call to action.                  | `boolean`                                       | `false`     |
+| `disabled`    | Disable clickable events.                                                                      | `boolean` or `undefined`                        | `undefined` |
+| `testId`      | Add a `data-tid` attribute to the DOM, useful for test purpose.                                | `string`                                        | `card`      |
+| `highlighted` | Display the surface as `highlighted`.                                                          | `boolean` or `undefined`                        | `undefined` |
+| `withArrow`   | Render an arrow icon / call to action next within the card on the right side.                  | `boolean` or `undefined`                        | `undefined` |
+
+## Slots
+
+| Slot name    | Description                                                                                          |
+|--------------|------------------------------------------------------------------------------------------------------|
+| Default slot | The content of the card.                                                                             |
+| `start`      | A heading title or content displayed at the top left side of the card.                               |
+| `end`        | A heading title or content displayed stacked or at the top right side of the card (on wider screen). |
+
+## Events
+
+| Event   | Description                                | Detail    |
+|---------|--------------------------------------------|-----------|
+| `click` | Propagated click event (if not `disabled`. | Inherited |
+
+## Showcase
+

--- a/src/routes/components/card.md
+++ b/src/routes/components/card.md
@@ -46,10 +46,16 @@ Cards are surfaces that display content and optionally actions on a single topic
 
 ## Styling
 
-In addition to the style that is inherited by using the component, the library also exposes few SCSS mixins that can be used to style the content projected in the card.
+In addition to the style that is inherited by using the component, the library also exposes a SCSS mixins that can be used to style the content projected in the card.
+
+```scss
+@use "@dfinity/gix-components/styles/mixins/card";
+```
+
+List of the mixins:
 
 | Mixin           | Description                                                                                                         |
-|-----------------|---------------------------------------------------------------------------------------------------------------------|
+| --------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `stacked-title` | A column commonly use to display two information in `start` and `end` slots.                                        |
 | `list`          | To display a list of information in `ul` without bullet style.                                                      |
 | `list-item`     | Style the `li` within above list.                                                                                   |
@@ -84,4 +90,63 @@ In addition to the style that is inherited by using the component, the library a
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 
+    <Card>
+        <div slot="start" class="title-block">
+            <span>Stacked title</span>
+            <span>Styling</span>
+        </div>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card>
+        <h3>List styling</h3>
+
+        <ul>
+            <li>First item</li>
+            <li>Second item</li>
+            <li>Third item</li>
+        </ul>
+    </Card>
+
+    <Card>
+        <div class="meta">
+            <span class="value">Meta</span>
+            <span class="value">Styling</span>
+        </div>
+
+        <div class="meta">
+            <span>Label</span>
+            <span class="value">Value</span>
+        </div>
+
+        <div class="meta">
+            <span>Label</span>
+            <span class="value">Value</span>
+        </div>
+
+        <p class="description">A description - Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
 </div>
+
+<style lang="scss">
+  @use "../../lib/styles/mixins/card";
+
+  .title-block {
+    @include card.stacked-title;
+    @include card.title;
+  }
+
+  ul {
+    @include card.list;
+  }
+
+  li {
+    @include card.list-item;
+  }
+
+  .meta {
+    @include card.meta;
+  }
+</style>

--- a/src/routes/components/card.md
+++ b/src/routes/components/card.md
@@ -44,6 +44,18 @@ Cards are surfaces that display content and optionally actions on a single topic
 | ------- | ------------------------------------------ | --------- |
 | `click` | Propagated click event (if not `disabled`. | Inherited |
 
+## Styling
+
+In addition to the style that is inherited by using the component, the library also exposes few SCSS mixins that can be used to style the content projected in the card.
+
+| Mixin           | Description                                                                                                         |
+|-----------------|---------------------------------------------------------------------------------------------------------------------|
+| `stacked-title` | A column commonly use to display two information in `start` and `end` slots.                                        |
+| `list`          | To display a list of information in `ul` without bullet style.                                                      |
+| `list-item`     | Style the `li` within above list.                                                                                   |
+| `title`         | A title that will be truncated on one line if overflow.                                                             |
+| `meta`          | Add space between two information and ensure return to new lines. Commonly used to pressent a `label` and a `value` |
+
 ## Showcase
 
 <div class="grid" style="margin-top: var(--padding)">

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -22,14 +22,14 @@ It sets the reference after each re-render of the list. **Pay attention to not t
 | `pageLimit` | How many items each pagination group contains?                           | `number`         | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
 | `layout`    | Display of the rendered items. Defined by a class set on `ul` container. | `list` or `grid` | `list`                              |
 
+## Slots
+
+| Slot name    | Description                                 |
+|--------------| ------------------------------------------- |
+| Default slot | The list of elements. Should be `li` nodes. |
+
 ## Events
 
 | Event          | Description                                                                                                | Detail    |
 | -------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
 | `nnsIntersect` | Triggered each time the next observed item is intersecting. The event that can be use to call your action. | No detail |
-
-## Slots
-
-| Slot name    | Description                                 |
-| ------------ | ------------------------------------------- |
-| Defautl slot | The list of elements. Should be `li` nodes. |

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -17,9 +17,10 @@ It sets the reference after each re-render of the list. **Pay attention to not t
 
 ## Properties
 
-| Property    | Description                                    | Type     | Detail                              |
-| ----------- | ---------------------------------------------- | -------- | ----------------------------------- |
-| `pageLimit` | How many items each pagination group contains? | `number` | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
+| Property    | Description                                                              | Type             | Detail                              |
+| ----------- | ------------------------------------------------------------------------ | ---------------- | ----------------------------------- |
+| `pageLimit` | How many items each pagination group contains?                           | `number`         | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
+| `layout`    | Display of the rendered items. Defined by a class set on `ul` container. | `list` or `grid` | `list`                              |
 
 ## Events
 

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -26,13 +26,12 @@ Layout component is used to create the layout of a dapp. It renders the `<Toolba
 | Property | Description                                                                | Type      | Default |
 | -------- | -------------------------------------------------------------------------- | --------- | ------- |
 | `back`   | Display an arrowed `back` button instead of the hamburger menu.            | `boolean` | `false` |
-| `modern` | Backwards compatibility for deprecated layout. Will ultimately be removed. | `boolean` | `true`  |
 
 ## Slots
 
 | Slot name     | Description                                               |
 | ------------- | --------------------------------------------------------- |
-| Defautl slot  | The content. See note about composition here under.       |
+| Default slot  | The content. See note about composition here under.       |
 | `title`       | The title of the page displayed centered in the toolbar.  |
 | `menu-items`  | The items of the menu - i.e. the links of the menu.       |
 | `toolbar-end` | An element that can be added to the `end` of the toolbar. |


### PR DESCRIPTION
# Motivation

Moving `_card.scss` mixins to `gix-components` and made few style adjustment for the new design ("list of proposals")

# Changes

lib:

- move `_card.scss` from nns-dapp to gix-components
- add new mixin `meta` for "list of proposals"
- make card > article a `display: flex + flex-direction: column` so that the last meta can be aligned bottom. This potentially impact all cards but as far as I tested, they all actually already follow that column layout

docs:

- `<Card />` component documentation

# Screenshots

<img width="1510" alt="Capture d’écran 2022-08-17 à 21 20 53" src="https://user-images.githubusercontent.com/16886711/185224944-18fa9fe7-30c5-444f-9961-b74ef6209c1b.png">
<img width="1510" alt="Capture d’écran 2022-08-17 à 21 21 02" src="https://user-images.githubusercontent.com/16886711/185224958-d6f81f6f-e471-4b1d-8a21-de62937a09fe.png">
lm
<img width="1510" alt="Capture d’écran 2022-08-17 à 21 21 05" src="https://user-images.githubusercontent.com/16886711/185224973-13549d6e-1300-46f7-b53c-ee6669695083.png">
<img width="1510" alt="Capture d’écran 2022-08-17 à 21 21 08" src="https://user-images.githubusercontent.com/16886711/185224974-863743c9-a28c-49b8-a47d-4d52010be082.png">
<img width="1510" alt="Capture d’écran 2022-08-17 à 21 21 14" src="https://user-images.githubusercontent.com/16886711/185224978-f248f263-e158-44be-8a0c-16495751b7f9.png">

