### PR TITLE
Html component

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ npm i @dfinity/gix-components
 
 Running `npm run package` takes the contents of `src/lib` and generate the `package` directory - i.e. the library that is published to npm.
 
+Then this directory can be used to install the local version of `gix-components` in another project (`npm i /../gix-components/package`).
+To use it with 'jest' unit tests the content needs to be packed first (`cd package && npm pack`) then the created package file can be used by another project (e.g. `npm i /../gix-components/package/dfinity-gix-components-0.0.1.tgz`).
+
 See [documentation](https://kit.svelte.dev/docs/packaging) for more information.
 
 ## Documentation & Showcase

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -15,3 +15,12 @@ global.TextEncoder = TextEncoder;
 configure({
   testIdAttribute: "data-tid",
 });
+
+// make `DOMPurify` available for unit tests
+import { JSDOM } from "jsdom";
+import DOMPurify from "dompurify";
+const { window } = new JSDOM("<!DOCTYPE html>");
+const purify = DOMPurify(window as unknown as Window);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: used for testing only
+global.DOMPurify = purify;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,16 @@
     "": {
       "name": "@dfinity/gix-components",
       "version": "0.0.1",
+      "dependencies": {
+        "dompurify": "^2.4.0"
+      },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0-next.41",
         "@sveltejs/kit": "^1.0.0-next.464",
         "@sveltejs/package": "^1.0.0-next.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/svelte": "^3.2.1",
+        "@types/dompurify": "^2.3.4",
         "@types/jest": "^28.1.7",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
@@ -1488,6 +1492,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-EXzDatIb5EspL2eb/xPGmaC8pePcTHrkDCONjeisusLFrVfl38Pjea/R0YJGu3k9ZQadSvMqW0WXPI2hEo2Ajg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1633,6 +1646,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -2656,6 +2675,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
+      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.225",
@@ -8600,6 +8624,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-EXzDatIb5EspL2eb/xPGmaC8pePcTHrkDCONjeisusLFrVfl38Pjea/R0YJGu3k9ZQadSvMqW0WXPI2hEo2Ajg==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8738,6 +8771,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
     },
     "@types/unist": {
@@ -9461,6 +9500,11 @@
       "requires": {
         "webidl-conversions": "^7.0.0"
       }
+    },
+    "dompurify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
+      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
     },
     "electron-to-chromium": {
       "version": "1.4.225",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sveltejs/package": "^1.0.0-next.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/svelte": "^3.2.1",
+    "@types/dompurify": "^2.3.4",
     "@types/jest": "^28.1.7",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
@@ -43,5 +44,8 @@
     "typescript": "^4.7.4",
     "vite": "^3.1.0-beta.2"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "dompurify": "^2.4.0"
+  }
 }

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -26,3 +26,4 @@ export { default as ProgressBar } from "./components/ProgressBar.svelte";
 export { default as Tag } from "./components/Tag.svelte";
 export { default as Checkbox } from "./components/Checkbox.svelte";
 export { default as Collapsible } from "./components/Collapsible.svelte";
+export { default as Html } from "./components/Html.svelte";

--- a/src/lib/components/Html.svelte
+++ b/src/lib/components/Html.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { sanitize } from "$lib/utils/html.utils";
+  import { onMount } from "svelte";
+
+  export let text: string | undefined = undefined;
+
+  // force to rerender after SSR
+  let mounted = false;
+  onMount(async () => (mounted = true));
+</script>
+
+{#if mounted && text !== undefined}
+  {@html sanitize(text)}
+{/if}

--- a/src/lib/utils/html.utils.ts
+++ b/src/lib/utils/html.utils.ts
@@ -1,0 +1,13 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Sanitize a text with DOMPurify.
+ *
+ * Note: this library needs a workaround to work in the NodeJS context - i.e. for our jest test suite.
+ * See the jest-setup.ts for details.
+ */
+export const sanitize = (text: string): string => {
+  const domPurify =
+    typeof DOMPurify === "object" ? DOMPurify : global.DOMPurify;
+  return domPurify.sanitize(text);
+};

--- a/src/lib/utils/html.utils.ts
+++ b/src/lib/utils/html.utils.ts
@@ -7,7 +7,20 @@ import DOMPurify from "dompurify";
  * See the jest-setup.ts for details.
  */
 export const sanitize = (text: string): string => {
-  const domPurify =
-    typeof DOMPurify === "function" ? DOMPurify : global.DOMPurify;
-  return domPurify.sanitize(text);
+  try {
+    if (typeof DOMPurify.sanitize === "function") {
+      return DOMPurify.sanitize(text);
+    }
+
+    if (typeof global.DOMPurify.sanitize === "function") {
+      // utilize jest version
+      return global.DOMPurify.sanitize(text);
+    }
+  } catch (err) {
+    console.error(err);
+  }
+
+  console.error('no DOMPurify support');
+
+  return '';
 };

--- a/src/lib/utils/html.utils.ts
+++ b/src/lib/utils/html.utils.ts
@@ -20,7 +20,7 @@ export const sanitize = (text: string): string => {
     console.error(err);
   }
 
-  console.error('no DOMPurify support');
+  console.error("no DOMPurify support");
 
-  return '';
+  return "";
 };

--- a/src/lib/utils/html.utils.ts
+++ b/src/lib/utils/html.utils.ts
@@ -8,6 +8,6 @@ import DOMPurify from "dompurify";
  */
 export const sanitize = (text: string): string => {
   const domPurify =
-    typeof DOMPurify === "object" ? DOMPurify : global.DOMPurify;
+    typeof DOMPurify === "function" ? DOMPurify : global.DOMPurify;
   return domPurify.sanitize(text);
 };

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -154,6 +154,6 @@
 
   <Card role="link" on:click={() => goto("/components/html")}>
     <h2 class="title" slot="start">Html</h2>
-    <p>A component for safe (sanitized) rendering html content.</p>
+    <p>A component for safe (sanitized) html content rendering.</p>
   </Card>
 </div>

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -151,4 +151,9 @@
       Checkboxes allow the selection of multiple options from a set of options.
     </p>
   </Card>
+
+  <Card role="link" on:click={() => goto("/components/html")}>
+    <h2 class="title" slot="start">Html</h2>
+    <p>A component for safe (sanitized) rendering html content.</p>
+  </Card>
 </div>

--- a/src/routes/components/html/+page.md
+++ b/src/routes/components/html/+page.md
@@ -8,7 +8,8 @@ Html component sanitizes the provided text and renders HTML directly into a comp
 
 ```html
 <Html text="Valid HTML: <a target="_blank" href="/">A link</a>." />
-<html text="Dangerous HTML: <img src=x onerror=alert('HTML')//>." />
+
+<Html text="Dangerous HTML: <img src=x onerror=alert('HTML')//>." />
 ```
 
 ## Properties

--- a/src/routes/components/html/+page.md
+++ b/src/routes/components/html/+page.md
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import Html from "$lib/components/Html.svelte";
+</script>
+
+# Html
+
+Html component sanitizes the provided text and renders HTML directly into a component using `{@html ...}` tag.
+
+```html
+<Html text="Valid HTML: <a target="_blank" href="/">A link</a>." />
+<html text="Dangerous HTML: <img src=x onerror=alert('HTML')//>." />
+```
+
+## Properties
+
+| Property | Description                          | Type     | Default |
+| -------- | ------------------------------------ | -------- | ------- |
+| `text`   | An html text that should be rendered | `string` |         |
+
+## Showcase
+
+<div class="card-grid">
+    <div>
+        <Html text='Valid HTML: <a target="_blank" href="/">A link</a>.' />
+    </div>
+    <div>
+        <Html text='Dangerous HTML: <img src=x onerror=alert("HTML")//>.' />
+    </div>
+</div>

--- a/src/routes/components/html/+page.md
+++ b/src/routes/components/html/+page.md
@@ -9,7 +9,7 @@ Html component sanitizes the provided text and renders HTML directly into a comp
 ```html
 <Html text="Valid HTML: <a target="_blank" href="/">A link</a>." />
 
-<Html text="Dangerous HTML: <img src=x onerror=alert('HTML')//>." />
+<html text="Dangerous HTML: <img src=x onerror=alert('HTML')//>." />
 ```
 
 ## Properties

--- a/src/tests/lib/components/Html.spec.ts
+++ b/src/tests/lib/components/Html.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/svelte";
+import Html from "$lib/components/Html.svelte";
+import { sanitize } from "$lib/utils/html.utils";
+
+jest.mock("$lib/utils/html.utils", () => {
+  return {
+    sanitize: jest.fn().mockImplementation((text: string) => text),
+  };
+});
+
+describe("Html", () => {
+  beforeEach((sanitize as jest.MockedFn<typeof sanitize>).mockClear);
+
+  afterAll(jest.clearAllMocks);
+
+  it("should render plane text", () => {
+    const { getByText } = render(Html, {
+      props: {
+        text: "test",
+      },
+    });
+
+    expect(getByText("test")).toBeInTheDocument();
+  });
+
+  it("should render HTML content", () => {
+    const { container, getByText } = render(Html, {
+      props: {
+        text: "<a href='#'>test link</a>",
+      },
+    });
+
+    expect(getByText("test link")).toBeInTheDocument();
+    expect(container.querySelector("a")).toBeInTheDocument();
+    expect(container.querySelector("a")?.getAttribute("href")).toEqual("#");
+  });
+
+  it("should call sanitize", async () => {
+    render(Html, {
+      props: {
+        text: "test",
+      },
+    });
+
+    expect(sanitize).toBeCalledTimes(1);
+  });
+});

--- a/src/tests/lib/utils/html.utils.spec.ts
+++ b/src/tests/lib/utils/html.utils.spec.ts
@@ -1,0 +1,23 @@
+import { sanitize } from "../../../lib/utils/html.utils";
+
+describe("html-utils", () => {
+  it("should sanitize HTML", () => {
+    // Examples from DOMPurify README - https://github.com/cure53/DOMPurify
+    expect(sanitize("<img src=x onerror=alert(1)//>")).toEqual('<img src="x">');
+    expect(sanitize("<svg><g/onload=alert(2)//<p>")).toEqual(
+      "<svg><g></g></svg>"
+    );
+    expect(
+      sanitize("<p>abc<iframe//src=jAva&Tab;script:alert(3)>def</p>")
+    ).toEqual("<p>abc</p>");
+    expect(
+      sanitize('<math><mi//xlink:href="data:x,<script>alert(4)</script>">')
+    ).toEqual("<math><mi></mi></math>");
+    expect(sanitize("<TABLE><tr><td>HELLO</tr></TABL>")).toEqual(
+      "<table><tbody><tr><td>HELLO</td></tr></tbody></table>"
+    );
+    expect(sanitize("<UL><li><A HREF=//google.com>click</UL>")).toEqual(
+      '<ul><li><a href="//google.com">click</a></li></ul>'
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

`Html` component with sanitizing. To avoid direct usage of `@html`.

# Changes

- move and refactor `DOMPurify` usage from `nns-dapp`
- move `sanitize` util function from `nns-dapp`

# Tests

- Html component
- sanitize()

# Screenshots

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/98811342/197870838-b8a2b269-f28c-46ab-b693-883e7b3da989.png">
