### PR TITLE
fix: collapsible calculated height on Firefox

### DIFF
--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -17,7 +17,7 @@
   const dispatch = createEventDispatcher();
 
   export let expanded = initiallyExpanded;
-  let offsetHeight: number | undefined;
+  let container: HTMLDivElement | undefined;
   let userUpdated = false;
   let maxHeight: number | undefined;
 
@@ -31,7 +31,8 @@
 
   const calculateMaxContentHeight = (): number => {
     if (maxContentHeight !== undefined) return maxContentHeight;
-    const height = offsetHeight === undefined ? 0 : offsetHeight;
+    const height =
+      container?.getBoundingClientRect().height ?? container?.offsetHeight ?? 0;
     return height < CONTENT_MIN_HEIGHT ? CONTENT_MIN_HEIGHT : height;
   };
   const maxHeightStyle = (height: number | undefined): string =>
@@ -93,7 +94,7 @@
     aria-labelledby={id !== undefined ? `heading${id}` : undefined}
     class="content"
     class:wrapHeight
-    bind:offsetHeight
+    bind:this={container}
   >
     <slot />
   </div>


### PR DESCRIPTION
# Motivation

A user noticed and reported on the [forum](https://forum.dfinity.org/t/modify-nns-front-code/18560) an issue with the `Collapsible` component which did not computed the expandable height correctly. I was able to reproduce it in Firefox only.

# Changes

- fix height computation of the `Collapsible` element by using primarly the `getBoundingClientRect` API which according test seems more accurate on Firefox and compatible with Chrome, Safari and iOS

# Screenshots

Bug

![bug](https://user-images.githubusercontent.com/16886711/219857326-910339ab-a1e6-41dd-9cc4-eb73be58c829.gif)

Fix

![fix](https://user-images.githubusercontent.com/16886711/219857333-cafd87ca-387e-49b5-8479-119110ca8e05.gif)
