### PR TITLE
fix: optionally format raw input to normal number format

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -96,7 +96,7 @@
 
   const handleInput = ({ currentTarget }: InputEventHandler) => {
     if (inputType === "icp") {
-      const currentValue = currentTarget.value;
+      const currentValue = exponentToPlainNumberString(currentTarget.value);
 
       // handle invalid input
       if (isValidICPFormat(currentValue) === false) {

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -396,6 +396,25 @@ describe("Input", () => {
       expect(container.querySelector("input")?.value).toBe("0.00000001");
     });
 
+    it.only("should avoid exponent formatted on change in icp mode", async () => {
+      const { container } = render(Input, {
+        props: {
+          ...props,
+          value: "",
+          inputType: "icp",
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+
+      if (isNullish(input)) {
+        throw new Error("No input");
+      }
+
+      fireEvent.input(input, { target: { value: 0.00000001 } });
+      expect(input.value).toBe("0.00000001");
+    });
+
     it("should avoid exponent formatted initial value (>0) in icp mode", () => {
       const { container } = render(InputValueTest, {
         props: {

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -396,7 +396,7 @@ describe("Input", () => {
       expect(container.querySelector("input")?.value).toBe("0.00000001");
     });
 
-    it.only("should avoid exponent formatted on change in icp mode", async () => {
+    it("should avoid exponent formatted on change in icp mode", async () => {
       const { container } = render(Input, {
         props: {
           ...props,


### PR DESCRIPTION
# Motivation

Avoid exponential formatting for the icp values.

Original issuer: when a user clicks on the 'Max' button and has a very small amount of tokens left, the value appears in exponential format, which is incorrect. The fix checks and replaces any Xe-Y formatted value on change.

# Changes

- apply optional formatting to input

# Tests

- should avoid exponent formatted on change in icp mode

# Screenshot

## Before
<img width="521" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/87f5833b-883a-41c6-8df7-5a267219fc9f">

## After
![Screen Recording 2023-05-11 at 10 27 07](https://github.com/dfinity/nns-dapp/assets/98811342/53188468-02c4-45b3-a141-c302b150c6d6)
