### PR TITLE
style: smaller dropdown and fix icon click

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -55,6 +55,7 @@
       appearance: none;
 
       font-size: inherit;
+      font-weight: inherit;
 
       &:focus {
         outline: none;

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -49,7 +49,7 @@
       background: transparent;
       border: none;
 
-      padding: var(--padding-2x);
+      padding: var(--padding) calc(5 * var(--padding)) var(--padding) var(--padding-2x);
 
       appearance: none;
 
@@ -70,6 +70,9 @@
       margin-right: var(--padding-1_5x);
 
       color: var(--disable-contrast);
+
+      position: absolute;
+      right: 0;
 
       // Size to match the line-height when font-size is 16px
       :global(svg) {

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -49,7 +49,8 @@
       background: transparent;
       border: none;
 
-      padding: var(--padding) calc(5 * var(--padding)) var(--padding) var(--padding-2x);
+      padding: var(--padding) calc(5 * var(--padding)) var(--padding)
+        var(--padding-2x);
 
       appearance: none;
 


### PR DESCRIPTION
# Motivation

Less padding in the dropdown to spare space and fix click on icon that had no effect anymore.

# Screenshots

<img width="1536" alt="Capture d’écran 2022-11-21 à 15 33 59" src="https://user-images.githubusercontent.com/16886711/203081742-d33a4ffd-6a4c-464f-8e19-d75870895492.png">
<img width="660" alt="Capture d’écran 2022-11-21 à 15 34 03" src="https://user-images.githubusercontent.com/16886711/203081754-a32e33d1-2d3f-4b85-836e-a1c17b06ed72.png">
<img width="660" alt="Capture d’écran 2022-11-21 à 15 34 07" src="https://user-images.githubusercontent.com/16886711/203081760-76a75c63-45fc-4402-9b10-02132aeddc3e.png">


<img width="1536" alt="Capture d’écran 2022-11-21 à 15 33 54" src="https://user-images.githubusercontent.com/16886711/203081709-e9d197bc-a7cb-4609-a48e-84502088eea0.png">
