### PR TITLE
style: add a CSS variable to justify key value pair

### DIFF
--- a/src/lib/components/KeyValuePair.svelte
+++ b/src/lib/components/KeyValuePair.svelte
@@ -16,7 +16,7 @@
 <style lang="scss">
   dl {
     display: flex;
-    justify-content: space-between;
+    justify-content: var(--key-value-pair-justify-content, space-between);
     align-items: baseline;
     gap: var(--padding-2x);
 


### PR DESCRIPTION
# Motivation

Was requested to center a key value pair for ckBTC.

# Changes

- add `--key-value-pair-justify-content` CSS variable

# Screenshots

<img width="1536" alt="Capture d’écran 2023-04-06 à 11 57 18" src="https://user-images.githubusercontent.com/16886711/230344159-5d1cec7c-574b-4d17-8042-d75f8c3cdfca.png">

