### PR TITLE
feat: hide close button if modal disabled

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -43,12 +43,13 @@
       {#if showHeader}
         <div class="header">
           <h2 id="modalTitle"><slot name="title" /></h2>
-          <button
-            data-tid="close-modal"
-            on:click|stopPropagation={close}
-            aria-label={$i18n.core.close}
-            disabled={disablePointerEvents}><IconClose size="24px" /></button
-          >
+          {#if !disablePointerEvents}
+            <button
+              data-tid="close-modal"
+              on:click|stopPropagation={close}
+              aria-label={$i18n.core.close}><IconClose size="24px" /></button
+            >
+          {/if}
         </div>
       {/if}
 

--- a/src/tests/lib/components/Modal.spec.ts
+++ b/src/tests/lib/components/Modal.spec.ts
@@ -129,8 +129,6 @@ describe("Modal", () => {
       },
     });
 
-    const button: HTMLElement = getByTestId("close-modal") as HTMLElement;
-
-    expect(button).toBeDisabled();
+    expect(() => getByTestId("close-modal")).toThrow();
   });
 });


### PR DESCRIPTION
# Motivation

As requested, hide "Close" button if modal has disabled events (instead of disabling the button).
