### PR TITLE
build: publish to npm with provenance

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
-        run: npm publish --tag next
+        run: npm publish --provenance --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Set up npm
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
-        run: npm publish --access public
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/gix-components",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dependencies": {
         "dompurify": "^3.0.1",
         "html5-qrcode": "^2.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && vite build",


### PR DESCRIPTION
# Motivation

Publish provenance alongside our libraries to npm.

# Source

 - https://github.blog/2023-04-19-introducing-npm-package-provenance/
 - https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/

# Changes

- add flag `--provenance` next to `npm publish`
