### PR TITLE
style: fix menuitems z-index

### DIFF
--- a/src/lib/components/MenuItem.svelte
+++ b/src/lib/components/MenuItem.svelte
@@ -22,6 +22,8 @@
     color: var(--menu-color);
     transition: color var(--animation-time-short) ease-in;
 
+    z-index: var(--menu-z-index);
+
     @include fonts.h5;
 
     text-decoration: none;


### PR DESCRIPTION
# Motivation

`<MenuItem />` are rendered under background on small height devices.

# Changes

- add a z-index

# Screenshots

Before

<img width="1536" alt="Capture d’écran 2022-11-17 à 07 12 44" src="https://user-images.githubusercontent.com/16886711/202370662-0ebfb5e2-9ad4-4c3c-bfb5-5f629a0ebbe0.png">

After

<img width="1536" alt="Capture d’écran 2022-11-17 à 07 13 01" src="https://user-images.githubusercontent.com/16886711/202370695-6410098b-734d-44bc-ad68-2ff0ee0783e1.png">
