### PR TITLE
Pass testId from WizardModal to Modal

### DIFF
--- a/src/lib/components/WizardModal.svelte
+++ b/src/lib/components/WizardModal.svelte
@@ -6,6 +6,7 @@
 
   export let steps: WizardSteps;
   export let disablePointerEvents = false;
+  export let testId: string | undefined = undefined;
 
   let stepState: WizardStepsState;
   $: stepState = new WizardStepsState(steps);
@@ -26,6 +27,7 @@
 <Modal
   on:nnsClose
   on:introend={() => (presented = true)}
+  {testId}
   {disablePointerEvents}
 >
   <slot name="title" slot="title" />

--- a/src/tests/lib/components/Modal.spec.ts
+++ b/src/tests/lib/components/Modal.spec.ts
@@ -107,6 +107,33 @@ describe("Modal", () => {
     backdrop && fireEvent.click(backdrop);
   });
 
+  it("should not have a data-tid attribute", () => {
+    const { container } = render(Modal, {
+      props: {
+        ...props,
+      },
+    });
+
+    const modal = container.querySelector("div.modal");
+    expect(modal?.getAttribute("data-tid")).toBeNull();
+  });
+
+  it("should have a single root with data-tid attribute", () => {
+    const testId = "my-test-id";
+    const { container } = render(Modal, {
+      props: {
+        ...props,
+        testId,
+      },
+    });
+
+    // Make sure the data-tid encloses everything in the component.
+    expect(container.firstElementChild?.children.length).toBe(1);
+    const modal = container.firstElementChild?.firstElementChild;
+    expect(modal?.classList).toContain("modal");
+    expect(modal?.getAttribute("data-tid")).toBe(testId);
+  });
+
   it("should trigger close modal on click on close button", (done) => {
     const { getByTestId, component } = render(ModalTest, {
       props,

--- a/src/tests/lib/components/WizardModal.spec.ts
+++ b/src/tests/lib/components/WizardModal.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import WizardModal from "$lib/components/WizardModal.svelte";
+import type { WizardStep } from "$lib/types/wizard";
+import { render } from "@testing-library/svelte";
+
+describe("WizardModal", () => {
+  const steps: WizardStep[] = [
+    {
+      title: "Step 1",
+      name: "step1",
+    },
+  ];
+
+  const props: { steps: WizardStep[] } = { steps };
+
+  it("should not have a data-tid attribute", () => {
+    const { container } = render(WizardModal, {
+      props: {
+        ...props,
+      },
+    });
+
+    const modal = container.querySelector("div.modal");
+    expect(modal?.getAttribute("data-tid")).toBeNull();
+  });
+
+  it("should have a single root with data-tid attribute", () => {
+    const testId = "my-test-id";
+    const { container } = render(WizardModal, {
+      props: {
+        ...props,
+        testId,
+      },
+    });
+
+    // Make sure the data-tid encloses everything in the component.
+    expect(container.firstElementChild?.children.length).toBe(1);
+    const modal = container.firstElementChild?.firstElementChild;
+    expect(modal?.classList).toContain("modal");
+    expect(modal?.getAttribute("data-tid")).toBe(testId);
+  });
+});


### PR DESCRIPTION
# Motivation

Currently, getting the root element of a WizardModal component by test ID requires adding an additional wrapping `div` to put the `data-tid` attribute on.
Since WizardModal already has a single root component, being able to set a test ID on that would remove the requirement of the extra div.

# Changes

1. Pass testId from WizardModal to Modal
2. Add data-tid test to Modal
3. Add data-tid test to WizardModal

# Screenshots

no visible changes

# Tests

Unit tests for Modal and WizardModal