### PR TITLE
feat: two columns & two rows, two columns

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+
+  let itemA: boolean;
+  $: itemA = $$slots["item-a"];
+  let itemB: boolean;
+  $: itemB = $$slots["item-b"];
+  let itemC: boolean;
+  $: itemC = $$slots["item-c"];
+  let itemD: boolean;
+  $: itemD = $$slots["item-d"];
+</script>
+
+<div class="wrapper" data-tid={testId}>
+  {#if itemA}
+    <div class="item-a">
+      <slot name="item-a" />
+    </div>
+  {/if}
+
+  {#if itemB}
+    <div class="item-b">
+      <slot name="item-b" />
+    </div>
+  {/if}
+
+  {#if itemC}
+    <div class="item-c">
+      <slot name="item-c" />
+    </div>
+  {/if}
+
+  {#if itemD}
+    <div class="item-d">
+      <slot name="item-d" />
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "../styles/mixins/media";
+  @use "../styles/mixins/grid";
+
+  .wrapper {
+    @include grid.wrapper;
+
+    @include media.min-width(large) {
+      grid-template-rows: auto;
+      grid-template-areas:
+        "item-a item-a item-a item-a item-a item-a item-b item-b item-b item-b item-b item-b"
+        "item-c item-c item-c item-c item-c item-c item-d item-d item-d item-d item-d item-d";
+    }
+
+    .item-a {
+      grid-area: item-a;
+    }
+
+    .item-b {
+      grid-area: item-b;
+    }
+
+    .item-c {
+      grid-area: item-c;
+    }
+
+    .item-d {
+      grid-area: item-d;
+    }
+  }
+</style>

--- a/src/lib/components/TwoColumns.svelte
+++ b/src/lib/components/TwoColumns.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+</script>
+
+<div class="wrapper" data-tid={testId}>
+  <div class="start">
+    <slot name="start" />
+  </div>
+  <div class="end">
+    <slot name="end" />
+  </div>
+</div>
+
+<style lang="scss">
+  @use "../styles/mixins/media";
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--row-gap);
+    width: 100%;
+
+    @include media.min-width(large) {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      place-items: stretch;
+      column-gap: var(--column-gap);
+      min-height: auto;
+
+      .start {
+        grid-column-start: 1;
+        grid-column-end: 6;
+      }
+
+      .end {
+        grid-column-start: 7;
+        grid-column-end: 13;
+      }
+    }
+  }
+</style>

--- a/src/lib/components/TwoColumns.svelte
+++ b/src/lib/components/TwoColumns.svelte
@@ -13,20 +13,12 @@
 
 <style lang="scss">
   @use "../styles/mixins/media";
+  @use "../styles/mixins/grid";
 
   .wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: var(--row-gap);
-    width: 100%;
+    @include grid.wrapper;
 
     @include media.min-width(large) {
-      display: grid;
-      grid-template-columns: repeat(12, 1fr);
-      place-items: stretch;
-      column-gap: var(--column-gap);
-      min-height: auto;
-
       .start {
         grid-column-start: 1;
         grid-column-end: 6;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,6 +10,7 @@ export { default as Card } from "./components/Card.svelte";
 export { default as InfiniteScroll } from "./components/InfiniteScroll.svelte";
 export { default as HeaderTitle } from "./components/HeaderTitle.svelte";
 export { default as TwoColumns } from "./components/TwoColumns.svelte";
+export { default as Content } from "./components/Content.svelte";
 
 export { default as IconArrowRight } from "./icons/IconArrowRight.svelte";
 export { default as IconBackIosNew } from "./icons/IconBackIosNew.svelte";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,6 +9,7 @@ export { default as Back } from "./components/Back.svelte";
 export { default as Card } from "./components/Card.svelte";
 export { default as InfiniteScroll } from "./components/InfiniteScroll.svelte";
 export { default as HeaderTitle } from "./components/HeaderTitle.svelte";
+export { default as TwoColumns } from "./components/TwoColumns.svelte";
 
 export { default as IconArrowRight } from "./icons/IconArrowRight.svelte";
 export { default as IconBackIosNew } from "./icons/IconBackIosNew.svelte";

--- a/src/lib/styles/mixins/_grid.scss
+++ b/src/lib/styles/mixins/_grid.scss
@@ -1,0 +1,16 @@
+@use "./media";
+
+@mixin wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--row-gap);
+  width: 100%;
+
+  @include media.min-width(large) {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    place-items: stretch;
+    column-gap: var(--column-gap);
+    min-height: auto;
+  }
+}

--- a/src/routes/components.svelte
+++ b/src/routes/components.svelte
@@ -29,6 +29,12 @@
     <p>A grid based columns container to spread content.</p>
   </Card>
 
+  <Card role="link" on:click={() => goto("/components/two-columns")}>
+    <h2 class="title" slot="start">Two Columns</h2>
+
+    <p>A responsive columns based container.</p>
+  </Card>
+
   <Card role="link" on:click={() => goto("/components/card")}>
     <h2 class="title" slot="start">Card</h2>
 

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -1,8 +1,8 @@
 # Infinite Scroll
 
-The Infinite Scroll component calls an action to be performed when the user scrolls a specified distance of the list presented in the page.
+The `<InfiniteScroll />` component calls an action to be performed when the user scrolls a specified distance of the list presented in the page.
 
-```javascript
+```html
 <InfiniteScroll>
   {#each array as data}
     <li>{data}</li>

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -5,7 +5,7 @@ The `<InfiniteScroll />` component calls an action to be performed when the user
 ```html
 <InfiniteScroll>
   {#each array as data}
-    <li>{data}</li>
+  <li>{data}</li>
   {/each}
 </InfiniteScroll>
 ```

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -4,15 +4,11 @@
 
 ```html
 <Layout>
-  <Title slot="title">My dapp page</Title>
+  <title slot="title">My dapp page</title>
 
   <svelte:fragment slot="menu-items">
-    <MenuItem href="/" on:click>
-      Home
-    </MenuItem>
-    <MenuItem href="/page" on:click>
-      page
-    </MenuItem>
+    <menuitem href="/" on:click> Home </menuitem>
+    <menuitem href="/page" on:click> page </menuitem>
   </svelte:fragment>
 
   <main>

--- a/src/routes/components/layout.md
+++ b/src/routes/components/layout.md
@@ -1,8 +1,8 @@
 # Layout
 
-Layout component is used to create the layout of a dapp. It renders the `<Toolbar />`, a `<Menu />` (sticky on wide screen, overlay on mobile) and a slotted content.
+`<Layout />` component is used to create the layout of a dapp. It renders the `<Toolbar />`, a `<Menu />` (sticky on wide screen, overlay on mobile) and a slotted content.
 
-```javascript
+```html
 <Layout>
   <Title slot="title">My dapp page</Title>
 

--- a/src/routes/components/two-columns.md
+++ b/src/routes/components/two-columns.md
@@ -1,0 +1,21 @@
+# Two Columns
+
+A container that split its content into two columns on wider devices and on a single one on smaller devices.
+
+```html
+<TwoColumns>
+    <div slot="start">
+        Some content
+    </div>
+    <div slot="end">
+        Some more details and actions
+    </div>
+</TwoColumns>
+```
+
+## Slots
+
+| Slot name | Description                                                                                                |
+|-----------|------------------------------------------------------------------------------------------------------------|
+| `start`   | The first column or content. Currently left column on wider devices and first content on smaller devices.  |
+| `end`     | The second column or content. Currently right column on wider devices and last content on smaller devices. |

--- a/src/routes/components/two-columns.md
+++ b/src/routes/components/two-columns.md
@@ -4,18 +4,14 @@ A container that split its content into two columns on wider devices and on a si
 
 ```html
 <TwoColumns>
-    <div slot="start">
-        Some content
-    </div>
-    <div slot="end">
-        Some more details and actions
-    </div>
+  <div slot="start">Some content</div>
+  <div slot="end">Some more details and actions</div>
 </TwoColumns>
 ```
 
 ## Slots
 
 | Slot name | Description                                                                                                |
-|-----------|------------------------------------------------------------------------------------------------------------|
+| --------- | ---------------------------------------------------------------------------------------------------------- |
 | `start`   | The first column or content. Currently left column on wider devices and first content on smaller devices.  |
 | `end`     | The second column or content. Currently right column on wider devices and last content on smaller devices. |

--- a/src/tests/components/ToolbarTest.svelte
+++ b/src/tests/components/ToolbarTest.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <Toolbar>
-  <div data-tid="toolbar-test-start-slot" />
+  <div data-tid="toolbar-test-start-slot" slot="start" />
   <div data-tid="toolbar-test-slot" />
-  <div data-tid="toolbar-test-end-slot" />
+  <div data-tid="toolbar-test-end-slot" slot="end" />
 </Toolbar>

--- a/src/tests/components/TwoColumns.spec.ts
+++ b/src/tests/components/TwoColumns.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import TwoColumnsTest from "./TwoColumnsTest.svelte";
+
+describe("TwoColumns", () => {
+  it("should render slots", () => {
+    const { getByTestId } = render(TwoColumnsTest);
+
+    expect(getByTestId("two-columns-test-start-slot")).not.toBeNull();
+    expect(getByTestId("two-columns-test-end-slot")).not.toBeNull();
+
+    expect(
+      getByTestId(
+        "two-columns-test-start-slot"
+      )?.parentElement?.classList.contains("start")
+    ).toBeTruthy();
+    expect(
+      getByTestId(
+        "two-columns-test-end-slot"
+      )?.parentElement?.classList.contains("end")
+    ).toBeTruthy();
+  });
+
+  it("should style two columns with classes", () => {
+    const { getByTestId } = render(TwoColumnsTest);
+
+    expect(
+      getByTestId(
+        "two-columns-test-start-slot"
+      )?.parentElement?.classList.contains("start")
+    ).toBeTruthy();
+    expect(
+      getByTestId(
+        "two-columns-test-end-slot"
+      )?.parentElement?.classList.contains("end")
+    ).toBeTruthy();
+  });
+});

--- a/src/tests/components/TwoColumnsTest.svelte
+++ b/src/tests/components/TwoColumnsTest.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import TwoColumns from "$lib/components/TwoColumns.svelte";
+</script>
+
+<TwoColumns>
+  <div data-tid="two-columns-test-start-slot" slot="start" />
+  <div data-tid="two-columns-test-end-slot" slot="end" />
+</TwoColumns>


### PR DESCRIPTION
# Motivation

Move `<TwoColumns />` cmp from NNS-dapp and add a new component for two rows and two columns.

# Changes

- lib: copy - move - component `<TwoColumns />` cmp from NNS-dapp
- lib: rename `left` and `right` slots to `start` and `end`
- lib: extract flex and grid to mixin
- lib: create new `<Content />` cmp to display two columns and two rows ("ACBD"")
- docs: brief documentation for `<TwoColumns />`

