### PR TITLE
chore: release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/gix-components",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "dompurify": "^2.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && vite build",


### PR DESCRIPTION
# Motivation

Bump version number to release `v1.0.0` to npm 🥳.
