### PR TITLE
fix: incorrect undefined-description data-tid

### DIFF
--- a/src/lib/components/KeyValuePairInfo.svelte
+++ b/src/lib/components/KeyValuePairInfo.svelte
@@ -20,7 +20,10 @@
     <svelte:fragment slot="value"><slot name="value" /></svelte:fragment>
   </KeyValuePair>
 
-  <p class="description" data-tid={`${testId}-description`}>
+  <p
+    class="description"
+    data-tid={testId !== undefined ? `${testId}-description` : undefined}
+  >
     <slot name="info" />
   </p>
 </Collapsible>


### PR DESCRIPTION
# Motivation

No `data-tid` should be appended to the DOM if the related `testId` is `undefined.

Currently, the `KeyValuePairInfo` renders `data-tid="undefined-description"`.

