### PR TITLE
feat: cells utility classes and grid spacing

### DIFF
--- a/src/lib/styles/global.scss
+++ b/src/lib/styles/global.scss
@@ -6,6 +6,7 @@
 @import "./global/link.scss";
 @import "./global/modal.scss";
 @import "./global/grid.scss";
+@import "./global/utility-classes.scss";
 @import "./global/colors.scss";
 @import "./themes/dark.scss";
 @import "./themes/light.scss";

--- a/src/lib/styles/global/grid.scss
+++ b/src/lib/styles/global/grid.scss
@@ -37,7 +37,8 @@
     grid-template-rows: auto;
     grid-template-areas:
       "content-a content-a content-a content-a content-a content-a content-b content-b content-b content-b content-b content-b"
-      "content-c content-c content-c content-c content-c content-c content-d content-d content-d content-d content-d content-d";
+      "content-c content-c content-c content-c content-c content-c content-d content-d content-d content-d content-d content-d"
+      "content-e content-e content-e content-e content-e content-e content-f content-f content-f content-f content-f content-f";
   }
 
   .content-a {
@@ -54,5 +55,13 @@
 
   .content-d {
     grid-area: content-d;
+  }
+
+  .content-e {
+    grid-area: content-e;
+  }
+
+  .content-f {
+    grid-area: content-f;
   }
 }

--- a/src/lib/styles/global/theme.scss
+++ b/src/lib/styles/global/theme.scss
@@ -22,30 +22,6 @@ body {
   box-sizing: border-box;
 }
 
-// text color helper classes
-.value {
-  color: var(--value-color);
-}
-.label {
-  color: var(--label-color);
-}
-.description {
-  color: var(--description-color);
-}
-
-// TODO: find a better solution.
-.card {
-  .value {
-    color: var(--card-background-contrast);
-  }
-  .label {
-    color: rgba(var(--card-background-contrast-rgb), var(--light-opacity));
-  }
-  .description {
-    color: rgba(var(--card-background-contrast-rgb), var(--very-light-opacity));
-  }
-}
-
 ::-webkit-scrollbar {
   background: var(--background);
 }

--- a/src/lib/styles/global/utility-classes.scss
+++ b/src/lib/styles/global/utility-classes.scss
@@ -1,0 +1,38 @@
+// text color helper classes
+.value {
+  color: var(--value-color);
+}
+.label {
+  color: var(--label-color);
+}
+.description {
+  color: var(--description-color);
+}
+
+// TODO: find a better solution.
+.card {
+  .value {
+    color: var(--card-background-contrast);
+  }
+  .label {
+    color: rgba(var(--card-background-contrast-rgb), var(--light-opacity));
+  }
+  .description {
+    color: rgba(var(--card-background-contrast-rgb), var(--very-light-opacity));
+  }
+}
+
+// Cells utilities
+.content-cell-title {
+  margin: 0;
+  line-height: var(--line-height-standard);
+  word-break: break-word;
+}
+
+.content-cell-details {
+  margin-top: var(--padding-2x);
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--padding);
+}

--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -17,8 +17,8 @@
   --padding-6x: calc(6 * var(--padding));
   --padding-8x: calc(8 * var(--padding));
 
-  --column-gap: var(--padding-2x);
-  --row-gap: var(--padding-4x);
+  --column-gap: var(--padding-8x);
+  --row-gap: var(--padding-6x);
 
   --border-radius: 10px;
   --border-radius-5x: calc(5 * var(--border-radius));

--- a/src/routes/utility-classes.svelte
+++ b/src/routes/utility-classes.svelte
@@ -25,4 +25,10 @@
       Various grid styles - based on a 12 columns system - to spread content.
     </p>
   </Card>
+
+  <Card role="link" on:click={() => goto("/utility-classes/cells")}>
+    <h2 class="title" slot="start">Cells</h2>
+
+    <p>Some pre-defined utilities to set spaces for grid's cells.</p>
+  </Card>
 </div>

--- a/src/routes/utility-classes/cells.md
+++ b/src/routes/utility-classes/cells.md
@@ -1,0 +1,46 @@
+# Cells
+
+Some pre-defined utilities to set spaces for grid's cells.
+
+```html
+<div class="content-grid">
+  <div class="content-a">
+    <h2 class="content-cell-title">My Title</h2>
+
+    <div class="content-cell-details">
+      <p>Some content.</p>
+      <p>And other information.</p>
+    </div>
+  </div>
+</div>
+```
+
+## Usage
+
+| Type                                   | CSS class              |
+| -------------------------------------- | ---------------------- |
+| header, title, first information, etc. | `content-cell-title`   |
+| related content or details             | `content-cell-details` |
+
+### Showcase
+
+<div class="content-grid" style="margin-top: var(--padding-4x)">
+    <div class="content-a">
+        <h2 class="content-cell-title">Lorem ipsum</h2>
+
+        <div class="content-cell-details">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque porttitor nisi ut mi porttitor facilisis. Fusce sodales, sapien et convallis volutpat.</p>
+            <p>Velit lorem lacinia massa, sed dictum libero ex et lectus.</p>
+        </div>
+    </div>
+
+    <div class="content-b">
+        <h2 class="content-cell-title">Lorem ipsum</h2>
+
+        <div class="content-cell-details">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque porttitor nisi ut mi porttitor facilisis. Fusce sodales, sapien et convallis volutpat.</p>
+            <p>Velit lorem lacinia massa, sed dictum libero ex et lectus.</p>
+        </div>
+    </div>
+
+</div>


### PR DESCRIPTION
# Motivation

Introduce class utilities for common grids' cells and give spacing to the grid.

# Changes

- lib: add cells utils classes
- lib: move text opacity utils classes to new global `utilitiy-classes.scss`
- lib: increase gap for the grid (value closer to figma design)
- docs: briefly document cells
- lib: add content-e and content-f to grid (for the position of the payload in the new proposal detail page)
