### PR TITLE
feat: add an option to clean selected toasts

### DIFF
--- a/src/lib/stores/toasts.store.ts
+++ b/src/lib/stores/toasts.store.ts
@@ -1,4 +1,4 @@
-import type { ToastMsg } from "$lib/types/toast";
+import type { ToastLevel, ToastMsg } from "$lib/types/toast";
 import { writable, type Readable } from "svelte/store";
 
 export interface ToastsStore extends Readable<ToastMsg[]> {
@@ -8,7 +8,7 @@ export interface ToastsStore extends Readable<ToastMsg[]> {
     id: symbol;
     content: Partial<Omit<ToastMsg, "id">>;
   }) => void;
-  reset: () => void;
+  reset: (levels?: ToastLevel[]) => void;
 }
 
 /**
@@ -17,7 +17,7 @@ export interface ToastsStore extends Readable<ToastMsg[]> {
  * - show: display a message in toast component
  * - hide: remove the toast message with that timestamp or the first one.
  * - update: update the existed toast content.
- * - reset: empty all toasts
+ * - reset: empty all toasts or optionally only those that match particular levels
  */
 const initToastsStore = (): ToastsStore => {
   const { subscribe, update, set } = writable<ToastMsg[]>([]);
@@ -65,7 +65,14 @@ const initToastsStore = (): ToastsStore => {
       );
     },
 
-    reset() {
+    reset(levels?: ToastLevel[]) {
+      if (levels !== undefined && levels.length > 0) {
+        update((messages: ToastMsg[]) =>
+          messages.filter(({ level }) => !levels.includes(level))
+        );
+        return;
+      }
+
       set([]);
     },
   };

--- a/src/tests/lib/stores/toasts.store.spec.ts
+++ b/src/tests/lib/stores/toasts.store.spec.ts
@@ -1,0 +1,42 @@
+import { get } from "svelte/store";
+import { toastsStore } from "../../../lib";
+
+describe("toasts-store", () => {
+  it("should reset selected toast", () => {
+    toastsStore.show({
+      level: "success",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "success",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "warn",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "warn",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "error",
+      text: "test",
+    });
+
+    toastsStore.show({
+      level: "info",
+      text: "test",
+    });
+
+    toastsStore.reset(["error", "warn"]);
+
+    const msgs = get(toastsStore);
+
+    expect(msgs.length).toEqual(3);
+  });
+});


### PR DESCRIPTION
# Motivation

We will use this option to clean selected toast after sign-in in NNS-dapp (insted of reset() and workaround).
