### PR TITLE
feat: content height and scroll length with bottom sheet

### DIFF
--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -1,4 +1,15 @@
-<div role="dialog" data-tid="bottom-sheet">
+<script lang="ts">
+  import { layoutBottomOffset } from "../stores/layout.store";
+  import { onDestroy } from "svelte";
+
+  onDestroy(() => ($layoutBottomOffset = 0));
+</script>
+
+<div
+  role="dialog"
+  data-tid="bottom-sheet"
+  bind:clientHeight={$layoutBottomOffset}
+>
   <slot />
 </div>
 

--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -3,13 +3,19 @@
   import { onDestroy } from "svelte";
 
   onDestroy(() => ($layoutBottomOffset = 0));
+
+  // 1024 is the $breakpoint-large size. See also the CSS code of this component. On large screen the bottom sheet is not sticky.
+  const updateBottomOffset = () =>
+    ($layoutBottomOffset = innerWidth < 1024 ? height : 0);
+
+  let height = 0;
+  let innerWidth = 0;
+  $: height, innerWidth, updateBottomOffset();
 </script>
 
-<div
-  role="dialog"
-  data-tid="bottom-sheet"
-  bind:clientHeight={$layoutBottomOffset}
->
+<svelte:window bind:innerWidth />
+
+<div role="dialog" data-tid="bottom-sheet" bind:clientHeight={height}>
   <slot />
 </div>
 

--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -44,10 +44,6 @@
     // This to avoid the content to be presented behind the bottom sheet and
     // to display a scrollbar that ends before the bottom sheet.
     padding-bottom: var(--layout-bottom-offset, 0);
-
-    @include media.min-width(large) {
-      padding-bottom: 0;
-    }
   }
 
   .scrollable-content {

--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { layoutBottomOffset } from "$lib/stores/layout.store";
+
   export let sticky = false;
   let innerWidth = 0;
 
@@ -12,7 +14,10 @@
 
 <div class="split-pane">
   <slot name="menu" />
-  <div class="content">
+  <div
+    class="content"
+    style={`--layout-bottom-offset: ${$layoutBottomOffset}px`}
+  >
     <div class="scrollable-content"><slot /></div>
   </div>
 </div>
@@ -34,6 +39,15 @@
   .content {
     position: relative;
     width: 100%;
+
+    // If a bottom sheet is displayed the content pane height should be updated accordingly
+    // This to avoid the content to be presented behind the bottom sheet and
+    // to display a scrollbar that ends before the bottom sheet.
+    padding-bottom: var(--layout-bottom-offset, 0);
+
+    @include media.min-width(large) {
+      padding-bottom: 0;
+    }
   }
 
   .scrollable-content {

--- a/src/lib/stores/layout.store.ts
+++ b/src/lib/stores/layout.store.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const layoutBottomOffset = writable<number>(0);


### PR DESCRIPTION
# Motivation

Adapt content height and scroll length if a bottom sheet is presented.

# Changes

- add a new store for the layout bottom offset
- update offset according window width and bottom sheet height in component
- add padding bottom to content

# Screenshot

<img width="885" alt="Capture d’écran 2022-09-09 à 07 37 31" src="https://user-images.githubusercontent.com/16886711/189281277-df9f7870-52b3-4ea2-8c3f-8e9485e304cf.png">
<img width="1510" alt="Capture d’écran 2022-09-09 à 07 37 36" src="https://user-images.githubusercontent.com/16886711/189281289-84a29059-b948-4fcf-950f-cfc90faf9109.png">

