### PR TITLE
Top-align checkboxes

### DIFF
--- a/src/lib/components/Checkbox.svelte
+++ b/src/lib/components/Checkbox.svelte
@@ -52,7 +52,6 @@
   .checkbox {
     display: flex;
     justify-content: space-between;
-    align-items: center;
     flex-direction: var(--checkbox-flex-direction);
     gap: var(--padding);
 

--- a/src/routes/(split)/components/checkbox/+page.md
+++ b/src/routes/(split)/components/checkbox/+page.md
@@ -3,6 +3,7 @@
 
     let checkbox1 = false;
     let checkbox2 = true;
+    let checkbox3 = false;
 </script>
 
 # Checkbox
@@ -42,4 +43,12 @@ Checkboxes allow the selection of multiple options from a set of options. They a
         <Checkbox checked={checkbox2} on:nnsChange={() => (checkbox2 = !checkbox2)}>An option with row-reverse style</Checkbox>
     </div>
 
+    <div style="--checkbox-flex-direction: row-reverse">
+        <Checkbox
+          checked={checkbox3}
+          on:nnsChange={() => (checkbox3 = !checkbox3)}
+          text="block"
+        >An option with row-reverse style and enough text to cover
+        multiple lines. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</Checkbox>
+    </div>
 </div>

--- a/src/routes/(split)/components/checkbox/+page.md
+++ b/src/routes/(split)/components/checkbox/+page.md
@@ -51,4 +51,5 @@ Checkboxes allow the selection of multiple options from a set of options. They a
         >An option with row-reverse style and enough text to cover
         multiple lines. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</Checkbox>
     </div>
+
 </div>


### PR DESCRIPTION
# Motivation

When a checkbox has a label that spans multiple lines, `align-items: center` looks strange.
When removing `align-items: center`, the single line labels also shift slightly.
I showed the difference to Mary and she told me to make the change for all checkboxes.

# Changes

1. Remove `align-items: center` from `Checkbox.svelte` and use the default top alignment.
2. Add a showcase with a multi-line label.

# Screenshots
Before:
<img width="1295" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/4beb8890-b0a5-45f1-8128-3c7e578b262a">

After:
<img width="1295" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/ce281201-52cf-47f2-b781-05725623ebb6">
