### PR TITLE
Add data-tid to Dropdown component

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -13,7 +13,7 @@
   $: showStart = nonNullish($$slots.start);
 </script>
 
-<div class="select">
+<div class="select" data-tid="dropdown-component">
   {#if showStart}
     <div class="start">
       <slot name="start" />


### PR DESCRIPTION
# Motivation

The Dropdown page object should use a test ID to locate the Dropdown component.

# Changes

Add `data-tid="dropdown-component"` attribute to the outer element of the Dropdown component.

# Screenshots

N/A