### PR TITLE
style: fix input inner box-shadow

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -199,7 +199,7 @@
     padding: var(--padding-2x);
     box-sizing: border-box;
 
-    box-shadow: var(--current-box-inset-shadow);
+    box-shadow: var(--input-box-shadow);
 
     border-radius: var(--element-border-radius);
 


### PR DESCRIPTION
# Motivation

The CSS variable for the box-shadow of input has been renamed to be develop input range as in Figma but the input wasn't updated accordingly.

# Changes

- use correct css variable