### PR TITLE
feat: trim QR code reader result

### DIFF
--- a/src/lib/workers/qrcode.worker.ts
+++ b/src/lib/workers/qrcode.worker.ts
@@ -43,14 +43,14 @@ const decodeQRCode = ({
     inversionAttempts: "dontInvert",
   });
 
-  if (result === undefined || result == null || result.data === "") {
+  if (result === undefined || result == null || result.data.trim() === "") {
     return;
   }
 
   postMessage({
     msg: "nnsQRCodeValue",
     data: {
-      qrCode: result.data,
+      qrCode: result.data.trim(),
     },
   });
 };


### PR DESCRIPTION
# Motivation

This morning I noticed some leading spaces in a QR code I scanned. Probably worth trimming the result so that user will not have to edit the input field afterwards to remove such empty characters.
