### PR TITLE
feat: backdrop over content if menu open on small devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/gix-components",
-      "version": "2.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "dompurify": "^2.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && vite build",
@@ -48,5 +48,13 @@
   "type": "module",
   "dependencies": {
     "dompurify": "^2.4.0"
-  }
+  },
+  "keywords": [
+    "ui",
+    "ux",
+    "designsystem",
+    "uikit",
+    "sveltekit",
+    "svelte"
+  ]
 }

--- a/src/lib/components/Backdrop.svelte
+++ b/src/lib/components/Backdrop.svelte
@@ -36,8 +36,7 @@
     @include interaction.tappable;
 
     &.disablePointerEvents {
-      cursor: inherit;
-      pointer-events: none;
+      @include interaction.none;
     }
   }
 </style>

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -10,7 +10,7 @@
   let open: boolean;
 </script>
 
-<SplitPane>
+<SplitPane bind:open>
   <header slot="header">
     <Toolbar>
       <svelte:fragment slot="start">

--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { layoutBottomOffset } from "$lib/stores/layout.store";
+  import Backdrop from "$lib/components/Backdrop.svelte";
+
+  export let open = false;
 </script>
 
 <div class="split-pane">
@@ -10,7 +13,9 @@
   >
     <slot name="header" />
 
-    <div class="scrollable-content">
+    <div class="scrollable-content" class:open>
+      <Backdrop on:nnsClose={() => (open = false)} />
+
       <slot />
     </div>
   </div>
@@ -19,6 +24,7 @@
 <style lang="scss">
   @use "../styles/mixins/media";
   @use "../styles/mixins/display";
+  @use "../styles/mixins/interaction";
 
   .split-pane {
     position: absolute;
@@ -50,6 +56,32 @@
 
     overflow-x: hidden;
     overflow-y: scroll;
+  }
+
+  // Reusing the component <Backdrop> but animated and displayed with CSS only for UX performance reason
+  .scrollable-content {
+    & > :global(div.backdrop) {
+      opacity: 0;
+      visibility: hidden;
+
+      transition: opacity var(--animation-time-short);
+    }
+
+    // On smaller screen the menu is open on demand
+    &.open > :global(div.backdrop) {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    // On xlarge screen the menu is sticky so we do not display a backdrop even if .open is set
+    @include media.min-width(xlarge) {
+      &.open > :global(div.backdrop) {
+        opacity: 0;
+        visibility: hidden;
+
+        @include interaction.none;
+      }
+    }
   }
 
   // BEGIN: On small devices the header is sticky

--- a/src/lib/styles/mixins/_interaction.scss
+++ b/src/lib/styles/mixins/_interaction.scss
@@ -13,3 +13,8 @@
   touch-action: none;
   pointer-events: none;
 }
+
+@mixin none {
+  cursor: inherit;
+  pointer-events: none;
+}


### PR DESCRIPTION
# Motivation

- improve user experience when the menu pushes the content on mobile devices
- improve user experience glitch when menu is open on small window, then user navigate and browser is resized and back button is still displayed

# Changes

- use the `<Backdrop />` component in the `<SplitPan />` but animate with CSS only and not with JavaScript / Svelte to have a smooth behavior without the need to observe window size with JS

# Edge case

If user as a small window, open the menu, make the window bigger, then navigate, then make the window smaller, the "back" button and menu open are going to be displayed. I think it's an acceptable edge case - i.e. a pure CSS solution is better than a JavaScript less smooth solution.

# Screenshots

![Enregistrement de l’écran 2022-11-15 à 10 46 47](https://user-images.githubusercontent.com/16886711/201887705-441f87c1-f2ca-4cfa-bbaf-54c813642782.gif)
![Enregistrement de l’écran 2022-11-15 à 10 47 35](https://user-images.githubusercontent.com/16886711/201887732-5b8f3b2b-e3c3-4800-9652-db21ef3bf5d5.gif)

