### PR TITLE
fix: missing shadow

### DIFF
--- a/src/lib/styles/global/layout.scss
+++ b/src/lib/styles/global/layout.scss
@@ -1,4 +1,5 @@
 @use "../mixins/media";
+@use "../mixins/display";
 
 main {
   height: fit-content;
@@ -42,7 +43,7 @@ header {
   &::after {
     content: "";
     position: absolute;
-    inset: 0;
+    @include display.inset;
     box-shadow: var(--header-box-shadow);
     pointer-events: none;
     z-index: calc(var(--menu-z-index) + 1);

--- a/src/lib/styles/global/layout.scss
+++ b/src/lib/styles/global/layout.scss
@@ -21,8 +21,6 @@ header {
   left: 0;
   right: 0;
 
-  box-shadow: var(--header-box-shadow);
-
   height: var(--header-height);
 
   display: block;
@@ -39,6 +37,16 @@ header {
   color: var(--primary-gradient-contrast);
 
   --toolbar-pointer-events: all;
+
+  // bottom shadow
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    box-shadow: var(--header-box-shadow);
+    pointer-events: none;
+    z-index: calc(var(--menu-z-index) + 1);
+  }
 }
 
 footer {


### PR DESCRIPTION
# Motivation

Because of no z-index on the header the shadow is not visible. The shadow was moved to the `::after` block.

# Changes

- move box shadow to the `after` component

# Screenshots

<img width="403" alt="image" src="https://user-images.githubusercontent.com/98811342/191797470-21312e62-9e28-4a93-b43b-d4296de3cc8e.png">