### PR TITLE
build: accept any utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "svelte"
   ],
   "peerDependencies": {
-    "@dfinity/utils": "0.*",
+    "@dfinity/utils": "*",
     "svelte": "^3.55.1"
   },
   "repository": {


### PR DESCRIPTION
# Motivation

Accept any `@dfinity/utils` to avoid conflicts in NNS-dapp.
