### PR TITLE
style: better disable card color ratio

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -78,7 +78,7 @@
 
     &.disabled {
       background: var(--input-background);
-      color: rgba(var(--disable-contrast-rgb), 0.2);
+      color: rgba(var(--disable-contrast-rgb), 0.8);
 
       :global(*) {
         color: inherit;

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -172,7 +172,7 @@
     width: var(--input-width);
 
     &.disabled {
-      --disabled-color: rgba(var(--disable-contrast-rgb), 0.2);
+      --disabled-color: rgba(var(--disable-contrast-rgb), 0.8);
       color: var(--disabled-color);
 
       input {


### PR DESCRIPTION
# Motivation

As reported on [twitter](https://twitter.com/DfinityToday/status/1595439754396729344), the ratio when the card is disabled is not good enough.

![image](https://user-images.githubusercontent.com/16886711/203593288-8de3d5cc-0054-4492-a2da-220d9b1b3217.png)

