### PR TITLE
style: dialog bigger height and wizard form

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -126,8 +126,8 @@
       width: var(--dialog-width);
       max-width: var(--dialog-max-width);
 
+      min-height: var(--dialog-min-height);
       height: var(--dialog-height);
-
       max-height: var(--dialog-max-height, 100%);
 
       @supports (-webkit-touch-callout: none) {

--- a/src/lib/styles/global/modal.scss
+++ b/src/lib/styles/global/modal.scss
@@ -9,7 +9,7 @@ div.modal {
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    justify-content: center;
+    justify-content: flex-start;
     gap: var(--padding-3x);
   }
 

--- a/src/lib/styles/global/modal.scss
+++ b/src/lib/styles/global/modal.scss
@@ -5,19 +5,12 @@
  */
 
 div.modal {
-  .wizard-wrapper {
+  form {
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    justify-content: flex-start;
-    gap: var(--padding);
-    height: 100%;
-    min-height: inherit;
-    padding: 0;
-  }
-
-  .wizard-list {
-    padding-bottom: var(--padding);
+    justify-content: center;
+    gap: var(--padding-3x);
   }
 
   .toolbar {

--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -66,8 +66,9 @@
 
     --dialog-width: 888px;
     --dialog-max-width: var(--alert-max-width);
-    --dialog-height: var(--alert-max-height);
-    --dialog-max-height: 554.25px;
+    --dialog-min-height: 554.25px;
+    --dialog-height: fit-content;
+    --dialog-max-height: var(--alert-max-height);
     --dialog-border-radius: var(--alert-border-radius);
     --dialog-padding-x: var(--padding-6x);
   }


### PR DESCRIPTION
# Motivation

The dialog modal new design is too wide for Transactions in NNS-dapp on larger (> medium) screen.

We can also deprecate the wizard style and generally style form in modal.

# Changes

- make dialog height fit-content on large screen
- set previous max-height as mix-height to smooth the opening transition
- replace wizard style with form style

# Screenshots

Is:

<img width="1536" alt="Capture d’écran 2022-10-10 à 07 40 44" src="https://user-images.githubusercontent.com/16886711/194804535-8fea7cda-5272-422c-94b6-627fb10c87bd.png">
<img width="1536" alt="Capture d’écran 2022-10-10 à 07 40 46" src="https://user-images.githubusercontent.com/16886711/194804542-63c19169-a636-48b4-bc7d-7ac08eb91837.png">

Will be:

<img width="1536" alt="Capture d’écran 2022-10-10 à 07 40 29" src="https://user-images.githubusercontent.com/16886711/194804555-3a043e74-9057-46fb-a295-b3d9f40295ee.png">
<img width="1536" alt="Capture d’écran 2022-10-10 à 07 40 35" src="https://user-images.githubusercontent.com/16886711/194804569-d2f6d2bf-1ab7-44b7-b751-fdb60bda1ad5.png">

