### PR TITLE
style: badge color

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -70,7 +70,12 @@
   --scrollbar-thumb-color: var(--content-color);
 
   // Badge
-  --card-badge-background: linear-gradient(113.27deg, #24133C 0%, #291641 49.25%, #29103C 100%);
+  --card-badge-background: linear-gradient(
+    113.27deg,
+    #24133c 0%,
+    #291641 49.25%,
+    #29103c 100%
+  );
   --card-badge-color: var(--content-color);
 
   // Custom backgrounds

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -69,7 +69,7 @@
   --scrollbar-thumb-background: var(--content-background);
   --scrollbar-thumb-color: var(--content-color);
 
-  // Badge
+  // Card badge
   --card-badge-background: linear-gradient(
     113.27deg,
     #24133c 0%,

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -69,6 +69,10 @@
   --scrollbar-thumb-background: var(--content-background);
   --scrollbar-thumb-color: var(--content-color);
 
+  // Badge
+  --card-badge-background: linear-gradient(113.27deg, #24133C 0%, #291641 49.25%, #29103C 100%);
+  --card-badge-color: var(--content-color);
+
   // Custom backgrounds
   --body-background: linear-gradient(
       275.08deg,

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -37,6 +37,9 @@
     --scrollbar-thumb-background: transparent;
     --scrollbar-thumb-color: #9f9ba5;
 
+    // Badge
+    --card-badge-background: linear-gradient(113.27deg, #D5C7EB 0%, #EDDCEA 100%);
+
     // Custom backgrounds
     --body-background: linear-gradient(
         360deg,

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -38,7 +38,11 @@
     --scrollbar-thumb-color: #9f9ba5;
 
     // Badge
-    --card-badge-background: linear-gradient(113.27deg, #D5C7EB 0%, #EDDCEA 100%);
+    --card-badge-background: linear-gradient(
+      113.27deg,
+      #d5c7eb 0%,
+      #eddcea 100%
+    );
 
     // Custom backgrounds
     --body-background: linear-gradient(

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -37,7 +37,7 @@
     --scrollbar-thumb-background: transparent;
     --scrollbar-thumb-color: #9f9ba5;
 
-    // Badge
+    // Card badge
     --card-badge-background: linear-gradient(
       113.27deg,
       #d5c7eb 0%,


### PR DESCRIPTION
# Motivation

In new design badges have a custom linear gradient background.

<img width="622" alt="Capture d’écran 2022-11-18 à 11 42 39" src="https://user-images.githubusercontent.com/16886711/202685958-06ee77da-00c8-499f-8883-71aebcce6532.png">

