### PR TITLE
style: header border spacing as in design

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -21,3 +21,15 @@
     <slot name="toolbar-end" slot="end" />
   </Toolbar>
 </header>
+
+<style lang="scss">
+  @use "../styles/mixins/media";
+
+  header {
+    --toolbar-padding: 0 var(--padding-2x);
+
+    @include media.min-width(xlarge) {
+      --toolbar-padding: 0;
+    }
+  }
+</style>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -36,6 +36,8 @@
     :global(.tooltip-wrapper) {
       pointer-events: all;
     }
+
+    padding: var(--toolbar-padding);
   }
 
   .main {


### PR DESCRIPTION
# Motivation

Give some spacing for the header borders on mobile devices as in design.

# Screenshots

<img width="660" alt="Capture d’écran 2023-01-10 à 10 28 57" src="https://user-images.githubusercontent.com/16886711/211513947-87cea17b-12d8-4919-b60d-d4a88456f107.png">

