### PR TITLE
style: hover text button color

### DIFF
--- a/src/lib/styles/global/button.scss
+++ b/src/lib/styles/global/button.scss
@@ -21,6 +21,7 @@ button {
     &:active,
     &:focus {
       text-decoration: underline;
+      color: var(--value-color);
     }
 
     &[disabled] {


### PR DESCRIPTION
# Motivation

When hovered, the color of the links become `value`. This PR align the same color behavior for button of type text.
