### PR TITLE
fix: wizard modal glitch

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { fade, scale } from "svelte/transition";
-  import { quintOut } from "svelte/easing";
+  import { fade } from "svelte/transition";
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import IconClose from "$lib/icons/IconClose.svelte";
@@ -22,22 +21,27 @@
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");
+
+  // A bit faster fade in that backdrop IN, a bit slower on OUT
+  const FADE_IN_DURATION = 125 as const;
+  const FADE_OUT_DURATION = 200 as const;
 </script>
 
 {#if visible}
   <div
     class="modal"
-    transition:fade={{ duration: 125 }}
+    transition:fade={{ duration: 25 }}
+    on:introend
     {role}
     data-tid={testId}
     aria-labelledby={showHeader ? "modalTitle" : undefined}
     aria-describedby="modalContent"
     on:click|stopPropagation
-    on:introend
   >
     <Backdrop {disablePointerEvents} on:nnsClose />
     <div
-      transition:scale={{ delay: 25, duration: 150, easing: quintOut }}
+      in:fade={{ duration: FADE_IN_DURATION }}
+      out:fade={{ duration: FADE_OUT_DURATION }}
       class={`wrapper ${role}`}
     >
       {#if showHeader}


### PR DESCRIPTION
# Motivation

The wizard modal opening is glitchy on desktop which really annoys me.

# The problem

The wizard modal is glitchy because we noticed issue last year which we solved by wrapping the transition component within a `if` that became `true` only once the modal intro animation was done. This is the major root cause of the issue. Because the transition is not displayed, the slot it contains is not displayed and per extension the content is not displayed, therefore the height is not correct.

In addition to be glitchy, this is also an issue for the browser as if such guard is removed without further code, it can lead the browser to become irresponsive as the component transition ends in an infinite loop (⚠️ 🚨).

After opening and closing the modal a zillion times this afternoon I came to the conclusion that the root cause of the issue is the `onDestroy` side effect of the `WizardModal` that is sometimes not called when the modal is used in NNS-dapp.

This problem looks like the Svelte issue 👉 https://github.com/sveltejs/svelte/issues/5268

To overcome the issue, I observed the `nnsClose` event of the modal and force not rendering its content when this happens which has for effect to destroy the transition ✅.

See screenshots for demos.

# Changes

- in `WizardModal`, on `nnsClose`, set a flag to `false` to destroy / not render its content instead of waiting for `introEnd`
- remove the `scale` and replace with a `fade` effect

# Screenshots

Current glitch:

![git-glitch-1](https://user-images.githubusercontent.com/16886711/232515055-e0721185-ed3c-4a48-a5fe-fa0ece4a41b8.gif)

Current glitch slowed down:

![gif-glitch-2](https://user-images.githubusercontent.com/16886711/232515251-6d3c1d34-daa9-4ddf-bf09-dff00ad5786a.gif)

New animation effect without glitch:

![git-new-animation](https://user-images.githubusercontent.com/16886711/232515332-96b57e3c-3b51-459e-8110-9b00a12a587f.gif)

Issue and infinite loop problem if only `introEnd` is removed:

![gif-infinite-loop](https://user-images.githubusercontent.com/16886711/232515441-4b57dbb3-b657-49fd-8b93-214b0804fc90.gif)

No issue if `nnsClose` is used to force deletion of content (no infinite loop happening after a while):

![gif-loop-fix-3](https://user-images.githubusercontent.com/16886711/232517773-83dc9cef-c97f-42c2-83d0-bca8a2a05d02.gif)

