### PR TITLE
fix: menu background loading glitch

### DIFF
--- a/src/lib/components/MenuBackground.svelte
+++ b/src/lib/components/MenuBackground.svelte
@@ -35,7 +35,8 @@
       loading="lazy"
     />
 
-    <img data-tid="menu-background"
+    <img
+      data-tid="menu-background"
       class="background"
       src={background}
       role="presentation"

--- a/src/lib/components/MenuBackground.svelte
+++ b/src/lib/components/MenuBackground.svelte
@@ -35,7 +35,7 @@
       loading="lazy"
     />
 
-    <img
+    <img data-tid="menu-background"
       class="background"
       src={background}
       role="presentation"

--- a/src/lib/components/MenuBackground.svelte
+++ b/src/lib/components/MenuBackground.svelte
@@ -26,21 +26,23 @@
     loading="lazy"
   />
 
-  <img
-    class="on-chain"
-    src={logoOnChain}
-    role="presentation"
-    alt="100% on-chain Internet Computer logo"
-    loading="lazy"
-  />
+  {#if $themeStore !== undefined}
+    <img
+      class="on-chain"
+      src={logoOnChain}
+      role="presentation"
+      alt="100% on-chain Internet Computer logo"
+      loading="lazy"
+    />
 
-  <img
-    class="background"
-    src={background}
-    role="presentation"
-    alt=""
-    loading="lazy"
-  />
+    <img
+      class="background"
+      src={background}
+      role="presentation"
+      alt=""
+      loading="lazy"
+    />
+  {/if}
 </div>
 
 <style lang="scss">

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -10,7 +10,7 @@
     themeStore.select(detail ? Theme.DARK : Theme.LIGHT);
 
   let checked: boolean;
-  $: checked = $themeStore === Theme.DARK;
+  $: checked = $themeStore !== Theme.LIGHT;
 </script>
 
 <div class="theme-toggle" data-tid="theme-toggle">

--- a/src/lib/stores/theme.store.ts
+++ b/src/lib/stores/theme.store.ts
@@ -2,10 +2,10 @@ import type { Theme } from "$lib/types/theme";
 import { applyTheme, initTheme } from "$lib/utils/theme.utils";
 import { writable } from "svelte/store";
 
-const initialTheme: Theme = initTheme();
+const initialTheme: Theme | undefined = initTheme();
 
 export const initThemeStore = () => {
-  const { subscribe, set } = writable<Theme>(initialTheme);
+  const { subscribe, set } = writable<Theme | undefined>(initialTheme);
 
   return {
     subscribe,

--- a/src/lib/utils/theme.utils.ts
+++ b/src/lib/utils/theme.utils.ts
@@ -5,10 +5,10 @@ import { enumFromStringExists } from "./enum.utils";
 export const THEME_ATTRIBUTE = "theme";
 export const LOCALSTORAGE_THEME_KEY = "nnsTheme";
 
-export const initTheme = (): Theme => {
-  // Jest NodeJS environment has no document
+export const initTheme = (): Theme | undefined => {
+  // No DOM therefore cannot guess the theme
   if (isNode()) {
-    return Theme.DARK;
+    return undefined;
   }
 
   const theme: string | null =

--- a/src/tests/lib/components/MenuBackground.spec.ts
+++ b/src/tests/lib/components/MenuBackground.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import MenuBackground from "$lib/components/MenuBackground.svelte";
+import { themeStore } from "$lib/stores/theme.store";
+import { Theme } from "$lib/types/theme";
+import { render } from "@testing-library/svelte";
+
+describe("MenuBackground", () => {
+  it("should not render background image", () => {
+    const { getByTestId } = render(MenuBackground);
+    expect(() => getByTestId("menu-background")).toThrow();
+  });
+
+  it("should render background image when theme is set", () => {
+    themeStore.select(Theme.DARK);
+
+    const { getByTestId } = render(MenuBackground);
+    expect(getByTestId("menu-background")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# Motivation

Despite loaded in root, the actual default value of the theme store is undefined.

- when built where no DOM exists, therefore cannot guess the theme
- when loaded in the browser, because of the chunking, might be loaded after other resources have already been loaded and displayed

This is what lead the menu background to be displayed in dark mode over a light theme.

# Changes

- set `undefined` as default theme store value
- do not display menu background if theme is not set

# Note

I tried to add a `transition:fade` to makes the images appearing smooth but it had no effect.

# Screenshots

Issue:

![issue](https://user-images.githubusercontent.com/16886711/229421022-4aa88299-c1b4-44bf-bbc6-80fc87b1d2c7.gif)

Solve:

![solve](https://user-images.githubusercontent.com/16886711/229421059-6d45b2dd-59a7-4edb-b6b4-9cd07fee3190.gif)

