### PR TITLE
build: fix provenance

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Motivation

To use `provenance` the GitHub actions need specific `permissions`.

# Source

- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
- https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/

<img width="638" alt="Capture d’écran 2023-04-20 à 10 00 58" src="https://user-images.githubusercontent.com/16886711/233300384-2fbec0eb-7671-4bb7-90a4-f6f96b50e24a.png">
<img width="638" alt="Capture d’écran 2023-04-20 à 10 01 09" src="https://user-images.githubusercontent.com/16886711/233300390-c49f9501-f1fd-4a59-82a8-361dd879e701.png">
