### PR TITLE
fix: menu backdrop accessibility and z-index

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -37,7 +37,9 @@
   </header>
 
   <div class="scrollable-content" class:open={$layoutMenuOpen}>
-    <Backdrop on:nnsClose={() => layoutMenuOpen.set(false)} />
+    {#if $layoutMenuOpen}
+      <Backdrop on:nnsClose={() => layoutMenuOpen.set(false)} />
+    {/if}
 
     <slot />
   </div>
@@ -92,29 +94,9 @@
     overflow-y: auto;
   }
 
-  // Reusing the component <Backdrop> but animated and displayed with CSS only for UX performance reason
   .scrollable-content {
     & > :global(div.backdrop) {
-      opacity: 0;
-      visibility: hidden;
-
-      transition: opacity var(--animation-time-short);
-    }
-
-    // On smaller screen the menu is open on demand
-    &.open > :global(div.backdrop) {
-      opacity: 1;
-      visibility: visible;
-    }
-
-    // On xlarge screen the menu is sticky so we do not display a backdrop even if .open is set
-    @include media.min-width(xlarge) {
-      &.open > :global(div.backdrop) {
-        opacity: 0;
-        visibility: hidden;
-
-        @include interaction.none;
-      }
+      z-index: var(--overlay-z-index);
     }
   }
 </style>

--- a/src/lib/components/SplitPane.svelte
+++ b/src/lib/components/SplitPane.svelte
@@ -1,3 +1,23 @@
+<script lang="ts">
+  import { layoutMenuOpen } from "../stores/layout.store";
+
+  let innerWidth = 0;
+
+  // Close menu if it was opened and the viewport width becomes larger than xlarge screen (where the menu becomes sticky)
+  const onWindowSizeChange = (innerWidth: number) => {
+    if (!$layoutMenuOpen) {
+      return;
+    }
+
+    // The media query breakpoint to stick the menu is media xlarge 1300px
+    layoutMenuOpen.set(innerWidth > 1300 ? false : $layoutMenuOpen);
+  };
+
+  $: onWindowSizeChange(innerWidth);
+</script>
+
+<svelte:window bind:innerWidth />
+
 <div class="split-pane">
   <slot name="menu" />
   <slot />


### PR DESCRIPTION
# Motivation

While displaying a backdrop over the content when the menu is open works, the accessibility is not good because the related element remains in the DOM even if not presented. This was an original decision for performance reason but after thinking about it, it's cleaner to remove it when not presented.

In addition, this PR also fixes a z-index issue.

# Changes

- add backdrop to dom over content only when needed
- close "menu open store" on wide screen with JS (to solve above requirements)
- fix z-index quirks

# Screenshots

![image](https://user-images.githubusercontent.com/16886711/202437608-4660e8c5-8d0e-41c6-8b82-078f0f5a3616.png)

