### PR TITLE
fix: auto import incomplete path

### DIFF
--- a/src/lib/components/StretchPane.svelte
+++ b/src/lib/components/StretchPane.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { layoutMenuOpen } from "../stores/layout.store";
-  import { BREAKPOINT_LARGE } from "$lib";
+  import { BREAKPOINT_LARGE } from "$lib/constants/constants";
 
   let innerWidth = 0;
 

--- a/src/tests/lib/components/HeaderTitle.spec.ts
+++ b/src/tests/lib/components/HeaderTitle.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { HeaderTitle } from "$lib";
+import HeaderTitle from "$lib/components/HeaderTitle.svelte";
 import { render } from "@testing-library/svelte";
 import ComponentTest from "./ComponentTest.svelte";
 


### PR DESCRIPTION
# Motivation

Auto-imported path are incomplete which makes the lib hard to use locally in NNS-dapp.
