### PR TITLE
Feat: Add slot to Modal

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -64,9 +64,13 @@
         </div>
       {/if}
 
-      <div class="container">
-        <div class="content" id={modalContentId} class:alert={role === "alert"}>
-          <slot />
+      <div class="container-wrapper">
+        <slot name="sub-title" />
+
+        <div class="container">
+          <div class="content" id={modalContentId} class:alert={role === "alert"}>
+            <slot />
+          </div>
         </div>
       </div>
 
@@ -112,6 +116,14 @@
 
     box-shadow: var(--overlay-box-shadow);
 
+    .container-wrapper {
+      margin: var(--padding-1_5x) var(--padding-2x) auto;
+
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-1_5x);
+    }
+
     &.alert {
       width: var(--alert-width);
       max-width: var(--alert-max-width);
@@ -124,9 +136,8 @@
         padding: var(--alert-padding-y) var(--alert-padding-x) var(--padding);
       }
 
-      .container {
-        margin: var(--padding-1_5x) var(--padding-2x)
-          calc(var(--alert-padding-y) * 2 / 3);
+      .container-wrapper {
+        margin-bottom: calc(var(--alert-padding-y) * 2 / 3);
       }
 
       .content {
@@ -166,8 +177,8 @@
         padding: var(--dialog-padding-y) var(--padding-3x) var(--padding);
       }
 
-      .container {
-        margin: var(--padding-1_5x) var(--padding-2x) var(--dialog-padding-y);
+      .container-wrapper {
+        margin-bottom: var(--padding-1_5x) var(--padding-2x) var(--dialog-padding-y);
       }
 
       .content {

--- a/src/routes/(split)/components/modal/+page.md
+++ b/src/routes/(split)/components/modal/+page.md
@@ -42,6 +42,7 @@ A Modal is a dialog that appears on top of the app's content, and must be dismis
 | Default slot | The content of the modal.                                                                    |
 | `title`      | The title of the modal. Displayed in a toolbar with a "Close" icon button on the right side. |
 | `toolbar`    | A sticky toolbar displayed at the bottom of the modal. Available for "alert" only.           |
+| `sub-title`  | A slot below the title but outside of the content card.                                      |
 
 ## Events
 
@@ -63,6 +64,8 @@ Open modal
 
 <Modal {visible} on:nnsClose={() => (visible = false)} {role}>
 <svelte:fragment slot="title">My title</svelte:fragment>
+
+<p slot="sub-title">This is the subtitle</p>
 
 <DocsLoremIpsum length={role === "alert" ? 1 : 10} />
 

--- a/src/tests/lib/components/Modal.spec.ts
+++ b/src/tests/lib/components/Modal.spec.ts
@@ -77,6 +77,18 @@ describe("Modal", () => {
     expect(wrapper).not.toBeNull();
   });
 
+  it("should render a subtitle", () => {
+    const subTitle = "My subtitle";
+    const { getByText } = render(ModalTest, {
+      props: {
+        ...props,
+        subTitle,
+      },
+    });
+
+    expect(getByText(subTitle)).not.toBeNull();
+  });
+
   it("should render a toolbar", () => {
     const { container } = render(Modal, {
       props,

--- a/src/tests/lib/components/ModalTest.svelte
+++ b/src/tests/lib/components/ModalTest.svelte
@@ -3,8 +3,10 @@
 
   export let visible: boolean;
   export let disablePointerEvents = false;
+  export let subTitle: string | undefined = undefined;
 </script>
 
 <Modal {visible} {disablePointerEvents} on:nnsClose>
   <h3 slot="title">Test</h3>
+  <p slot="sub-title">{subTitle}</p>
 </Modal>


### PR DESCRIPTION
# Motivation

Add the filter all above the modal content, below the title.

# Changes

* Add a new slot to Modal `sub-title`. Create a new parent for the `container` of the content and move some rules there.

# Screenshots

![Screenshot 2023-06-27 at 13 44 44](https://github.com/dfinity/gix-components/assets/4550653/9177a94b-30f4-4ab8-950d-c17d948c117e)
![Screenshot 2023-06-27 at 13 44 52](https://github.com/dfinity/gix-components/assets/4550653/92b72efa-8634-4651-80ce-528a4270c49e)

This is what we want to do in the nns-dapp:

![Screenshot 2023-06-27 at 11 57 45](https://github.com/dfinity/gix-components/assets/4550653/c158ee05-d923-4bd8-ab16-9f4f76739ddb)

