### PR TITLE
style: fix header title single line overflow

### DIFF
--- a/src/lib/components/HeaderTitle.svelte
+++ b/src/lib/components/HeaderTitle.svelte
@@ -7,7 +7,7 @@
     margin: 0;
     color: white;
 
-    @include text.clamp(2);
+    @include text.truncate;
 
     text-align: center;
     line-height: inherit;

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -15,8 +15,13 @@
     position: absolute;
     @include display.inset;
 
+    --actions-width: 15%;
+    --main-width: calc(100% - (2 * var(--actions-width)));
+
     display: grid;
-    grid-template-columns: 25% 50% 25%;
+    grid-template-columns: var(--actions-width) var(--main-width) var(
+        --actions-width
+      );
 
     justify-content: center;
     align-items: center;
@@ -37,11 +42,8 @@
     grid-column: 2 / 3;
 
     display: flex;
-    justify-content: center;
-    align-items: stretch;
-
     justify-self: center;
 
-    gap: var(--padding);
+    max-width: 100%;
   }
 </style>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -42,8 +42,13 @@
     grid-column: 2 / 3;
 
     display: flex;
+    justify-content: center;
+    align-items: stretch;
+
     justify-self: center;
 
     max-width: 100%;
+
+    gap: var(--padding);
   }
 </style>


### PR DESCRIPTION
# Motivation

The header now supports only one line.

# Changes

- update tootlbar and header style

# Screenshots

<img width="1528" alt="Capture d’écran 2022-09-20 à 09 02 53" src="https://user-images.githubusercontent.com/16886711/191192774-e4a6cdd9-dd7b-4dd4-a4d0-1cef1f43f16a.png">
<img width="1528" alt="Capture d’écran 2022-09-20 à 09 06 45" src="https://user-images.githubusercontent.com/16886711/191192793-119293f9-c9de-461d-be42-772f33433fed.png">
<img width="1528" alt="Capture d’écran 2022-09-20 à 09 16 33" src="https://user-images.githubusercontent.com/16886711/191192809-85558282-b294-427a-991a-53c22394ebf4.png">
<img width="1528" alt="Capture d’écran 2022-09-20 à 09 16 58" src="https://user-images.githubusercontent.com/16886711/191192813-b93b07b0-e964-4350-9076-3cddaaa89ad7.png">

