### PR TITLE
style: fix split content width

### DIFF
--- a/src/lib/components/SplitContent.svelte
+++ b/src/lib/components/SplitContent.svelte
@@ -70,7 +70,7 @@
 
     @include media.min-width(large) {
       display: block;
-      min-width: var(--content-start-width);
+      width: var(--content-start-width);
     }
   }
 

--- a/src/lib/styles/global/variables.scss
+++ b/src/lib/styles/global/variables.scss
@@ -4,7 +4,7 @@
   --header-height: 40px;
   --menu-width: 240px;
   --max-main-content-width: calc(1600px + (2 * var(--padding-4x)));
-  --content-start-width: 260px;
+  --content-start-width: 280px;
   --content-start-height: calc(140px + var(--padding-2x));
 
   --icon-width: 24px;


### PR DESCRIPTION
# Motivation

Fix width and adjust a bit wider.

# Screenshots

Bad:

<img width="1536" alt="Capture d’écran 2023-01-10 à 19 59 43" src="https://user-images.githubusercontent.com/16886711/211638405-108cfd83-e74d-4b2d-bb61-7787ad4ccd13.png">

Better:

<img width="1536" alt="Capture d’écran 2023-01-10 à 19 59 17" src="https://user-images.githubusercontent.com/16886711/211638435-fc5abeca-3c38-4cad-a56d-373ef3d45e19.png">

