### PR TITLE
style: modal form gap narrower

### DIFF
--- a/src/lib/styles/global/modal.scss
+++ b/src/lib/styles/global/modal.scss
@@ -10,7 +10,7 @@ div.modal {
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
-    gap: var(--padding-3x);
+    gap: var(--padding-2x);
   }
 
   .toolbar {


### PR DESCRIPTION
# Motivation

The modal being narrower on desktop and given the fact that we have to display more information in the transactions modal, setting a smaller gap between lines of `form` within modal fits better the display.
