### PR TITLE
feat: infinite scroll observe last element

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -50,7 +50,7 @@
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
     // If not children, no element to observe
-    if (container.children.length === 0) {
+    if (container.lastElementChild === null) {
       return;
     }
 

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -7,7 +7,7 @@
   } from "svelte";
 
   export let layout: "list" | "grid" = "list";
-  export let disabled: boolean = false;
+  export let disabled = false;
 
   // IntersectionObserverInit is not recognized by the linter
   // eslint-disable-next-line no-undef

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import {afterUpdate, beforeUpdate, createEventDispatcher, onDestroy} from "svelte";
+  import {
+    afterUpdate,
+    beforeUpdate,
+    createEventDispatcher,
+    onDestroy,
+  } from "svelte";
 
   export let layout: "list" | "grid" = "list";
   export let disabled: boolean = false;
@@ -39,7 +44,7 @@
   );
 
   // We disconnect previous observer first. We do want to trigger an intersection in case of layout shifting.
-  beforeUpdate(() => observer.disconnect())
+  beforeUpdate(() => observer.disconnect());
 
   afterUpdate(() => {
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
@@ -60,13 +65,14 @@
   onDestroy(() => observer.disconnect());
 
   // The infinite scroll "disabled" property is updated. If it becomes "false", the observer should be disconnected.
-  $: disabled, (() => {
-    if (!disabled) {
-      return;
-    }
+  $: disabled,
+    () => {
+      if (!disabled) {
+        return;
+      }
 
-    observer.disconnect();
-  })
+      observer.disconnect();
+    };
 </script>
 
 <ul bind:this={container} class:card-grid={layout === "grid"}>

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-  import { afterUpdate, createEventDispatcher, onDestroy } from "svelte";
-  import {
-    INFINITE_SCROLL_OFFSET,
-    DEFAULT_LIST_PAGINATION_LIMIT,
-  } from "$lib/constants/constants";
+  import {afterUpdate, beforeUpdate, createEventDispatcher, onDestroy} from "svelte";
 
-  export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
   export let layout: "list" | "grid" = "list";
+  export let disabled: boolean = false;
 
   // IntersectionObserverInit is not recognized by the linter
   // eslint-disable-next-line no-undef
@@ -42,57 +38,35 @@
     options
   );
 
+  // We disconnect previous observer first. We do want to trigger an intersection in case of layout shifting.
+  beforeUpdate(() => observer.disconnect())
+
   afterUpdate(() => {
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
-    // We disconnect previous observer first. We do want to observe multiple elements.
-    observer.disconnect();
-
+    // If not children, no element to observe
     if (container.children.length === 0) {
       return;
     }
 
-    const pageIndex: number = container.children.length / pageLimit - 1;
-    // If the pageIndex is not an integer the all page was not fetched - e.g. 50 elements instead of 100 - therefore there is no more elements to fetch
-    if (!Number.isInteger(pageIndex)) {
+    // If the infinite scroll is disabled, no observation should happen
+    if (disabled) {
       return;
     }
 
-    /**
-     * The infinite scroll observe an element that finds place after x % of last page.
-     *
-     * For example given following list of elements:
-     *
-     * [0-100]
-     * [101-200]
-     *
-     * If ratio is set to `0.2`, the observer observes 20% of the last page aka element at position 120.
-     *
-     * [0-100]
-     * [101-200]
-     * [201-300]
-     *
-     * Infinite scroll observe element 220.
-     *
-     * [0-100]
-     * [101-200]
-     * [201-300]
-     * [301-345]
-     *
-     * Infinite scroll does not observe because all data are fetched.
-     */
-    const element: Element | undefined = Array.from(container.children)[
-      pageIndex * pageLimit + Math.round(pageLimit * INFINITE_SCROLL_OFFSET)
-    ];
-
-    if (element === undefined) {
-      return;
-    }
-
-    observer.observe(element);
+    observer.observe(container.lastElementChild);
   });
 
   onDestroy(() => observer.disconnect());
+
+  // The infinite scroll "disabled" property is updated. If it becomes "false", the observer should be disconnected.
+  $: disabled, (() => {
+    if (!disabled) {
+      return;
+    }
+
+    observer.disconnect();
+  })
 </script>
 
 <ul bind:this={container} class:card-grid={layout === "grid"}>

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -43,7 +43,7 @@
     options
   );
 
-  // We disconnect previous observer first. We do want to trigger an intersection in case of layout shifting.
+  // We disconnect previous observer before any update. We do want to trigger an intersection in case of layout shifting.
   beforeUpdate(() => observer.disconnect());
 
   afterUpdate(() => {
@@ -63,16 +63,6 @@
   });
 
   onDestroy(() => observer.disconnect());
-
-  // The infinite scroll "disabled" property is updated. If it becomes "false", the observer should be disconnected.
-  $: disabled,
-    () => {
-      if (!disabled) {
-        return;
-      }
-
-      observer.disconnect();
-    };
 </script>
 
 <ul bind:this={container} class:card-grid={layout === "grid"}>

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -1,9 +1,0 @@
-/**
- * Default number of items fetched in a paginated or infinite scrolled list.
- */
-export const DEFAULT_LIST_PAGINATION_LIMIT = 100;
-
-/**
- * The infinite scroll observe an element that finds place after x % of last page.
- */
-export const INFINITE_SCROLL_OFFSET = 0.2;

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -18,7 +18,7 @@ It sets the reference to the last element of the list after each re-render. **Pa
 ## Properties
 
 | Property   | Description                                                                                                                      | Type             | Default |
-|------------|----------------------------------------------------------------------------------------------------------------------------------|------------------|---------|
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
 | `layout`   | Display of the rendered items. Defined by a class set on `ul` container.                                                         | `list` or `grid` | `list`  |
 | `disabled` | If `true`, the infinite scroll will stop observing for intersection and therefore, will stop calling the action to be performed. | `boolean`        | `false` |
 

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -13,14 +13,14 @@ The Infinite Scroll component calls an action to be performed when the user scro
 ## Usage
 
 The component renders a `ul` and observe the elements of the list using the [IntersectionObserver](https://developer.mozilla.org/fr/docs/Web/API/Intersection_Observer_API).
-It sets the reference after each re-render of the list. **Pay attention to not trigger unnecessary updates**.
+It sets the reference to the last element of the list after each re-render. **Pay attention to not trigger unnecessary updates**.
 
 ## Properties
 
-| Property    | Description                                                              | Type             | Detail                              |
-| ----------- | ------------------------------------------------------------------------ | ---------------- | ----------------------------------- |
-| `pageLimit` | How many items each pagination group contains?                           | `number`         | `DEFAULT_LIST_PAGINATION_LIMIT=100` |
-| `layout`    | Display of the rendered items. Defined by a class set on `ul` container. | `list` or `grid` | `list`                              |
+| Property   | Description                                                                                                                      | Type             | Default |
+|------------|----------------------------------------------------------------------------------------------------------------------------------|------------------|---------|
+| `layout`   | Display of the rendered items. Defined by a class set on `ul` container.                                                         | `list` or `grid` | `list`  |
+| `disabled` | If `true`, the infinite scroll will stop observing for intersection and therefore, will stop calling the action to be performed. | `boolean`        | `false` |
 
 ## Slots
 

--- a/src/routes/components/infinite-scroll.md
+++ b/src/routes/components/infinite-scroll.md
@@ -17,10 +17,10 @@ It sets the reference to the last element of the list after each re-render. **Pa
 
 ## Properties
 
-| Property   | Description                                                                                                                      | Type             | Default |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
-| `layout`   | Display of the rendered items. Defined by a class set on `ul` container.                                                         | `list` or `grid` | `list`  |
-| `disabled` | If `true`, the infinite scroll will stop observing for intersection and therefore, will stop calling the action to be performed. | `boolean`        | `false` |
+| Property   | Description                                                                                                                  | Type             | Default |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
+| `layout`   | Display of the rendered items. Defined by a class set on `ul` container.                                                     | `list` or `grid` | `list`  |
+| `disabled` | If `true`, the infinite scroll stops observing for intersection and therefore, will stop calling the action to be performed. | `boolean`        | `false` |
 
 ## Slots
 

--- a/src/tests/components/InfiniteScroll.spec.ts
+++ b/src/tests/components/InfiniteScroll.spec.ts
@@ -5,10 +5,6 @@
 import { render } from "@testing-library/svelte";
 import InfiniteScroll from "$lib/components/InfiniteScroll.svelte";
 import {
-  DEFAULT_LIST_PAGINATION_LIMIT,
-  INFINITE_SCROLL_OFFSET,
-} from "$lib/constants/constants";
-import {
   IntersectionObserverActive,
   IntersectionObserverPassive,
 } from "../mocks/infinitescroll.mock";
@@ -34,21 +30,7 @@ describe("InfiniteScroll", () => {
 
     render(InfiniteScrollTest, {
       props: {
-        elements: new Array(DEFAULT_LIST_PAGINATION_LIMIT),
-        spy: spyIntersect,
-      },
-    });
-
-    expect(spyIntersect).toHaveBeenCalled();
-  });
-
-  it("should trigger an intersect event with custom page limit", () => {
-    const spyIntersect = jest.fn();
-
-    render(InfiniteScrollTest, {
-      props: {
-        pageLimit: 5,
-        elements: new Array(5),
+        elements: new Array(100),
         spy: spyIntersect,
       },
     });
@@ -61,30 +43,8 @@ describe("InfiniteScroll", () => {
 
     render(InfiniteScrollTest, {
       props: {
-        elements: new Array(DEFAULT_LIST_PAGINATION_LIMIT + 1),
-        spy: spyIntersect,
-      },
-    });
-
-    expect(spyIntersect).not.toHaveBeenCalled();
-  });
-
-  it("should not trigger an intersect event if more elements than offset but less than page", () => {
-    const spyIntersect = jest.fn();
-
-    /**
-     * [0-100]
-     * [101-121]
-     *
-     * Infinite scroll does not observe because all data are fetched.
-     */
-    render(InfiniteScrollTest, {
-      props: {
-        elements: new Array(
-          DEFAULT_LIST_PAGINATION_LIMIT +
-            Math.round(DEFAULT_LIST_PAGINATION_LIMIT * INFINITE_SCROLL_OFFSET) +
-            1
-        ),
+        elements: new Array(100),
+        disabled: true,
         spy: spyIntersect,
       },
     });

--- a/src/tests/components/InfiniteScrollTest.svelte
+++ b/src/tests/components/InfiniteScrollTest.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import InfiniteScroll from "$lib/components/InfiniteScroll.svelte";
-  import { DEFAULT_LIST_PAGINATION_LIMIT } from "$lib/constants/constants";
 
   export let elements: number[];
-  export let pageLimit: number = DEFAULT_LIST_PAGINATION_LIMIT;
+  export let disabled: boolean = false;
   export let spy: () => void;
 </script>
 
-<InfiniteScroll on:nnsIntersect={spy} {pageLimit}>
+<InfiniteScroll on:nnsIntersect={spy} {disabled}>
   {#each elements as element, i}
     <div>Test {i}</div>
   {/each}

--- a/src/tests/components/InfiniteScrollTest.svelte
+++ b/src/tests/components/InfiniteScrollTest.svelte
@@ -2,7 +2,7 @@
   import InfiniteScroll from "$lib/components/InfiniteScroll.svelte";
 
   export let elements: number[];
-  export let disabled: boolean = false;
+  export let disabled = false;
   export let spy: () => void;
 </script>
 


### PR DESCRIPTION
# Motivation

Make the `<InfiniteScroll />` component compatible for both list and grid. To do so, update behavior to observe last element of the container.

# Changes

- observe last element of the container instead of calculated position
- remove unused constants
- `disconnect` on `beforeUpdate` instead of `afterUpdate` to prevent the component to emitting on layout shift
- add cmp property `disabled` to disable observation ("to disable the component when everything is fetched")
