### PR TITLE
Feat: TestId changes in Collapsible and KeyValuePairInfo

### DIFF
--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -2,11 +2,12 @@
   import { afterUpdate, createEventDispatcher } from "svelte";
   import IconExpandMore from "$lib/icons/IconExpandMore.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import TestIdWrapper from "./TestIdWrapper.svelte";
 
   export let id: string | undefined = undefined;
   export let initiallyExpanded = false;
   export let maxContentHeight: number | undefined = undefined;
-  export let testId: string = "collapsible-header";
+  export let testId: string | undefined = undefined;
 
   export let iconSize: "small" | "medium" = "small";
   export let expandButton = true;
@@ -59,51 +60,57 @@
   afterUpdate(updateMaxHeight);
 </script>
 
-<div
-  data-tid={testId}
-  id={id !== undefined ? `heading${id}` : undefined}
-  role="term"
-  class={`header ${externalToggle ? "external" : ""}`}
-  on:click={() => (externalToggle ? undefined : toggleContent())}
->
-  <div class="header-content">
-    <slot name="header" />
-  </div>
-  {#if expandButton}
-    <button
-      class="collapsible-expand-icon"
-      class:size-medium={iconSize === "medium"}
-      class:expanded
-      data-tid="collapsible-expand-button"
-      aria-expanded={expanded}
-      aria-controls={id}
-      title={expanded ? $i18n.core.collapse : $i18n.core.expand}
-    >
-      <IconExpandMore />
-    </button>
-  {/if}
-</div>
-<div
-  data-tid="collapsible-content"
-  role="definition"
-  class="wrapper"
-  class:expanded
-  style={`${maxHeightStyle(maxHeight)}${overflyYStyle(maxHeight)}`}
->
+<TestIdWrapper {testId}>
   <div
-    {id}
-    aria-labelledby={id !== undefined ? `heading${id}` : undefined}
-    class="content"
-    class:wrapHeight
-    bind:this={container}
+    data-tid="collapsible-header"
+    id={id !== undefined ? `heading${id}` : undefined}
+    role="term"
+    class={`header ${externalToggle ? "external" : ""}`}
+    on:click={() => (externalToggle ? undefined : toggleContent())}
   >
-    <slot />
+    <div class="header-content">
+      <slot name="header" />
+    </div>
+    {#if expandButton}
+      <button
+        class="collapsible-expand-icon"
+        class:size-medium={iconSize === "medium"}
+        class:expanded
+        data-tid="collapsible-expand-button"
+        aria-expanded={expanded}
+        aria-controls={id}
+        title={expanded ? $i18n.core.collapse : $i18n.core.expand}
+      >
+        <IconExpandMore />
+      </button>
+    {/if}
   </div>
-</div>
+  <div
+    data-tid="collapsible-content"
+    role="definition"
+    class="wrapper"
+    class:expanded
+    style={`${maxHeightStyle(maxHeight)}${overflyYStyle(maxHeight)}`}
+  >
+    <div
+      {id}
+      aria-labelledby={id !== undefined ? `heading${id}` : undefined}
+      class="content"
+      class:wrapHeight
+      bind:this={container}
+    >
+      <slot />
+    </div>
+  </div>
+</TestIdWrapper>
 
 <style lang="scss">
   @use "../styles/mixins/interaction";
   @use "../styles/mixins/media";
+
+  .contents {
+    display: contents;
+  }
 
   .header {
     &:not(.external) {

--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -6,7 +6,7 @@
   export let id: string | undefined = undefined;
   export let initiallyExpanded = false;
   export let maxContentHeight: number | undefined = undefined;
-  export let testId: string | undefined = undefined;
+  export let testId: string = "collapsible-header";
 
   export let iconSize: "small" | "medium" = "small";
   export let expandButton = true;
@@ -60,7 +60,7 @@
 </script>
 
 <div
-  data-tid={ testId ?? "collapsible-header"}
+  data-tid={testId}
   id={id !== undefined ? `heading${id}` : undefined}
   role="term"
   class={`header ${externalToggle ? "external" : ""}`}

--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -6,6 +6,7 @@
   export let id: string | undefined = undefined;
   export let initiallyExpanded = false;
   export let maxContentHeight: number | undefined = undefined;
+  export let testId: string | undefined = undefined;
 
   export let iconSize: "small" | "medium" = "small";
   export let expandButton = true;
@@ -59,7 +60,7 @@
 </script>
 
 <div
-  data-tid="collapsible-header"
+  data-tid={ testId ?? "collapsible-header"}
   id={id !== undefined ? `heading${id}` : undefined}
   role="term"
   class={`header ${externalToggle ? "external" : ""}`}

--- a/src/lib/components/KeyValuePairInfo.svelte
+++ b/src/lib/components/KeyValuePairInfo.svelte
@@ -8,8 +8,8 @@
   let toggleContent: () => void;
 </script>
 
-<Collapsible expandButton={false} externalToggle={true} bind:toggleContent>
-  <KeyValuePair {testId} slot="header">
+<Collapsible {testId} expandButton={false} externalToggle={true} bind:toggleContent>
+  <KeyValuePair slot="header">
     <div class="wrapper" slot="key">
       <slot name="key" />
       <button class="icon" on:click|stopPropagation={toggleContent}>

--- a/src/lib/components/KeyValuePairInfo.svelte
+++ b/src/lib/components/KeyValuePairInfo.svelte
@@ -8,7 +8,12 @@
   let toggleContent: () => void;
 </script>
 
-<Collapsible {testId} expandButton={false} externalToggle={true} bind:toggleContent>
+<Collapsible
+  {testId}
+  expandButton={false}
+  externalToggle={true}
+  bind:toggleContent
+>
   <KeyValuePair slot="header">
     <div class="wrapper" slot="key">
       <slot name="key" />

--- a/src/lib/components/TestIdWrapper.svelte
+++ b/src/lib/components/TestIdWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+</script>
+
+<div class="contents" data-tid={testId}>
+  <slot />
+</div>
+
+<style lang="scss">
+  .contents {
+    display: contents;
+  }
+</style>

--- a/src/tests/lib/components/TestIdWrapper.spec.ts
+++ b/src/tests/lib/components/TestIdWrapper.spec.ts
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 
-import TestIdWrapper from "./TestIdWrapperTest.svelte";
 import { render } from "@testing-library/svelte";
+import TestIdWrapper from "./TestIdWrapperTest.svelte";
 
 describe("TestIdWrapper", () => {
-  const testId = "test-id"
-  const childTestId = "child-test-id"
+  const testId = "test-id";
+  const childTestId = "child-test-id";
   it("should wrap component with the passed test id", () => {
     const { queryByTestId } = render(TestIdWrapper, {
-      props: { testId }
+      props: { testId },
     });
 
     expect(queryByTestId(testId)).toBeInTheDocument();
@@ -18,7 +18,7 @@ describe("TestIdWrapper", () => {
 
   it("should render child component", () => {
     const { queryByTestId } = render(TestIdWrapper, {
-      props: { testId, childTestId }
+      props: { testId, childTestId },
     });
 
     expect(queryByTestId(childTestId)).toBeInTheDocument();

--- a/src/tests/lib/components/TestIdWrapper.spec.ts
+++ b/src/tests/lib/components/TestIdWrapper.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import TestIdWrapper from "./TestIdWrapperTest.svelte";
+import { render } from "@testing-library/svelte";
+
+describe("TestIdWrapper", () => {
+  const testId = "test-id"
+  const childTestId = "child-test-id"
+  it("should wrap component with the passed test id", () => {
+    const { queryByTestId } = render(TestIdWrapper, {
+      props: { testId }
+    });
+
+    expect(queryByTestId(testId)).toBeInTheDocument();
+  });
+
+  it("should render child component", () => {
+    const { queryByTestId } = render(TestIdWrapper, {
+      props: { testId, childTestId }
+    });
+
+    expect(queryByTestId(childTestId)).toBeInTheDocument();
+  });
+});

--- a/src/tests/lib/components/TestIdWrapperTest.svelte
+++ b/src/tests/lib/components/TestIdWrapperTest.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Back from "$lib/components/Back.svelte";
+import TestIdWrapper from "$lib/components/TestIdWrapper.svelte";
+
+  export let testId: string | undefined = undefined;
+  export let childTestId: string | undefined = undefined;
+</script>
+
+<TestIdWrapper {testId}>
+  <div data-tid={childTestId} />
+</TestIdWrapper>

--- a/src/tests/lib/components/TestIdWrapperTest.svelte
+++ b/src/tests/lib/components/TestIdWrapperTest.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Back from "$lib/components/Back.svelte";
-import TestIdWrapper from "$lib/components/TestIdWrapper.svelte";
+  import TestIdWrapper from "$lib/components/TestIdWrapper.svelte";
 
   export let testId: string | undefined = undefined;
   export let childTestId: string | undefined = undefined;


### PR DESCRIPTION
# Motivation

To improve testing, the testId must be in the most parent element.

In KeyValuePairInfo that means that the Collapsible should have the test id.

# Changes

* Add prop testId in Collapsible.
* KeyValuePairInfo passes testId to parent Collapsible.

# Screenshots

* No new tests required.
