### PR TITLE
style: fix z-index modal bottom sheet toast

### DIFF
--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -30,8 +30,8 @@
   --header-z-index: calc(var(--menu-z-index) + 1);
   --overlay-z-index: calc(var(--header-z-index) + 1);
   --toast-z-index: calc(var(--overlay-z-index) + 1);
+  --modal-z-index: calc(var(--overlay-z-index) + 1);
   --bottom-sheet-z-index: calc(var(--overlay-z-index) + 2);
-  --modal-z-index: calc(var(--bottom-sheet-z-index) + 1);
 
   --section-max-width: 800px;
   --footer-height: 20vh;


### PR DESCRIPTION
# Motivation

Toast should be over modal except if the modal source is in a bottom sheet.

# Changes

- redo z-index modal

# Screenshot

will be:
<img width="1511" alt="Capture d’écran 2022-09-12 à 15 43 38" src="https://user-images.githubusercontent.com/16886711/189670188-27162d26-ce3a-4d41-ad8e-24178de628e1.png">
<img width="1511" alt="Capture d’écran 2022-09-12 à 15 43 45" src="https://user-images.githubusercontent.com/16886711/189670201-22658dc7-4742-4407-ad1e-2ec80bcaac13.png">


