### PR TITLE
Add testId to Value component

### DIFF
--- a/src/lib/components/Value.svelte
+++ b/src/lib/components/Value.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   export let ariaLabel: string | undefined = undefined;
+  export let testId: string | undefined = undefined;
 </script>
 
-<span class="value" aria-label={ariaLabel}>
+<span class="value" aria-label={ariaLabel} data-tid={testId}>
   <slot />
 </span>


### PR DESCRIPTION
# Motivation

I want to refer to a Value component from a page object in the nns-dapp repository.

# Changes

Add `testId` prop which sets `data-tid` attribute to `Value` component.

# Screenshots

N/A
