### PR TITLE
style: copy button round in flex

### DIFF
--- a/src/lib/components/Copy.svelte
+++ b/src/lib/components/Copy.svelte
@@ -20,6 +20,7 @@
   button {
     height: var(--padding-4x);
     width: var(--padding-4x);
+    min-width: var(--padding-4x);
 
     &.icon-only {
       color: var(--tertiary);


### PR DESCRIPTION
# Motivation

Preserve "Copy" button rounded nature even when use in flex container.

# Screenshots

Is:

<img width="1536" alt="Capture d’écran 2023-03-21 à 09 59 17" src="https://user-images.githubusercontent.com/16886711/226559179-973f08ca-53ad-42f1-b144-81627fce69b6.png">

Afterwards:
<img width="1536" alt="Capture d’écran 2023-03-21 à 09 59 27" src="https://user-images.githubusercontent.com/16886711/226559308-3cf66717-e4bf-47de-8608-0fd5eccd920f.png">


