### PR TITLE
style: remove scrollbar thumb height

### DIFF
--- a/src/lib/styles/global/theme.scss
+++ b/src/lib/styles/global/theme.scss
@@ -28,7 +28,6 @@ body {
 
 ::-webkit-scrollbar-thumb {
   background: var(--background-shade);
-  height: 200px;
   border: solid 2.5px var(--background);
   border-radius: 0.5em;
   -webkit-border-radius: 0.5em;


### PR DESCRIPTION
# Motivation

Remove `height` to fix toast message scrollbar.

# Changes

- remove custom `height`

# Screenshots

## Before
<img width="923" alt="Screenshot 2022-11-09 at 09 22 34" src="https://user-images.githubusercontent.com/98811342/200778432-9ef10933-2d13-4866-a930-49cc1a6d01ec.png">

## After

<img width="429" alt="Screenshot 2022-11-09 at 09 28 25" src="https://user-images.githubusercontent.com/98811342/200778549-5590bbf1-965f-4813-9526-f499edfe97b2.png">


<img width="508" alt="Screenshot 2022-11-08 at 20 36 53" src="https://user-images.githubusercontent.com/98811342/200778625-75631a46-0097-442b-b8fd-ffd1fcf13658.png">

<img width="507" alt="Screenshot 2022-11-08 at 20 35 37" src="https://user-images.githubusercontent.com/98811342/200778779-edbd1cd7-ed56-41d4-bf84-b54190d1e714.png">

