### PR TITLE
style: fix content backdrop z-index

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -96,7 +96,7 @@
 
   .scrollable-content {
     & > :global(div.backdrop) {
-      z-index: var(--overlay-z-index);
+      z-index: var(--z-index);
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

NNS-dapp e2e are failing https://github.com/dfinity/nns-dapp/actions/runs/3488539088/jobs/5837488928

`z-index` ❤️

# Screenshots

Before

<img width="1029" alt="Capture d’écran 2022-11-17 à 14 41 08" src="https://user-images.githubusercontent.com/16886711/202461945-efed5ef2-ab69-4156-a1a1-a950f96ac905.png">

After

<img width="1029" alt="Capture d’écran 2022-11-17 à 14 41 32" src="https://user-images.githubusercontent.com/16886711/202461983-a2ddf20a-c5ee-4221-8a72-0df12df1a6e0.png">
