### PR TITLE
fix: InfiniteScroll disabled because beforeUpdate is called twice when bindings are used

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -16,7 +16,7 @@
     threshold: 0,
   };
 
-  let container: HTMLUListElement;
+  let container: HTMLUListElement | undefined;
 
   const dispatch = createEventDispatcher();
 
@@ -43,14 +43,26 @@
     options
   );
 
+  // Svelte workaround: beforeUpdate is called twice when bindings are used -> https://github.com/sveltejs/svelte/issues/6016
+  let skipContainerNextUpdate = false;
+
   // We disconnect previous observer before any update. We do want to trigger an intersection in case of layout shifting.
-  beforeUpdate(() => observer.disconnect());
+  beforeUpdate(() => {
+    if (!skipContainerNextUpdate) {
+      observer.disconnect();
+    }
+
+    skipContainerNextUpdate = container === undefined;
+  });
 
   afterUpdate(() => {
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
     // If not children, no element to observe
-    if (container.lastElementChild === null) {
+    if (
+      container?.lastElementChild === null ||
+      container?.lastElementChild === undefined
+    ) {
       return;
     }
 


### PR DESCRIPTION
# Motivation

We disable the `<InfiniteScroll />` component `beforeUpdate` because we do want to trigger an intersection in case of layout shifting - i.e. we do not want to trigger additional unexpected query and update calls in the proposal list views.

We noticed that under certain circumstances, notably when initialized while enabling at the same time, a race condition can lead to the scroller being disabled.

Root cause of the problem is a Svelte issue [#6016](https://github.com/sveltejs/svelte/issues/6016). Indeed, when bindings are used (`bind:this=my_HTML_element`) within the compoment, the `beforeUpdate` lifecycle is called twice while `afterUpdate` is called only once. Therefore, as we disable the scroll in the first method and enable in the second, the scroller remains disabled.

# Reproduction

See PR #141 [comment](https://github.com/dfinity/gix-components/pull/141#issuecomment-1366697208).

# Changes

- implement a workaround to ignore second `beforeUpdate` call trigger by binding initialization
