### PR TITLE
build: make qr-creator available only in the browser

### DIFF
--- a/src/lib/types/qr-creator.ts
+++ b/src/lib/types/qr-creator.ts
@@ -1,0 +1,6 @@
+import type QrCreator from "qr-creator";
+
+export type QrCreatorConfig = QrCreator.Config;
+export type QrCreateClass = {
+  render: (config: QrCreatorConfig, $element: HTMLElement) => void;
+};


### PR DESCRIPTION
# Motivation

The library leads to issues (es modules import error, segmentation fault, blocking tests etc.) in jest tests of NNS-dapp when use explicitly or imported implicitly.
Therefore, the simplest way to avoid these problems is to skip it globally in jest tests.
It remains tested in e2e tests.

P.S.: Mocking it would probably be possible but that way no one using the library as to care about this issue.

This PR solves both `npm run test` and `npm run build` of NNS-dapp.

# Changes

- lazy load the `qr-creator` library for the browser only
