### PR TITLE
style: dialog max height on iOS

### DIFF
--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -62,6 +62,7 @@
 
   @supports (-webkit-touch-callout: none) {
     --dialog-height: -webkit-fill-available;
+    --alert-max-height: -webkit-fill-available;
   }
 
   @include media.min-width(medium) {


### PR DESCRIPTION
# Motivation

Fix max height for dialog on iOS.

# Screenshots

Before

<img width="533" alt="Capture d’écran 2022-11-16 à 18 43 46" src="https://user-images.githubusercontent.com/16886711/202254561-af845d79-84ad-4087-9a63-88bec2561bc4.png">

After

<img width="533" alt="Capture d’écran 2022-11-16 à 18 43 50" src="https://user-images.githubusercontent.com/16886711/202254598-7ef8fd00-fcbe-42ea-baab-44b5a2685847.png">

