### PR TITLE
style: summary grid

### DIFF
--- a/src/lib/styles/global/grid.scss
+++ b/src/lib/styles/global/grid.scss
@@ -1,23 +1,47 @@
 @use "../mixins/media";
 
-.card-grid {
+.card-grid,
+.summary-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: var(--padding-4x);
   grid-auto-rows: minmax(0, max-content);
 
-  @include media.min-width(medium) {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  @include media.min-width(xlarge) {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-
   :global(.card) {
     margin: 0;
     height: 100%;
     box-sizing: border-box;
+  }
+}
+
+.card-grid {
+  @include media.min-width(medium) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include media.min-width(xlarge) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.summary-grid {
+  @include media.min-width(medium) {
+    grid-template-columns: repeat(2, 1fr);
+    width: 85%;
+  }
+
+  @include media.min-width(large) {
+    grid-template-columns: repeat(3, 1fr);
+    width: 100%;
+  }
+  @include media.min-width(xlarge) {
+    grid-template-columns: repeat(2, 1fr);
+    width: 80%;
+  }
+
+  @include media.min-width(xlargemenu) {
+    grid-template-columns: repeat(4, 1fr);
+    width: 100%;
   }
 }
 

--- a/src/lib/styles/mixins/_media.scss
+++ b/src/lib/styles/mixins/_media.scss
@@ -3,6 +3,8 @@ $breakpoint-small: 576px;
 $breakpoint-medium: 768px;
 $breakpoint-large: 1024px;
 $breakpoint-extra-large: 1300px;
+// = calc(var(--menu-width) + $breakpoint-extra-large)
+$breakpoint-extra-large-plus-menu: 1540px;
 
 @mixin min-width($breakpoint) {
   @if ($breakpoint == xsmall) {
@@ -23,6 +25,10 @@ $breakpoint-extra-large: 1300px;
     }
   } @else if ($breakpoint == xlarge) {
     @media (min-width: $breakpoint-extra-large) {
+      @content;
+    }
+  } @else if ($breakpoint == xlargemenu) {
+    @media (min-width: $breakpoint-extra-large-plus-menu) {
       @content;
     }
   } @else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,55 @@
 
 <p>A UI kit developed by the GIX team.</p>
 
+<div class="summary-grid">
+  <Card role="link" on:click={() => goto("/start")}>
+    <h2 class="title" slot="start">Getting Started</h2>
+
+    <p>
+      Installation, theming, etc. all information you need to integrate <code
+    >gix-components</code
+    > to your dapp.
+    </p>
+  </Card>
+
+  <Card role="link" on:click={() => goto("/components")}>
+    <h2 class="title" slot="start">Components</h2>
+
+    <p>
+      Browse all user interface components that can be used in your project.
+    </p>
+  </Card>
+
+  <Card role="link" on:click={() => goto("/utility-classes")}>
+    <h2 class="title" slot="start">Utility Classes</h2>
+
+    <p>
+      A collection of utility classes to make the content of your dapp shine.
+    </p>
+  </Card>
+
+  <Card role="link" on:click={() => goto("/styling")}>
+    <h2 class="title" slot="start">Styling</h2>
+
+    <p>Information and guidelines regarding global styling.</p>
+  </Card>
+
+  <Card role="link" on:click={() => goto("/icons")}>
+    <h2 class="title" slot="start">Icons</h2>
+
+    <p>
+      Draw attention to important information with any icons provided by the
+      design kit.
+    </p>
+  </Card>
+
+  <Card role="link" on:click={() => goto("/resources")}>
+    <h2 class="title" slot="start">Resources</h2>
+
+    <p>Useful resources and links.</p>
+  </Card>
+</div>
+
 <div class="card-grid">
   <Card role="link" on:click={() => goto("/start")}>
     <h2 class="title" slot="start">Getting Started</h2>

--- a/src/routes/styling/breakpoints/+page.md
+++ b/src/routes/styling/breakpoints/+page.md
@@ -2,13 +2,14 @@
 
 The layout is defined for following viewport's breakpoints:
 
-| Breakpoint | Value    | Description         |
-| ---------- | -------- | ------------------- |
-| `xsmall`   | `320px`  | Extra small devices |
-| `small`    | `576px`  | Small               |
-| `medium`   | `768px`  | Medium              |
-| `large`    | `1024px` | Large               |
-| `xlarge`   | `1300px` | Extra large         |
+| Breakpoint   | Value    | Description                      |
+|--------------|----------|----------------------------------|
+| `xsmall`     | `320px`  | Extra small devices              |
+| `small`      | `576px`  | Small                            |
+| `medium`     | `768px`  | Medium                           |
+| `large`      | `1024px` | Large                            |
+| `xlarge`     | `1300px` | Extra large                      |
+| `xlargemenu` | `1540px` | Extra large including menu width |
 
 ## Usage
 

--- a/src/routes/utility-classes/grids/+page.md
+++ b/src/routes/utility-classes/grids/+page.md
@@ -11,6 +11,7 @@ The grids are layout elements that can be used to present and spread the content
 
 - [Definition](#definition)
 - [Usage](#usage)
+- [Summary Grid](#summary-grid)
 - [Card Grid](#card-grid)
 - [Content Grid](#content-grid)
 
@@ -42,6 +43,61 @@ The grids follow a 12 columns-sizing approach. According the various [breakpoint
 <h2 id="usage">Usage</h2>
 
 Unlike components, the grids can be applied to any HTML elements through the use of utility classes - styles that are available globally.
+
+<h2 id="summary-grid">Summary Grid</h2>
+
+Commonly use to present summaries information, the global `.summary-grid` style distribute its children according the window size and menu width as well.
+
+```html
+<div class="summary-grid">
+  <Card>
+    <h2 class="title" slot="start">Title A.</h2>
+  </Card>
+
+  <Card>
+    <h2 class="title" slot="start">Title B.</h2>
+  </Card>
+</div>
+```
+
+### Showcase
+
+<div class="summary-grid">
+  <Card>
+    <h2 class="title" slot="start">Summary 1</h2>
+
+    <DocsLoremIpsum />
+
+  </Card>
+
+  <Card>
+    <h2 class="title" slot="start">Summary 2</h2>
+
+    <DocsLoremIpsum />
+
+  </Card>
+
+  <Card>
+    <h2 class="title" slot="start">Summary 3</h2>
+
+    <DocsLoremIpsum />
+
+  </Card>
+
+  <Card>
+    <h2 class="title" slot="start">Summary 4</h2>
+
+    <DocsLoremIpsum />
+
+  </Card>
+
+  <Card>
+    <h2 class="title" slot="start">Summary 5</h2>
+
+    <DocsLoremIpsum />
+
+  </Card>
+</div>
 
 <h2 id="card-grid">Card Grid</h2>
 


### PR DESCRIPTION
# Motivation

For the new design we need some sort of "summary grid".

Might not be exactly what's in the design but, it's a start.

# Changes

- new media breakpoints for xlarge that amend the menu width
- new `.summary-grid`

# Screenshots

Design:

<img width="849" alt="Capture d’écran 2022-11-17 à 17 14 35" src="https://user-images.githubusercontent.com/16886711/202499194-f73d94ef-d5ec-4e9b-a68e-e0faf94ba899.png">

![Enregistrement de l’écran 2022-11-17 à 17 07 58](https://user-images.githubusercontent.com/16886711/202499406-d40b222a-33f8-429d-a880-769ed4f00221.gif)

