### PR TITLE
feat: apply exponentToPlain for initial icp values

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -35,7 +35,7 @@
 
   // replace exponent format (1e-4) w/ plain (0.0001)
   const exponentToPlainNumberString = (value: string): string =>
-    typeof value === "string" && value.includes("e")
+    value.includes("e")
       ? Number(value).toLocaleString("en", {
           useGrouping: false,
           maximumFractionDigits: 8,

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -35,6 +35,7 @@
 
   // replace exponent format (1e-4) w/ plain (0.0001)
   const exponentToPlainNumberString = (value: string): string =>
+    // number to toLocaleString doesn't support decimals for values >= ~1e16
     value.includes("e")
       ? Number(value).toLocaleString("en", {
           useGrouping: false,

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -33,11 +33,21 @@
   let selectionStart: number | null = 0;
   let selectionEnd: number | null = 0;
 
+  // replace exponent format (1e-4) w/ plain (0.0001)
+  const exponentToPlainNumberString = (value: string): string =>
+    typeof value === "string" && value.includes("e")
+      ? Number(value).toLocaleString("en", {
+          useGrouping: false,
+          maximumFractionDigits: 8,
+        })
+      : value;
   // To show undefined as "" (because of the type="text")
   const fixUndefinedValue = (value: string | number | undefined): string =>
     value === undefined ? "" : `${value}`;
 
-  let icpValue: string = fixUndefinedValue(value);
+  let icpValue: string = exponentToPlainNumberString(
+    fixUndefinedValue(value)
+  ) as string;
   let lastValidICPValue: string | number | undefined = value;
   let internalValueChange = true;
 

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -46,9 +46,7 @@
   const fixUndefinedValue = (value: string | number | undefined): string =>
     value === undefined ? "" : `${value}`;
 
-  let icpValue: string = exponentToPlainNumberString(
-    fixUndefinedValue(value)
-  ) as string;
+  let icpValue: string = exponentToPlainNumberString(fixUndefinedValue(value));
   let lastValidICPValue: string | number | undefined = value;
   let internalValueChange = true;
 

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -376,24 +376,23 @@ describe("Input", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
-          value: ".00000001",
+          value: 0.00000001,
           inputType: "icp",
         },
       });
-      expect(container.querySelector("input")?.value).toBe(".00000001");
+
+      expect(container.querySelector("input")?.value).toBe("0.00000001");
     });
 
     it("should avoid exponent formatted initial value in icp mode", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
-          value: "999999999.999999999",
+          value: 11111111.11111111,
           inputType: "icp",
         },
       });
-      expect(container.querySelector("input")?.value).toBe(
-        "999999999.999999999"
-      );
+      expect(container.querySelector("input")?.value).toBe("11111111.11111111");
     });
   });
 });

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -371,5 +371,29 @@ describe("Input", () => {
         done();
       });
     });
+
+    it("should avoid exponent formatted initial value in icp mode", () => {
+      const { container } = render(InputValueTest, {
+        props: {
+          ...props,
+          value: ".00000001",
+          inputType: "icp",
+        },
+      });
+      expect(container.querySelector("input")?.value).toBe(".00000001");
+    });
+
+    it("should avoid exponent formatted initial value in icp mode", () => {
+      const { container } = render(InputValueTest, {
+        props: {
+          ...props,
+          value: "999999999.999999999",
+          inputType: "icp",
+        },
+      });
+      expect(container.querySelector("input")?.value).toBe(
+        "999999999.999999999"
+      );
+    });
   });
 });

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -372,7 +372,19 @@ describe("Input", () => {
       });
     });
 
-    it("should avoid exponent formatted initial value in icp mode", () => {
+    it("should avoid exponent formatted initial zero in icp mode", () => {
+      const { container } = render(InputValueTest, {
+        props: {
+          ...props,
+          value: 0,
+          inputType: "icp",
+        },
+      });
+
+      expect(container.querySelector("input")?.value).toBe("0");
+    });
+
+    it("should avoid exponent formatted initial value (<0) in icp mode", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
@@ -380,11 +392,10 @@ describe("Input", () => {
           inputType: "icp",
         },
       });
-
       expect(container.querySelector("input")?.value).toBe("0.00000001");
     });
 
-    it("should avoid exponent formatted initial value in icp mode", () => {
+    it("should avoid exponent formatted initial value (>0) in icp mode", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,


### PR DESCRIPTION
# Motivation

Avoid displaying initial icp amount in exponential form.
https://dfinity.atlassian.net/browse/GIX-1373

# Changes

- apply exponentToPlainNumberString to initial icp value
- tests to cover this issue

# Screenshots

before
![Screen Recording 2023-03-03 at 17 12 41](https://user-images.githubusercontent.com/98811342/222771607-b23064d9-a15f-4e78-8796-381f83a80f78.gif)

after
![Screen Recording 2023-03-03 at 17 06 26](https://user-images.githubusercontent.com/98811342/222771784-a1c1a415-611e-4005-8f1b-0a4b9ea458f8.gif)


