### PR TITLE
style: fix bottom sheet, toast and modal z-index

### DIFF
--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -31,7 +31,7 @@
     background: var(--background);
     box-shadow: var(--bottom-sheet-box-shadow);
 
-    z-index: var(--z-index);
+    z-index: var(--bottom-sheet-z-index);
 
     @include media.min-width(large) {
       position: relative;

--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -29,8 +29,9 @@
   --menu-z-index: calc(var(--z-index) + 996);
   --header-z-index: calc(var(--menu-z-index) + 1);
   --overlay-z-index: calc(var(--header-z-index) + 1);
-  --modal-z-index: calc(var(--overlay-z-index) + 1);
-  --toast-z-index: calc(var(--modal-z-index) + 1);
+  --toast-z-index: calc(var(--overlay-z-index) + 1);
+  --bottom-sheet-z-index: calc(var(--overlay-z-index) + 2);
+  --modal-z-index: calc(var(--bottom-sheet-z-index) + 1);
 
   --section-max-width: 800px;
   --footer-height: 20vh;


### PR DESCRIPTION
# Motivation

Toasts should be displayed under the popups.

# Changes

- style z-index

# Screenshots

is:

<img width="1510" alt="Capture d’écran 2022-09-12 à 14 05 36" src="https://user-images.githubusercontent.com/16886711/189658683-d6ce41d8-800d-4fca-b9b4-a9d5d61f1dcb.png">

will be:

<img width="1510" alt="Capture d’écran 2022-09-12 à 14 49 09" src="https://user-images.githubusercontent.com/16886711/189658709-d00e2230-0861-4da0-8930-46ee73532dc6.png">

