### PR TITLE
Fix BottomSheet race condition

### DIFF
--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { nonNullish } from "@dfinity/utils";
   import { layoutBottomOffset } from "$lib/stores/layout.store";
   import { onDestroy } from "svelte";
   import { BREAKPOINT_LARGE } from "../constants/constants";
@@ -6,11 +7,14 @@
   onDestroy(() => ($layoutBottomOffset = 0));
 
   // See also the CSS code of this component. On large screen the bottom sheet is not sticky.
-  const updateBottomOffset = () =>
-    ($layoutBottomOffset = innerWidth < BREAKPOINT_LARGE ? height : 0);
+  const updateBottomOffset = () => {
+    if (nonNullish(innerWidth) && nonNullish(height)) {
+      $layoutBottomOffset = innerWidth < BREAKPOINT_LARGE ? height : 0;
+    }
+  };
 
-  let height = 0;
-  let innerWidth = 0;
+  let height : number | undefined = undefined;
+  let innerWidth : number | undefined = undefined;
   $: height, innerWidth, updateBottomOffset();
 </script>
 

--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -13,8 +13,8 @@
     }
   };
 
-  let height : number | undefined = undefined;
-  let innerWidth : number | undefined = undefined;
+  let height: number | undefined = undefined;
+  let innerWidth: number | undefined = undefined;
   $: height, innerWidth, updateBottomOffset();
 </script>
 


### PR DESCRIPTION
# Motivation

`<BottomSheet>` appears inline on large screens and docked to the bottom on small screens.
When it's docked to the bottom, it sets `$layoutBottomOffset` so layout components can take it into account.
`BottomSheet` listens to `innerWidth` of the window and `clientHeight` of the component.
In practice `clientHeight` is set first and since `innerWidth` is initialized to `0`, the code acts as if the screen is small until `innerWidth` is also set.
This means that on large screens, `$layoutBottomOffset` is briefly set to non-zero and then immediately back to `0` when `innerWidth` is set.
On CI (although I wasn't able to reproduce this on my Mac) this consistently results in the page being rendered twice.
And for some reason the second render happens before the first page is destroyed.
On the swap participation page of NNS dapp, this means that `ProjectDetail` will start polling for the ticket twice (which is redundant) and then immediately stops polling for the ticket when `onDestroy` is called.
This results in a UI that's "loading forever".

# Changes

1. In `BottomSheet.svelte` initialize `height` and `innerWidth` to `undefined` instead of `0`.
2. Only update `$layoutBottomOffset` if both `height` and `innerWidth` are defiend.

# Tests

I tried to add a unit test for this but the jsdom unit test environment does not behave in a way that allows exposing the bug.

I did make a fork of `BottomSheet.svelte` in the nns-dapp repo to check that fixing the problem actually allows the sns participation end-to-end test to participate:
https://github.com/dfinity/nns-dapp/actions/runs/4967150795
