### PR TITLE
fix: broken summary position on FF

### DIFF
--- a/src/lib/styles/global/grid.scss
+++ b/src/lib/styles/global/grid.scss
@@ -46,19 +46,28 @@
       "content-c content-c content-c content-c content-c content-spacer content-d content-d content-d content-d content-d content-d";
   }
 
+  .ff-flexbox-fix {
+    // https://stackoverflow.com/a/28909778/4971475
+    min-width: 0;
+  }
+
   .content-a {
+    @extend .ff-flexbox-fix;
     grid-area: content-a;
   }
 
   .content-b {
+    @extend .ff-flexbox-fix;
     grid-area: content-b;
   }
 
   .content-c {
+    @extend .ff-flexbox-fix;
     grid-area: content-c;
   }
 
   .content-d {
+    @extend .ff-flexbox-fix;
     grid-area: content-d;
   }
 }


### PR DESCRIPTION
# Motivation

Fix the broken summary position on FF ([screen 1](https://github.com/dfinity/gix-components/pull/112#:~:text=Screenshots-,Before,-After), worse on android FF)

# Changes

- `min-width: 0;`

# Tests

Tested on 
- Desktop: FF, chrome, safari
- Android: FF, chrome

# Screenshots

## Before
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/98811342/201071872-709fcfec-974a-45e1-ba41-9cbfacd7da9c.png">

## After
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/98811342/201072200-f598718c-85ed-4465-b216-5e704d27462e.png">










