### PR TITLE
fix: input pre-formatting test

### DIFF
--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -4,7 +4,7 @@
 
 import Input from "$lib/components/Input.svelte";
 import { isNullish, nonNullish } from "@dfinity/utils";
-import { fireEvent, render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import InputTest from "./InputTest.svelte";
 import InputValueTest from "./InputValueTest.svelte";
 
@@ -412,7 +412,7 @@ describe("Input", () => {
       }
 
       fireEvent.input(input, { target: { value: 0.00000001 } });
-      expect(input.value).toBe("0.00000001");
+      await waitFor(() => expect(input.value).toBe("0.00000001"));
     });
 
     it("should avoid exponent formatted initial value (>0) in icp mode", () => {


### PR DESCRIPTION
# Motivation

One of the tests was broken due to non-synchronous input value formatting.

# Changes

- waitFor was added to wait for the right value
