### PR TITLE
style: dropdown redo height and option

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -64,8 +64,12 @@
       background: transparent;
       border: none;
 
-      --select-padding-inner-top-bottom: var(--select-padding-top-bottom, var(--padding-2x));
-      padding: var(--select-padding-inner-top-bottom) calc(5 * var(--padding)) var(--select-padding-inner-top-bottom)
+      --select-padding-inner-top-bottom: var(
+        --select-padding-top-bottom,
+        var(--padding-2x)
+      );
+      padding: var(--select-padding-inner-top-bottom) calc(5 * var(--padding))
+        var(--select-padding-inner-top-bottom)
         var(--select-padding-inner-start, var(--padding-2x));
 
       &.offset {

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -64,12 +64,13 @@
       background: transparent;
       border: none;
 
-      padding: var(--padding) calc(5 * var(--padding)) var(--padding)
-        var(--select-offset-inner-start, var(--padding-2x));
+      --select-padding-inner-top-bottom: var(--select-padding-top-bottom, var(--padding-2x));
+      padding: var(--select-padding-inner-top-bottom) calc(5 * var(--padding)) var(--select-padding-inner-top-bottom)
+        var(--select-padding-inner-start, var(--padding-2x));
 
       &.offset {
-        --select-offset-inner-start: var(
-          --select-offset-start,
+        --select-padding-inner-start: var(
+          --select-padding-start,
           calc(5 * var(--padding))
         );
       }

--- a/src/routes/components/dropdown/+page.md
+++ b/src/routes/components/dropdown/+page.md
@@ -31,7 +31,7 @@ Dropdown are form controls to select an option, or options, from a set of option
 | --------- | -------------------------------------------------------------------------------------------------- |
 | `start`   | An element that can be displayed over the `select` on its left side. e.g. useful to display icons. |
 
-If a slot `start` is provided but, its element is hided through CSS, the start padding can be adjusted with a CSS variable `--select-offset-start`.
+If a slot `start` is provided but, its element is hided through CSS, the start padding can be adjusted with a CSS variable `--select-padding-start`.
 
 ## Showcase
 


### PR DESCRIPTION
# Motivation

Small dropdown fits well "project" selector but, do not fits well when used in modal.

# Changes

- redo previous padding and make top/bottom stylable

# Screenshots

<img width="1536" alt="Capture d’écran 2022-11-23 à 18 46 41" src="https://user-images.githubusercontent.com/16886711/203614590-e4153891-f5cb-4410-a13c-1ff1f521219e.png">

