### PR TITLE
fix: missing bottom sheet export

### DIFF
--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -10,3 +10,4 @@ export { default as Card } from "./components/Card.svelte";
 export { default as InfiniteScroll } from "./components/InfiniteScroll.svelte";
 export { default as HeaderTitle } from "./components/HeaderTitle.svelte";
 export { default as SkeletonText } from "./components/SkeletonText.svelte";
+export { default as BottomSheet } from "./components/BottomSheet.svelte";


### PR DESCRIPTION
# Motivation

The export for the `BottomSheet` got lost in PR https://github.com/dfinity/gix-components/pull/54

# Changes

- redo export of `BottomSheet`
