### PR TITLE
Modal data-tid on title

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -51,7 +51,9 @@
     >
       {#if showHeader}
         <div class="header">
-          <h2 id={modalTitleId} data-tid="modal-title"><slot name="title" /></h2>
+          <h2 id={modalTitleId} data-tid="modal-title">
+            <slot name="title" />
+          </h2>
           {#if !disablePointerEvents}
             <button
               data-tid="close-modal"

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -51,7 +51,7 @@
     >
       {#if showHeader}
         <div class="header">
-          <h2 id={modalTitleId}><slot name="title" /></h2>
+          <h2 id={modalTitleId} data-tid="modal-title"><slot name="title" /></h2>
           {#if !disablePointerEvents}
             <button
               data-tid="close-modal"


### PR DESCRIPTION
# Motivation

I want to migrate `frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts` in nns-dapp to use page objects and I need a way to get to the title of a Modal for that.

# Changes

Add `data-tid="modal-title"` on the title slot in `Modal.svelte`.

# Tested

I ran `npm run dev` and verified that the title of the `WizardModal` component has the `datat-tid="modal-title"` attribute.
