### PR TITLE
style: fix modal height

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -132,6 +132,10 @@
 
       @supports (-webkit-touch-callout: none) {
         max-height: -webkit-fill-available;
+
+        @include media.min-width(medium) {
+          max-height: var(--dialog-max-height, 100%);
+        }
       }
 
       border-radius: var(--dialog-border-radius);


### PR DESCRIPTION
# Motivation

We don't have it yet with the new modal but I guess we will.

# Changes

- fix modal height

# Screenshots

<img width="764" alt="Capture d’écran 2022-09-28 à 15 59 02" src="https://user-images.githubusercontent.com/16886711/192802239-e3306606-1972-4fd2-9617-92ef281251c9.png">

