### PR TITLE
feat: in case of errors display toasts on top

### DIFF
--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -2,11 +2,17 @@
   import { toastsStore } from "$lib/stores/toasts.store";
   import Toast from "./Toast.svelte";
   import { layoutBottomOffset } from "$lib/stores/layout.store";
+
+  let hasErrors: boolean;
+  $: hasErrors = $toastsStore?.find(({ level }) =>
+    ["error", "warn"].includes(level)
+  );
 </script>
 
 {#if $toastsStore.length > 0}
   <div
     class="wrapper"
+    class:error={hasErrors}
     style={`--layout-bottom-offset: ${$layoutBottomOffset}px`}
   >
     {#each $toastsStore as msg (msg.id)}
@@ -33,7 +39,11 @@
     flex-direction: column;
     gap: var(--padding);
 
-    z-index: var(--toast-z-index);
+    z-index: var(--toast-info-z-index);
+
+    &.error {
+      z-index: var(--toast-error-z-index);
+    }
 
     @include media.min-width(large) {
       // A little narrowwer than the section to differentiate notifications from content

--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -28,7 +28,8 @@
   --z-index: 1;
   --menu-z-index: calc(var(--z-index) + 996);
   --overlay-z-index: calc(var(--menu-z-index) + 1);
-  --toast-z-index: calc(var(--overlay-z-index) + 1);
+  --toast-info-z-index: calc(var(--overlay-z-index) + 1);
+  --toast-error-z-index: calc(var(--overlay-z-index) + 4);
   --modal-z-index: calc(var(--overlay-z-index) + 3);
   --bottom-sheet-z-index: calc(var(--overlay-z-index) + 2);
 


### PR DESCRIPTION
# Motivation

In case of errors display the toasts always on the top including above modals.

# Changes

- split `z-index` for toasts in two, one for normal behavior one for errors

# Screenshots
<img width="1536" alt="Capture d’écran 2022-09-21 à 08 30 18" src="https://user-images.githubusercontent.com/16886711/191431280-f639b60e-c77a-44bf-9e2f-98f82adf7b99.png">

<img width="1536" alt="Capture d’écran 2022-09-21 à 08 30 10" src="https://user-images.githubusercontent.com/16886711/191431265-61c769e4-4777-414b-9fff-2a9605b4f639.png">

