### PR TITLE
feat: dropdown slot start

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -7,10 +7,24 @@
   export let name: string;
   export let testId: string | undefined = undefined;
   export let disabled = false;
+
+  let showStart: boolean;
+  $: showStart = $$slots.start !== undefined;
 </script>
 
-<div>
-  <select {disabled} bind:value={selectedValue} {name} data-tid={testId}>
+<div class="select">
+  {#if showStart}
+    <div class="start">
+      <slot name="start" />
+    </div>
+  {/if}
+  <select
+    {disabled}
+    bind:value={selectedValue}
+    {name}
+    data-tid={testId}
+    class:offset={showStart}
+  >
     <slot />
   </select>
   <span class="icon">
@@ -21,7 +35,7 @@
 <style lang="scss">
   @use "../styles/mixins/form";
 
-  div {
+  .select {
     @include form.input;
 
     position: relative;
@@ -50,7 +64,14 @@
       border: none;
 
       padding: var(--padding) calc(5 * var(--padding)) var(--padding)
-        var(--padding-2x);
+        var(--select-offset-inner-start, var(--padding-2x));
+
+      &.offset {
+        --select-offset-inner-start: var(
+          --select-offset-start,
+          calc(5 * var(--padding))
+        );
+      }
 
       appearance: none;
 
@@ -82,5 +103,12 @@
         height: 20px;
       }
     }
+  }
+
+  .start {
+    position: absolute;
+    left: 0;
+
+    pointer-events: none;
   }
 </style>

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -34,6 +34,7 @@
 
 <style lang="scss">
   @use "../styles/mixins/form";
+  @use "../styles/mixins/text";
 
   .select {
     @include form.input;
@@ -81,6 +82,8 @@
       &:focus {
         outline: none;
       }
+
+      @include text.truncate;
     }
 
     .icon {

--- a/src/routes/components/dropdown/+page.md
+++ b/src/routes/components/dropdown/+page.md
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Dropdown from "$lib/components/Dropdown.svelte";
     import DropdownItem from "$lib/components/DropdownItem.svelte";
+    import {IconUser} from "$lib/icons";
 </script>
 
 # Dropdown
@@ -24,12 +25,32 @@ Dropdown are form controls to select an option, or options, from a set of option
 | `disabled`      | HTML input `disabled` field.                                                                           | `boolean`               | `false`     |
 | `testId`        | Add a `data-tid` attribute to the DOM, useful for test purpose.                                        | `string` or `undefined` | `undefined` |
 
+## Slots
+
+| Slot name | Description                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| `start`   | An element that can be displayed over the `select` on its left side. e.g. useful to display icons. |
+
+If a slot `start` is provided but, its element is hided through CSS, the start padding can be adjusted with a CSS variable `--select-offset-start`.
+
 ## Showcase
 
-<Dropdown
-    name="demo"
+<div class="card-grid">
+    <Dropdown
+    name="demo1"
     >
 <DropdownItem value="1">Option 1</DropdownItem>
 <DropdownItem value="2">Option 2</DropdownItem>
 <DropdownItem value="3">Option 3</DropdownItem>
 </Dropdown>
+
+    <Dropdown
+    name="demo2"
+    >
+
+<div slot="start" style="padding: 0 0 0 var(--padding)"><IconUser /></div>
+<DropdownItem value="1">Option 1</DropdownItem>
+<DropdownItem value="2">Option 2</DropdownItem>
+<DropdownItem value="3">Option 3</DropdownItem>
+</Dropdown>
+</div>


### PR DESCRIPTION
# Motivation

Add a `slot=start` to the `<Dropdown />` component. It will be use in PR https://github.com/dfinity/nns-dapp/pull/1548 on small devices to display the project logo within the dropdown.

# Screenshots

<img width="1536" alt="Capture d’écran 2022-11-21 à 20 13 13" src="https://user-images.githubusercontent.com/16886711/203140115-1155138e-2a8d-404e-9f26-7c16ff96a2d6.png">
<img width="1536" alt="Capture d’écran 2022-11-21 à 20 13 16" src="https://user-images.githubusercontent.com/16886711/203140130-17486bf6-9570-4bf6-8060-21ec0fae1fde.png">

