### PR TITLE
Add data-tid to Header component

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -6,7 +6,7 @@
   export let back = false;
 </script>
 
-<header>
+<header data-tid="header-component">
   <Toolbar>
     <svelte:fragment slot="start">
       {#if back}


### PR DESCRIPTION
# Motivation

We want to refer to the header element from a corresponding page object in the nns-dapp repo.

# Changes

Add `data-tid="header-component"` to `src/lib/components/Header.svelte`