### PR TITLE
feat: modal toolbar sticky only for alert

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -14,11 +14,11 @@
   let showHeader: boolean;
   $: showHeader = $$slots.title !== undefined;
 
-  let showToolbarDialog: boolean;
-  $: showToolbarDialog = $$slots.toolbar !== undefined && role === "dialog";
-
-  let showToolbarAlert: boolean;
-  $: showToolbarAlert = $$slots.toolbar !== undefined && role === "alert";
+  /**
+   * @deprecated according new design there should be no sticky footer
+   */
+  let showFooterAlert: boolean;
+  $: showFooterAlert = $$slots.footer !== undefined && role === "alert";
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");
@@ -54,17 +54,11 @@
 
       <div class="content" id="modalContent" class:alert={role === "alert"}>
         <slot />
-
-        {#if showToolbarDialog}
-          <div class="toolbar">
-            <slot name="toolbar" />
-          </div>
-        {/if}
       </div>
 
-      {#if showToolbarAlert}
-        <div class="toolbar">
-          <slot name="toolbar" />
+      {#if showFooterAlert}
+        <div class="footer toolbar">
+          <slot name="footer" />
         </div>
       {/if}
     </div>
@@ -119,7 +113,7 @@
           calc(var(--alert-padding-x) / 2) 0;
       }
 
-      .toolbar {
+      .footer {
         padding: 0 var(--alert-padding-x) var(--alert-padding-y);
 
         @include media.min-width(small) {
@@ -149,10 +143,6 @@
       .content {
         margin: 0 0 var(--dialog-padding-y);
         padding: var(--dialog-padding-y) var(--dialog-padding-x);
-      }
-
-      .toolbar {
-        padding: var(--padding-2x) 0 0;
       }
     }
   }
@@ -205,20 +195,5 @@
 
     overflow-y: auto;
     overflow-x: hidden;
-  }
-
-  .toolbar {
-    display: flex;
-    gap: var(--padding-2x);
-
-    :global(button) {
-      flex: 1;
-    }
-
-    @include media.min-width(small) {
-      :global(button) {
-        flex: none;
-      }
-    }
   }
 </style>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -14,6 +14,12 @@
   let showHeader: boolean;
   $: showHeader = $$slots.title !== undefined;
 
+  let showToolbarDialog: boolean;
+  $: showToolbarDialog = $$slots.toolbar !== undefined && role === "dialog";
+
+  let showToolbarAlert: boolean;
+  $: showToolbarAlert = $$slots.toolbar !== undefined && role === "alert";
+
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");
 </script>
@@ -48,9 +54,15 @@
 
       <div class="content" id="modalContent" class:alert={role === "alert"}>
         <slot />
+
+        {#if showToolbarDialog}
+          <div class="toolbar">
+            <slot name="toolbar" />
+          </div>
+        {/if}
       </div>
 
-      {#if $$slots.toolbar}
+      {#if showToolbarAlert}
         <div class="toolbar">
           <slot name="toolbar" />
         </div>
@@ -109,6 +121,10 @@
 
       .toolbar {
         padding: 0 var(--alert-padding-x) var(--alert-padding-y);
+
+        @include media.min-width(small) {
+          justify-content: flex-end;
+        }
       }
     }
 
@@ -132,12 +148,11 @@
 
       .content {
         margin: 0 0 var(--dialog-padding-y);
-        padding: var(--dialog-padding-y) var(--dialog-padding-x) 0;
+        padding: var(--dialog-padding-y) var(--dialog-padding-x);
       }
 
       .toolbar {
-        padding: 0 var(--dialog-padding-x)
-          max(var(--dialog-padding-y), env(safe-area-inset-bottom));
+        padding: var(--padding-2x) 0 0;
       }
     }
   }
@@ -201,8 +216,6 @@
     }
 
     @include media.min-width(small) {
-      justify-content: flex-end;
-
       :global(button) {
         flex: none;
       }

--- a/src/lib/styles/global/modal.scss
+++ b/src/lib/styles/global/modal.scss
@@ -1,3 +1,5 @@
+@use "../mixins/media";
+
 /**
  * Styles that are shared in components used within modal
  */
@@ -16,5 +18,22 @@ div.modal {
 
   .wizard-list {
     padding-bottom: var(--padding);
+  }
+
+  .toolbar {
+    display: flex;
+    gap: var(--padding-2x);
+
+    padding: var(--padding-2x) 0 0;
+
+    :global(button) {
+      flex: 1;
+    }
+
+    @include media.min-width(small) {
+      :global(button) {
+        flex: none;
+      }
+    }
   }
 }

--- a/src/routes/components/modal/+page.md
+++ b/src/routes/components/modal/+page.md
@@ -37,17 +37,23 @@ A Modal is a dialog that appears on top of the app's content, and must be dismis
 
 ## Slots
 
-| Slot name    | Description                                                                                                                             |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Default slot | The content of the modal.                                                                                                               |
-| `title`      | The title of the modal. Displayed in a toolbar with a "Close" icon button on the right side.                                            |
-| `toolbar`    | A toolbar added next to the content in case of "dialog" behavior. In case of "alert", the toolbar is sticky to the bottom of the modal. |
+| Slot name    | Description                                                                                  |
+| ------------ | -------------------------------------------------------------------------------------------- |
+| Default slot | The content of the modal.                                                                    |
+| `title`      | The title of the modal. Displayed in a toolbar with a "Close" icon button on the right side. |
+| `toolbar`    | A sticky toolbar displayed at the bottom of the modal. Available for "alert" only.           |
 
 ## Events
 
 | Event      | Description                                                                                                                                           | Detail    |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | `nnsClose` | Triggered when a closing interaction element is clicks - close button or backdrop. Note that the modal itself does not update the `visible` property. | No detail |
+
+## Utility Classes
+
+| CSS classes | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `toolbar`   | Append inlined actions after the content of a "dialog". |
 
 ## Showcase
 
@@ -60,10 +66,21 @@ Open modal
 
 <DocsLoremIpsum length={role === "alert" ? 1 : 10} />
 
-<svelte:fragment slot="toolbar">
+{#if role === "dialog"}
+
+<div class="toolbar">
+    <button class="secondary">Cancel</button>
+    <button class="primary">An action</button>
+</div>
+{/if}
+
+<svelte:fragment slot="footer">
+{#if role === "alert"}
 <button class="secondary">Cancel</button>
 <button class="primary">An action</button>
+{/if}
 </svelte:fragment>
+
 </Modal>
 
 <p style="padding-top: var(--padding-2x)">Role of the modal:</p>

--- a/src/routes/components/modal/+page.md
+++ b/src/routes/components/modal/+page.md
@@ -37,10 +37,11 @@ A Modal is a dialog that appears on top of the app's content, and must be dismis
 
 ## Slots
 
-| Slot name    | Description                                                                                  |
-| ------------ | -------------------------------------------------------------------------------------------- |
-| Default slot | The content of the modal.                                                                    |
-| `title`      | The title of the modal. Displayed in a toolbar with a "Close" icon button on the right side. |
+| Slot name    | Description                                                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Default slot | The content of the modal.                                                                                                               |
+| `title`      | The title of the modal. Displayed in a toolbar with a "Close" icon button on the right side.                                            |
+| `toolbar`    | A toolbar added next to the content in case of "dialog" behavior. In case of "alert", the toolbar is sticky to the bottom of the modal. |
 
 ## Events
 
@@ -59,7 +60,10 @@ Open modal
 
 <DocsLoremIpsum length={role === "alert" ? 1 : 10} />
 
-<button slot="toolbar" class="primary">An action</button>
+<svelte:fragment slot="toolbar">
+<button class="secondary">Cancel</button>
+<button class="primary">An action</button>
+</svelte:fragment>
 </Modal>
 
 <p style="padding-top: var(--padding-2x)">Role of the modal:</p>


### PR DESCRIPTION
# Motivation

Discussed with Mischa, the modal's toolbar should not be sticky in case of dialog.

In case of alert, we keep a sticky option for backwards compatibility and time being.

# Changes

- rename `toolbar` slot to `footer` for "alert" (breaking change will need a pr in nns-dapp)
- add utility class `.toolbar` for "dialog"
