### PR TITLE
feat: skeleton text

### DIFF
--- a/src/lib/components/SkeletonText.svelte
+++ b/src/lib/components/SkeletonText.svelte
@@ -1,6 +1,6 @@
 <!-- adapted source: https://github.com/ionic-team/ionic-framework/tree/main/core/src/components/skeleton-text -->
 <script lang="ts">
-  export let animated: boolean = true;
+  export let animated = true;
   export let tagName: "span" | "p" | "h1" | "h2" | "h3" = "span";
 </script>
 

--- a/src/lib/components/SkeletonText.svelte
+++ b/src/lib/components/SkeletonText.svelte
@@ -1,0 +1,69 @@
+<!-- adapted source: https://github.com/ionic-team/ionic-framework/tree/main/core/src/components/skeleton-text -->
+<script lang="ts">
+  export let animated: boolean = true;
+  export let tagName: "span" | "p" | "h1" | "h2" | "h3" = "span";
+</script>
+
+<div
+  data-tid="skeleton-text"
+  aria-busy="true"
+  class="skeleton-text"
+  class:animated
+>
+  <svelte:element this={tagName}>&nbsp;</svelte:element>
+</div>
+
+<style lang="scss">
+  .skeleton-text {
+    display: block;
+
+    width: 100%;
+    height: inherit;
+
+    margin: var(--padding-0_5x) 0;
+
+    --skeleton-text-background: rgba(var(--background-contrast-rgb), 0.065);
+    --skeleton-text-background-animated: rgba(
+      var(--background-contrast-rgb),
+      0.135
+    );
+    background: var(--skeleton-text-background);
+
+    line-height: var(--skeleton-text-line-height, 0.8);
+
+    user-select: none;
+    pointer-events: none;
+
+    * {
+      display: inline-block;
+    }
+  }
+
+  .animated {
+    position: relative;
+
+    background: linear-gradient(
+      to right,
+      var(--skeleton-text-background) 8%,
+      var(--skeleton-text-background-animated) 18%,
+      var(--skeleton-text-background) 33%
+    );
+    background-size: 800px 104px;
+    animation-duration: 1s;
+    animation-fill-mode: forwards;
+    animation-iteration-count: infinite;
+    animation-name: skeleton-text-shimmer;
+    animation-timing-function: linear;
+  }
+
+  /* -global- */
+  @keyframes -global-skeleton-text-shimmer {
+    0% {
+      background-position: -400px 0;
+    }
+
+    100% {
+      background-position: 400px 0;
+    }
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,6 +9,7 @@ export { default as Back } from "./components/Back.svelte";
 export { default as Card } from "./components/Card.svelte";
 export { default as InfiniteScroll } from "./components/InfiniteScroll.svelte";
 export { default as HeaderTitle } from "./components/HeaderTitle.svelte";
+export { default as SkeletonText } from "./components/SkeletonText.svelte";
 
 export { default as IconArrowRight } from "./icons/IconArrowRight.svelte";
 export { default as IconBackIosNew } from "./icons/IconBackIosNew.svelte";

--- a/src/routes/components.svelte
+++ b/src/routes/components.svelte
@@ -37,6 +37,12 @@
 
     <p>Calls an action when the user scrolls a specified distance in a list.</p>
   </Card>
+
+  <Card role="link" on:click={() => goto("/components/skeleton-text")}>
+    <h2 class="title" slot="start">Skeleton Text</h2>
+
+    <p>A component for rendering placeholder content.</p>
+  </Card>
 </div>
 
 <p>TODO docs:</p>

--- a/src/routes/components/skeleton-text.md
+++ b/src/routes/components/skeleton-text.md
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import SkeletonText from "$lib/components/SkeletonText.svelte";
+</script>
+
+# Skeleton Text
+
+Skeleton Text is a component for rendering placeholder content. The element will render a gray block with an optional background animation.
+
+```html
+<SkeletonText />
+<SkeletonText animated="{false}" />
+<SkeletonText tagName="h1" />
+```
+
+## Properties
+
+| Property   | Description                                        | Type                                  | Default |
+| ---------- | -------------------------------------------------- | ------------------------------------- | ------- |
+| `animated` | A background animation from left to right.         | `boolean`                             | `true`  |
+| `tagName`  | The HTML element that will be rendered to the DOM. | `span` or `p` or `h1` or `h2` or `h3` | `span`  |
+
+## Showcase
+
+<div class="card-grid">
+    <div>
+        <SkeletonText />
+        <SkeletonText />
+        <SkeletonText />
+    </div>
+
+    <div>
+        <SkeletonText tagName="h1" />
+        <SkeletonText tagName="h2" />
+        <SkeletonText tagName="h3" />
+        <SkeletonText tagName="p"/>
+        <SkeletonText />
+    </div>
+
+    <div>
+        <SkeletonText tagName="h1" animated={false} />
+        <SkeletonText animated={false} />
+        <SkeletonText animated={false} />
+    </div>
+
+</div>

--- a/src/tests/components/SkeletonText.spec.ts
+++ b/src/tests/components/SkeletonText.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import SkeletonText from "$lib/components/SkeletonText.svelte";
+
+describe("SkeletonText", () => {
+  it("should contains a selector for external test", () => {
+    const { getByTestId } = render(SkeletonText);
+
+    expect(getByTestId("skeleton-text")).not.toBeNull();
+  });
+
+  it("should render an animated style", () => {
+    const { getByTestId } = render(SkeletonText, { props: { animated: true } });
+
+    expect(
+      getByTestId("skeleton-text").classList.contains("animated")
+    ).toBeTruthy();
+  });
+
+  it("should render a span per default", () => {
+    const { container } = render(SkeletonText);
+
+    expect(container.querySelector("span")).not.toBeNull();
+  });
+
+  it("should render a p", () => {
+    const { container } = render(SkeletonText, {
+      props: { tagName: "p" },
+    });
+
+    expect(container.querySelector("span")).toBeNull();
+    expect(container.querySelector("p")).not.toBeNull();
+  });
+
+  it("should render a h1", () => {
+    const { container } = render(SkeletonText, {
+      props: { tagName: "h1" },
+    });
+
+    expect(container.querySelector("h1")).not.toBeNull();
+  });
+
+  it("should render a h2", () => {
+    const { container } = render(SkeletonText, {
+      props: { tagName: "h2" },
+    });
+
+    expect(container.querySelector("h2")).not.toBeNull();
+  });
+
+  it("should render a h3", () => {
+    const { container } = render(SkeletonText, {
+      props: { tagName: "h3" },
+    });
+
+    expect(container.querySelector("h3")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# Motivation

Add the skeleton component to gix-components.

# Note

The component was copied from NNS-dapp but instead of rendering a sole `span` it has been upgraded to support different types of HTML elements. This will be useful for the new proposal detail page.

# Changes

- lib: copy NNS-dapp `<SkeletonParagraph />` to `<SkeletonText />`
- lib: add option to render `span`, `p` or `h1-3`
- docs: add new doc page to document option and showcase
