### PR TITLE
fix: toast has error

### DIFF
--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -4,9 +4,9 @@
   import { layoutBottomOffset } from "$lib/stores/layout.store";
 
   let hasErrors: boolean;
-  $: hasErrors = $toastsStore?.find(({ level }) =>
-    ["error", "warn"].includes(level)
-  );
+  $: hasErrors =
+    $toastsStore?.find(({ level }) => ["error", "warn"].includes(level)) !==
+    undefined;
 </script>
 
 {#if $toastsStore.length > 0}


### PR DESCRIPTION
# Motivation

Linter detected a potential issue in the comparison of the toasts

# Changes

- compare if find is `undefined`
