### PR TITLE
feat: input and range

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        run: npm run package
+      - name: Set up npm
+        run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
+        working-directory: ./package
+      - name: Publish
+        run: npm publish --access public
+        working-directory: ./package
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -14,3 +14,5 @@ export { default as BottomSheet } from "./components/BottomSheet.svelte";
 export { default as Toasts } from "./components/Toasts.svelte";
 export { default as Spinner } from "./components/Spinner.svelte";
 export { default as Modal } from "./components/Modal.svelte";
+export { default as Input } from "./components/Input.svelte";
+export { default as InputRange } from "./components/InputRange.svelte";

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  export let name: string;
+  export let inputType: "number" | "text" = "number";
+  export let required = true;
+  export let spellcheck: boolean | undefined = undefined;
+  export let step: number | "any" | undefined = undefined;
+  export let disabled = false;
+  export let minLength: number | undefined = undefined;
+  export let max: number | undefined = undefined;
+  export let value: string | number | undefined = undefined;
+  export let placeholder: string;
+  export let testId: string | undefined = undefined;
+
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+  export let autocomplete: "off" | "on" | undefined = undefined;
+
+  // When forwarding slots, they always appear as true
+  // This is a known issue in Svelte
+  // https://github.com/sveltejs/svelte/issues/6059
+  // To hack this, we pass a prop to avoid showing info element when not needed
+  // Ideally, this would be calculated
+  // showInfo = $$slots.label || $$slots.additional
+  export let showInfo = true;
+
+  $: step = inputType === "number" ? step ?? "any" : undefined;
+  $: autocomplete = inputType !== "number" ? autocomplete ?? "off" : undefined;
+</script>
+
+<div class="input-block" class:disabled>
+  {#if showInfo}
+    <div class="info">
+      <label class="label" for={name}><slot name="label" /></label>
+      <slot name="additional" />
+    </div>
+  {/if}
+  <input
+    data-tid={testId}
+    type={inputType}
+    {required}
+    {spellcheck}
+    {name}
+    id={name}
+    {step}
+    {disabled}
+    {value}
+    {minLength}
+    {placeholder}
+    {max}
+    {autocomplete}
+    on:blur
+    on:focus
+    on:input
+    on:keydown
+  />
+</div>
+
+<style lang="scss">
+  @use "../styles/mixins/form";
+
+  .input-block {
+    position: relative;
+
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--padding);
+
+    width: var(--input-width);
+
+    --disabled-color: var(--disable-contrast);
+
+    &.disabled {
+      color: var(--disabled-color);
+
+      input {
+        border: 1px solid var(--disabled-color);
+      }
+    }
+
+    color: var(--background-contrast);
+    background: none;
+  }
+
+  .info {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  input {
+    @include form.input;
+    width: 100%;
+
+    font-size: inherit;
+
+    padding: var(--padding-2x);
+    box-sizing: border-box;
+
+    box-shadow: var(--current-box-inset-shadow);
+
+    border-radius: var(--element-border-radius);
+
+    outline: none;
+  }
+
+  input:focus {
+    border: 1px solid var(--primary);
+  }
+
+  input[disabled] {
+    cursor: text;
+  }
+</style>

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let name: string;
-  export let inputType: "number" | "text" = "number";
+  export let inputType: "icp" | "number" | "text" = "number";
   export let required = true;
   export let spellcheck: boolean | undefined = undefined;
   export let step: number | "any" | undefined = undefined;
@@ -22,10 +22,111 @@
   // showInfo = $$slots.label || $$slots.additional
   export let showInfo = true;
 
-  export let inputElement: HTMLInputElement | undefined;
+  let inputElement: HTMLInputElement | undefined;
 
   $: step = inputType === "number" ? step ?? "any" : undefined;
   $: autocomplete = inputType !== "number" ? autocomplete ?? "off" : undefined;
+
+  let selectionStart: number | null = 0;
+  let selectionEnd: number | null = 0;
+
+  // To show undefined as "" (because of the type="text")
+  const fixUndefinedValue = (value: string | number | undefined): string =>
+    value === undefined ? "" : `${value}`;
+
+  let icpValue: string = fixUndefinedValue(value);
+  let lastValidICPValue: string | number | undefined = value;
+  let internalValueChange = true;
+
+  $: value,
+    (() => {
+      if (!internalValueChange && inputType === "icp") {
+        icpValue = fixUndefinedValue(value);
+        lastValidICPValue = icpValue;
+      }
+
+      internalValueChange = false;
+    })();
+
+  const restoreFromValidValue = (noValue = false) => {
+    if (inputElement === undefined || inputType !== "icp") {
+      return;
+    }
+
+    if (noValue) {
+      lastValidICPValue = undefined;
+    }
+
+    internalValueChange = true;
+    value =
+      lastValidICPValue === undefined
+        ? undefined
+        : typeof lastValidICPValue === "number"
+        ? lastValidICPValue.toFixed(8)
+        : +lastValidICPValue;
+    icpValue = fixUndefinedValue(lastValidICPValue);
+
+    // force dom update (because no active triggers)
+    inputElement.value = icpValue;
+
+    // restore cursor position
+    inputElement.setSelectionRange(selectionStart, selectionEnd);
+  };
+
+  // The type declaration of the input event is neither defined in node types nor in svelte.
+  // This extends the event with the currentTarget that is provided by the browser and that can be used to retrieve the input value.
+  type InputEventHandler = Event & {
+    currentTarget: EventTarget & HTMLInputElement;
+  };
+
+  const isValidICPFormat = (text: string): boolean =>
+    /^[\d]*(\.[\d]{0,8})?$/.test(text);
+
+  const handleInput = ({ currentTarget }: InputEventHandler) => {
+    if (inputType === "icp") {
+      const currentValue = currentTarget.value;
+
+      // handle invalid input
+      if (isValidICPFormat(currentValue) === false) {
+        // restore value (e.g. to fix invalid paste)
+        restoreFromValidValue();
+        return;
+      }
+
+      // reset to undefined ("" => undefined)
+      if (currentValue.length === 0) {
+        restoreFromValidValue(true);
+        return;
+      }
+
+      lastValidICPValue = currentValue;
+      icpValue = fixUndefinedValue(currentValue);
+
+      internalValueChange = true;
+      // for inputType="icp" value is a number
+      // TODO: do we need to fix lost precision for too big for number inputs?
+      value = +currentValue;
+      return;
+    }
+
+    internalValueChange = true;
+    value = inputType === "number" ? +currentTarget.value : currentTarget.value;
+  };
+
+  const handleKeyDown = () => {
+    if (inputElement === undefined) {
+      return;
+    }
+
+    // preserve selection
+    ({ selectionStart, selectionEnd } = inputElement);
+  };
+
+  $: step = inputType === "number" ? step ?? "any" : undefined;
+  $: autocomplete =
+    inputType !== "number" && inputType !== "icp"
+      ? autocomplete ?? "off"
+      : undefined;
 </script>
 
 <div class="input-block" class:disabled>
@@ -38,22 +139,22 @@
   <input
     bind:this={inputElement}
     data-tid={testId}
-    type={inputType}
+    type={inputType === "icp" ? "text" : inputType}
     {required}
     {spellcheck}
     {name}
     id={name}
     {step}
     {disabled}
-    {value}
+    value={inputType === "icp" ? icpValue : value}
     {minLength}
     {placeholder}
     {max}
     {autocomplete}
     on:blur
     on:focus
-    on:input
-    on:keydown
+    on:input={handleInput}
+    on:keydown={handleKeyDown}
   />
 </div>
 

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -22,6 +22,8 @@
   // showInfo = $$slots.label || $$slots.additional
   export let showInfo = true;
 
+  export let inputElement: HTMLInputElement | undefined;
+
   $: step = inputType === "number" ? step ?? "any" : undefined;
   $: autocomplete = inputType !== "number" ? autocomplete ?? "off" : undefined;
 </script>
@@ -34,6 +36,7 @@
     </div>
   {/if}
   <input
+    bind:this={inputElement}
     data-tid={testId}
     type={inputType}
     {required}

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -204,6 +204,7 @@
     border-radius: var(--element-border-radius);
 
     outline: none;
+    -webkit-appearance: none;
   }
 
   input:focus {

--- a/src/lib/components/InputRange.svelte
+++ b/src/lib/components/InputRange.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  export let max: number;
+  export let min: number;
+  export let value: number;
+  export let ariaLabel: string;
+  export let handleInput: (() => void) | undefined = undefined;
+
+  let progression: number;
+  $: progression = Math.round(((value - min) / (max - min)) * 100);
+</script>
+
+<!-- Order of on:input and bind:value matters: https://svelte.dev/docs#template-syntax-element-directives-bind-property -->
+<input
+  data-tid="input-range"
+  {min}
+  {max}
+  aria-label={ariaLabel}
+  type="range"
+  bind:value
+  on:input={handleInput}
+  style={`--range-progression: ${progression}%; --range-end: ${
+    1 - progression
+  }%;`}
+/>
+
+<style lang="scss">
+  @use "../styles/mixins/interaction";
+  @use "../styles/mixins/media";
+
+  input {
+    appearance: none;
+    border-radius: 5px;
+    height: 5px;
+    width: 100%;
+
+    /** Declaring this value as a CSS variable in dark.scss and light.scss was not interpreted correctly, therefore we implement these here */
+    background: linear-gradient(
+      99.27deg,
+      var(--primary) -0.11%,
+      #4e48d2 var(--range-progression),
+      var(--background) var(--range-end)
+    );
+  }
+
+  @include media.light-theme() {
+    input {
+      background: linear-gradient(
+        99.27deg,
+        var(--primary) -0.11%,
+        #4e48d2 var(--range-progression),
+        var(--background-shade) var(--range-end)
+      );
+    }
+  }
+
+  input:focus {
+    outline: none;
+  }
+
+  input::-moz-focus-outer {
+    border: 0;
+  }
+
+  input::-webkit-slider-thumb {
+    height: var(--icon-width);
+    width: var(--icon-width);
+    border-radius: 50%;
+    background: var(--primary);
+    border: 2px solid var(--primary-contrast);
+    box-shadow: var(--interaction-box-shadow);
+    @include interaction.tappable;
+    appearance: none;
+  }
+
+  input::-moz-range-thumb {
+    height: var(--icon-width);
+    width: var(--icon-width);
+    border-radius: 50%;
+    background: var(--primary);
+    border: 2px solid var(--primary-contrast);
+    box-shadow: var(--interaction-box-shadow);
+    @include interaction.tappable;
+  }
+
+  input::-ms-thumb {
+    height: var(--icon-width);
+    width: var(--icon-width);
+    border-radius: 50%;
+    background: var(--primary);
+    border: 2px solid var(--primary-contrast);
+    box-shadow: var(--interaction-box-shadow);
+    @include interaction.tappable;
+  }
+
+  input::-webkit-slider-runnable-track {
+    cursor: pointer;
+  }
+</style>

--- a/src/lib/components/InputRange.svelte
+++ b/src/lib/components/InputRange.svelte
@@ -56,7 +56,7 @@
     width: var(--icon-width);
     border-radius: 50%;
     background: var(--primary);
-    border: 2px solid var(--primary-contrast);
+    border: 2px solid var(--card-background);
     box-shadow: var(--interaction-box-shadow);
     @include interaction.tappable;
     appearance: none;
@@ -67,7 +67,7 @@
     width: var(--icon-width);
     border-radius: 50%;
     background: var(--primary);
-    border: 2px solid var(--primary-contrast);
+    border: 2px solid var(--card-background);
     box-shadow: var(--interaction-box-shadow);
     @include interaction.tappable;
   }
@@ -77,7 +77,7 @@
     width: var(--icon-width);
     border-radius: 50%;
     background: var(--primary);
-    border: 2px solid var(--primary-contrast);
+    border: 2px solid var(--card-background);
     box-shadow: var(--interaction-box-shadow);
     @include interaction.tappable;
   }

--- a/src/lib/components/InputRange.svelte
+++ b/src/lib/components/InputRange.svelte
@@ -40,7 +40,7 @@
       var(--card-background) var(--range-end)
     );
 
-    box-shadow: var(--inner-box-shadow);
+    box-shadow: var(--range-box-inset-shadow);
   }
 
   input:focus {

--- a/src/lib/components/InputRange.svelte
+++ b/src/lib/components/InputRange.svelte
@@ -25,12 +25,11 @@
 
 <style lang="scss">
   @use "../styles/mixins/interaction";
-  @use "../styles/mixins/media";
 
   input {
     appearance: none;
-    border-radius: 5px;
-    height: 5px;
+    border-radius: var(--padding-0_5x);
+    height: var(--padding);
     width: 100%;
 
     /** Declaring this value as a CSS variable in dark.scss and light.scss was not interpreted correctly, therefore we implement these here */
@@ -38,19 +37,10 @@
       99.27deg,
       var(--primary) -0.11%,
       #4e48d2 var(--range-progression),
-      var(--background) var(--range-end)
+      var(--card-background) var(--range-end)
     );
-  }
 
-  @include media.light-theme() {
-    input {
-      background: linear-gradient(
-        99.27deg,
-        var(--primary) -0.11%,
-        #4e48d2 var(--range-progression),
-        var(--background-shade) var(--range-end)
-      );
-    }
+    box-shadow: var(--inner-box-shadow);
   }
 
   input:focus {

--- a/src/lib/components/InputRange.svelte
+++ b/src/lib/components/InputRange.svelte
@@ -40,7 +40,7 @@
       var(--card-background) var(--range-end)
     );
 
-    box-shadow: var(--range-box-inset-shadow);
+    box-shadow: var(--input-box-shadow);
   }
 
   input:focus {

--- a/src/lib/styles/mixins/_form.scss
+++ b/src/lib/styles/mixins/_form.scss
@@ -1,0 +1,4 @@
+@mixin input {
+  border: 1px solid var(--input-error-color, var(--input-border-color));
+  background: var(--card-background);
+}

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -8,7 +8,7 @@
     1px 1px 2px rgba(0, 0, 0, 0.3);
   --header-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   --bottom-sheet-box-shadow: -1px -1px 10px rgba(0, 0, 0, 0.25);
-  --inner-box-shadow: inset -1px -1px 4px rgba(255, 255, 255, 0.25),
+  --range-box-inset-shadow: inset -1px -1px 4px rgba(255, 255, 255, 0.25),
     inset 1px 1px 3px rgba(54, 54, 54, 0.4);
 
   --current-box-inset-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4) inset;

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -8,6 +8,8 @@
     1px 1px 2px rgba(0, 0, 0, 0.3);
   --header-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   --bottom-sheet-box-shadow: -1px -1px 10px rgba(0, 0, 0, 0.25);
+  --inner-box-shadow: inset -1px -1px 4px rgba(255, 255, 255, 0.25),
+    inset 1px 1px 3px rgba(54, 54, 54, 0.4);
 
   --current-box-inset-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4) inset;
 

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -8,10 +8,7 @@
     1px 1px 2px rgba(0, 0, 0, 0.3);
   --header-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   --bottom-sheet-box-shadow: -1px -1px 10px rgba(0, 0, 0, 0.25);
-  --range-box-inset-shadow: inset -1px -1px 4px rgba(255, 255, 255, 0.25),
-    inset 1px 1px 3px rgba(54, 54, 54, 0.4);
-
-  --current-box-inset-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4) inset;
+  --input-box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.4) inset;
 
   // Footer
   --footer-background: linear-gradient(

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -7,6 +7,8 @@
     --menu-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
     --interaction-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25), -1px -1px 2px #ffffff,
       var(--menu-box-shadow);
+    --input-box-shadow: inset -1px -1px 4px rgba(255, 255, 255, 0.25),
+    inset 1px 1px 3px rgba(54, 54, 54, 0.4);
 
     // Footer
     --footer-background: linear-gradient(

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -79,6 +79,12 @@
       interactions with the main view of an application.
     </p>
   </Card>
+
+  <Card role="link" on:click={() => goto("/components/input")}>
+    <h2 class="title" slot="start">Input</h2>
+
+    <p>A styled input field where the user can enter data.</p>
+  </Card>
 </div>
 
 <p>TODO docs:</p>

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -85,6 +85,15 @@
 
     <p>A styled input field where the user can enter data.</p>
   </Card>
+
+  <Card role="link" on:click={() => goto("/components/input-range")}>
+    <h2 class="title" slot="start">Input Range</h2>
+
+    <p>
+      An input of type range to let the user specify a numeric value which must
+      be no less than a given value, and no more than another given value.
+    </p>
+  </Card>
 </div>
 
 <p>TODO docs:</p>

--- a/src/routes/components/input-range/+page.md
+++ b/src/routes/components/input-range/+page.md
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import InputRange from "$lib/components/InputRange.svelte";
+</script>
+
+# Input Range
+
+The input range component is a wrapper to the HTML input of `type="range"`.
+
+```html
+<InputRange min="{0}" max="{50}" value="{10}" />
+```
+
+## Properties
+
+| Property      | Description                         | Type                        | Default     |
+| ------------- | ----------------------------------- | --------------------------- | ----------- |
+| `max`         | HTML input `max` field.             | `number`                    |             |
+| `min`         | HTML input `min` field.             | `number`                    |             |
+| `value`       | HTML input `value` field.           | `number`                    |             |
+| `ariaLabel`   | HTML input `aria-label` field.      | `string`                    |             |
+| `handleInput` | A callback executed on user inputs. | `() => void` or `undefined` | `undefined` |
+
+## Showcase
+
+<div class="card-grid">
+    <InputRange min={0} max={50} value={10} />
+</div>

--- a/src/routes/components/input/+page.md
+++ b/src/routes/components/input/+page.md
@@ -16,7 +16,7 @@ The input component is a wrapper to the HTML input element with custom styling a
 | Property       | Description                                                                               | Type                                | Default     |
 | -------------- | ----------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
 | `name`         | HTML input `name` field.                                                                  | `string`                            |             |
-| `inputType`    | TML input `type` field.                                                                   | `text` or `number`                  | `number`    |
+| `inputType`    | HTML input `type` field extended with a custom `icp` type.                                | `text` or `number` or `icp`         | `number`    |
 | `required`     | HTML input `required` field.                                                              | `boolean`                           | `true`      |
 | `spellcheck`   | HTML input `spellcheck` field.                                                            | `boolean` or `undefined`            | `undefined` |
 | `step`         | HTML input `step` field.                                                                  | `number` or `any` or `undefined`    | `undefined` |
@@ -28,7 +28,6 @@ The input component is a wrapper to the HTML input element with custom styling a
 | `autocomplete` | HTML input `autocomplete` field.                                                          | `off` or `on` or `undefined`        | `undefined` |
 | `showInfo`     | Display additional information related to the input. Should be used in addition to slots. | `boolean`                           | `false`     |
 | `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                           | `string` or `undefined`             | `undefined` |
-| `inputElement` | A reference to rendered input element.                                                    | `HTMLInputElement` or `undefined`   |             |
 
 ## Slots
 
@@ -45,6 +44,8 @@ Both slots are displayed `flex` with `space-between`.
     <Input placeholder="Input number" />
 
     <Input placeholder="Input text" inputType="text" value="" />
+
+    <Input placeholder="Enter ICP" inputType="icp" value="" />
 
     <Input placeholder="Disabled" disabled value="This is a disabled value" inputType="text" />
 

--- a/src/routes/components/input/+page.md
+++ b/src/routes/components/input/+page.md
@@ -1,0 +1,55 @@
+<script lang="ts">
+    import Input from "$lib/components/Input.svelte";
+</script>
+
+# Input
+
+The input component is a wrapper to the HTML input element with custom styling and additional functionality.
+
+```html
+<input placeholder="An input" />
+<input placeholder="An text" inputType="text" value="Hello World" />
+```
+
+## Properties
+
+| Property       | Description                                                                               | Type                                | Default     |
+| -------------- | ----------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
+| `name`         | HTML input `name` field.                                                                  | `string`                            |             |
+| `inputType`    | TML input `type` field.                                                                   | `text` or `number`                  | `number`    |
+| `required`     | HTML input `required` field.                                                              | `boolean`                           | `true`      |
+| `spellcheck`   | HTML input `spellcheck` field.                                                            | `boolean` or `undefined`            | `undefined` |
+| `step`         | HTML input `step` field.                                                                  | `number` or `any` or `undefined`    | `undefined` |
+| `disabled`     | HTML input `disabled` field.                                                              | `boolean`                           | `false`     |
+| `minLength`    | HTML input `minlength` field.                                                             | `number` or `undefined`             | `undefined` |
+| `max`          | HTML input `max` field.                                                                   | `number` or `undefined`             | `undefined` |
+| `value`        | HTML input `value` field.                                                                 | `string` or `number` or `undefined` | `undefined` |
+| `placeholder`  | HTML input `placeholder` field.                                                           | `string`                            |             |
+| `autocomplete` | HTML input `autocomplete` field.                                                          | `off` or `on` or `undefined`        | `undefined` |
+| `showInfo`     | Display additional information related to the input. Should be used in addition to slots. | `boolean`                           | `false`     |
+| `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                           | `string` or `undefined`             | `undefined` |
+
+## Slots
+
+| Slot name    | Description                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| `label`      | A label related to the input. Need to be activated with the property `showInfo`.                       |
+| `additional` | An addition such as an action related to the input. Need to be activated with the property `showInfo`. |
+
+Both slots are displayed `flex` with `space-between`.
+
+## Showcase
+
+<div class="card-grid">
+    <Input placeholder="Input number" />
+
+    <Input placeholder="Input text" inputType="text" value="" />
+
+    <Input placeholder="Disabled" disabled value="This is a disabled value" inputType="text" />
+
+    <Input placeholder="Input text" inputType="text" value="" showInfo>
+        <svelte:fragment slot="label">A label</svelte:fragment>
+        <span slot="additional">More</span>
+    </Input>
+
+</div>

--- a/src/routes/components/input/+page.md
+++ b/src/routes/components/input/+page.md
@@ -28,6 +28,7 @@ The input component is a wrapper to the HTML input element with custom styling a
 | `autocomplete` | HTML input `autocomplete` field.                                                          | `off` or `on` or `undefined`        | `undefined` |
 | `showInfo`     | Display additional information related to the input. Should be used in addition to slots. | `boolean`                           | `false`     |
 | `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                           | `string` or `undefined`             | `undefined` |
+| `inputElement` | A reference to rendered input element.                                                    | `HTMLInputElement` or `undefined`   |             |
 
 ## Slots
 

--- a/src/tests/components/Input.spec.ts
+++ b/src/tests/components/Input.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import Input from "$lib/components/Input.svelte";
+import InputTest from "./InputTest.svelte";
+import InputValueTest from "./InputValueTest.svelte";
+
+describe("Input", () => {
+  const props = { name: "name", placeholder: "test.placeholder" };
+
+  it("should render an input", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+  });
+
+  it("should render a placeholder", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    expect(container.querySelector("input")?.getAttribute("placeholder")).toBe(
+      "test.placeholder"
+    );
+  });
+
+  const testGetAttribute = ({
+    attribute,
+    expected,
+    container,
+  }: {
+    attribute: string;
+    expected: string;
+    container: HTMLElement;
+  }) => {
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input?.getAttribute(attribute)).toEqual(expected);
+  };
+
+  const testHasAttribute = ({
+    attribute,
+    expected,
+    container,
+    expectedValue,
+  }: {
+    attribute: string;
+    expected: boolean;
+    container: HTMLElement;
+    expectedValue?: boolean;
+  }) => {
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input?.hasAttribute(attribute)).toEqual(expected);
+    if (expectedValue !== undefined) {
+      expect(input?.getAttribute(attribute)).toEqual(expectedValue);
+    }
+  };
+
+  it("should render an input of type number", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    testGetAttribute({ container, attribute: "type", expected: "number" });
+  });
+
+  it("should render an input of type text", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+      },
+    });
+
+    testGetAttribute({ container, attribute: "type", expected: "text" });
+  });
+
+  it("should render a required input", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    testHasAttribute({ container, attribute: "required", expected: true });
+  });
+
+  it("should render a required input", () => {
+    const { container } = render(Input, {
+      props: { ...props, required: false },
+    });
+
+    testHasAttribute({ container, attribute: "required", expected: false });
+  });
+
+  it("should render an input without spellcheck", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    testHasAttribute({ container, attribute: "spellcheck", expected: false });
+  });
+
+  it("should render an input with spellcheck", () => {
+    const { container } = render(Input, {
+      props: { ...props, spellcheck: true },
+    });
+
+    testHasAttribute({ container, attribute: "spellcheck", expected: true });
+  });
+
+  it("should render an input without autocomplete", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    testHasAttribute({ container, attribute: "autocomplete", expected: false });
+  });
+
+  it("should render an input with autocomplete", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+        autocomplete: "off",
+      },
+    });
+
+    testHasAttribute({ container, attribute: "autocomplete", expected: true });
+  });
+
+  it("should render an input with step any", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    testGetAttribute({ container, attribute: "step", expected: "any" });
+  });
+
+  it("should render a text input with autocomplete to off as default value", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+      },
+    });
+
+    testGetAttribute({ container, attribute: "autocomplete", expected: "off" });
+  });
+
+  it("should render an input with min length", () => {
+    const { container } = render(Input, {
+      props: { ...props, minLength: 10 },
+    });
+
+    testGetAttribute({ container, attribute: "minLength", expected: "10" });
+  });
+
+  it("should render an input with a max attribute", () => {
+    const { container } = render(Input, {
+      props: { ...props, max: 10 },
+    });
+
+    testGetAttribute({ container, attribute: "max", expected: "10" });
+  });
+
+  it("should render an input with a particular step attribute", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        step: 2,
+      },
+    });
+
+    testGetAttribute({ container, attribute: "step", expected: "2" });
+  });
+
+  it("should render an input with no step", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+      },
+    });
+
+    testHasAttribute({ container, attribute: "step", expected: false });
+  });
+
+  it("should only accept number as input", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+    if (input) {
+      fireEvent.change(input, { target: { value: "test" } });
+      expect(input.value).toBe("");
+
+      fireEvent.change(input, { target: { value: "123" } });
+      expect(input.value).toBe("123");
+    }
+  });
+
+  it("should accept text as input", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+      },
+    });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+    if (input) {
+      fireEvent.change(input, { target: { value: "test" } });
+      expect(input.value).toBe("test");
+
+      fireEvent.change(input, { target: { value: "123" } });
+      expect(input.value).toBe("123");
+
+      fireEvent.change(input, { target: { value: "test123" } });
+      expect(input.value).toBe("test123");
+    }
+  });
+
+  it("should render the button slot", () => {
+    const { getByText } = render(InputTest, {
+      props: {
+        props: {
+          ...props,
+          inputType: "text",
+        },
+      },
+    });
+    expect(getByText("Test Button")).toBeInTheDocument();
+  });
+
+  it("should not be disabled per default", () => {
+    const { container } = render(Input, {
+      props: { ...props },
+    });
+
+    testHasAttribute({ container, attribute: "disabled", expected: false });
+  });
+
+  it("should render a disabled input", () => {
+    const { container } = render(Input, {
+      props: { ...props, disabled: true },
+    });
+
+    testHasAttribute({ container, attribute: "disabled", expected: true });
+  });
+
+  it("should bind value", async () => {
+    const { container } = render(InputValueTest, {
+      props: {
+        ...props,
+        inputType: "text",
+      },
+    });
+
+    const testInput = "new value";
+    const testBind: HTMLSpanElement | null = container.querySelector("#test");
+    testBind && (await fireEvent.click(testBind));
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input?.value).toBe(testInput);
+  });
+});

--- a/src/tests/components/Input.spec.ts
+++ b/src/tests/components/Input.spec.ts
@@ -269,4 +269,95 @@ describe("Input", () => {
     const input: HTMLInputElement | null = container.querySelector("input");
     expect(input?.value).toBe(testInput);
   });
+
+  describe("inputType=icp", () => {
+    it("should render an input of type icp as text", () => {
+      const { container } = render(Input, {
+        props: {
+          ...props,
+          inputType: "icp",
+        },
+      });
+
+      testGetAttribute({ container, attribute: "type", expected: "text" });
+    });
+
+    it("should bind value", (done) => {
+      const { container, component } = render(InputValueTest, {
+        props: {
+          ...props,
+          inputType: "icp",
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+
+      if (input === null) {
+        throw new Error("No input");
+      }
+
+      fireEvent.input(input, { target: { value: "100" } });
+      expect(input.value).toBe("100");
+
+      component.$on("testAmount", ({ detail }) => {
+        expect(detail.amount).toBe(100);
+        done();
+      });
+    });
+
+    it("should not accept not icp formatted changed", async () => {
+      const { container } = render(Input, {
+        props: {
+          ...props,
+          value: "1",
+          inputType: "icp",
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+
+      if (input === null) {
+        throw new Error("No input");
+      }
+
+      fireEvent.input(input, { target: { value: "100" } });
+      expect(input.value).toBe("100");
+
+      fireEvent.input(input, { target: { value: "test" } });
+      expect(input.value).toBe("100");
+
+      fireEvent.input(input, { target: { value: "123" } });
+      expect(input.value).toBe("123");
+
+      fireEvent.input(input, { target: { value: ".0000001" } });
+      expect(input.value).toBe(".0000001");
+
+      fireEvent.input(input, { target: { value: ".000000001" } });
+      expect(input.value).toBe(".0000001");
+    });
+
+    it('should replace "" with undefined', (done) => {
+      const { container, component } = render(InputValueTest, {
+        props: {
+          ...props,
+          value: "0",
+          inputType: "icp",
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+
+      if (input === null) {
+        throw new Error("No input");
+      }
+
+      fireEvent.input(input, { target: { value: "" } });
+      expect(input.value).toBe("");
+
+      component.$on("testAmount", ({ detail }) => {
+        expect(detail.amount).toBe(undefined);
+        done();
+      });
+    });
+  });
 });

--- a/src/tests/components/InputRange.spec.ts
+++ b/src/tests/components/InputRange.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from "@testing-library/svelte";
+import InputRange from "$lib/components/InputRange.svelte";
+import InputRangeTest from "./InputRangeTest.svelte";
+
+describe("InputRange", () => {
+  const min = 0;
+  const max = 100;
+  const ariaLabel = "test";
+  it("should render an input", () => {
+    const { container } = render(InputRange, {
+      props: { min, max, value: 25, ariaLabel },
+    });
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+  });
+
+  it("should change value programatically", async () => {
+    const { container, queryByTestId } = render(InputRangeTest);
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+
+    // Should match values in InputRangeTest
+    const initialValue = 25;
+    const changedValue = 60;
+
+    expect(input?.value).toBe(initialValue.toString());
+
+    const button = queryByTestId("change-test-value");
+    expect(button).not.toBeNull();
+
+    button && (await fireEvent.click(button));
+    expect(input?.value).toBe(changedValue.toString());
+  });
+
+  it("should bind the value", async () => {
+    const initialValue = 25;
+    const changedValue = 90;
+    const { container } = render(InputRange, {
+      props: { min, max, value: initialValue, ariaLabel },
+    });
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe(initialValue.toString());
+
+    input &&
+      (await fireEvent.input(input, {
+        target: {
+          value: changedValue,
+        },
+      }));
+    expect(input?.value).toBe(changedValue.toString());
+  });
+
+  it("should respect the max value", async () => {
+    const initialValue = 25;
+    const changedValue = max + initialValue;
+    const { container } = render(InputRange, {
+      props: { min, max, value: initialValue, ariaLabel },
+    });
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe(initialValue.toString());
+
+    input &&
+      (await fireEvent.input(input, {
+        target: {
+          value: changedValue,
+        },
+      }));
+    expect(input?.value).not.toBe(changedValue.toString());
+  });
+
+  it("should respect the min value", async () => {
+    const initialValue = 25;
+    const newMin = 20;
+    const changedValue = 10;
+    const { container } = render(InputRange, {
+      props: { min: newMin, max, value: initialValue, ariaLabel },
+    });
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe(initialValue.toString());
+
+    input &&
+      (await fireEvent.input(input, {
+        target: {
+          value: changedValue,
+        },
+      }));
+    expect(input?.value).not.toBe(changedValue.toString());
+  });
+});

--- a/src/tests/components/InputRangeTest.svelte
+++ b/src/tests/components/InputRangeTest.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import InputRange from "$lib/components/InputRange.svelte";
+
+  let value = 25;
+
+  const change = () => (value = 60);
+</script>
+
+<button data-tid="change-test-value" on:click={change}>Click</button>
+<InputRange ariaLabel="test" min={0} max={100} bind:value />

--- a/src/tests/components/InputTest.svelte
+++ b/src/tests/components/InputTest.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Input from "$lib/components/Input.svelte";
+
+  export let props = {};
+</script>
+
+<Input {...props}>
+  <svelte:fragment slot="additional">
+    <button>Test Button</button>
+  </svelte:fragment>
+</Input>

--- a/src/tests/components/InputValueTest.svelte
+++ b/src/tests/components/InputValueTest.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte/internal";
+
+  import Input from "$lib/components/Input.svelte";
+
+  const dispatch = createEventDispatcher();
+
+  export let inputType: "text" | "icp" = "text";
+  export let name: string;
+  export let value: string | undefined = undefined;
+  export let placeholder = "test.placeholder";
+
+  let amount: string | undefined = value;
+  $: amount, (() => dispatch("testAmount", { amount }))();
+
+  // We want to test that we can change value programtically
+  const changeValue = () => {
+    amount = "new value";
+  };
+</script>
+
+<span on:click={changeValue} id="test" />
+
+<Input bind:value={amount} {inputType} {name} {placeholder} />

--- a/src/tests/components/InputValueTest.svelte
+++ b/src/tests/components/InputValueTest.svelte
@@ -13,7 +13,7 @@
   let amount: string | undefined = value;
   $: amount, (() => dispatch("testAmount", { amount }))();
 
-  // We want to test that we can change value programtically
+  // We want to test that we can change value programmatically
   const changeValue = () => {
     amount = "new value";
   };


### PR DESCRIPTION
# Motivation

- Add `<Input />` and `<InputRange />` to `gix-components`
- Review input range design to be able to use it in dark mode with new design

# Changes

lib:

- move `<Input />` and `<InputRange />` from NNS-dapp
- adapt input to make it agnostic
- review range style
- rename CSS variable for input box shadow (will have to be adapted in NNS-dapp)

doc:

- add new related pages
