### PR TITLE
style: fix line color in light mode

### DIFF
--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -32,7 +32,7 @@
     --disable-contrast: #858585;
 
     // Line
-    --line: #505050;
+    --line: #e5e5e5;
     --line-contrast: #858585;
 
     // Palette


### PR DESCRIPTION
# Motivation

The `--line` color in light mode currently equals the one of `--dark`. It should equals the color of `--disable` in `--light`. There was a copy/paste typo when introduced in previous PR.

# Changes

- fix light color for `--line`