### PR TITLE
style: fix header button width

### DIFF
--- a/src/lib/styles/mixins/_header.scss
+++ b/src/lib/styles/mixins/_header.scss
@@ -4,6 +4,7 @@
 
 @mixin button($color) {
   width: var(--padding-4x);
+  min-width: var(--padding-4x);
   height: var(--padding-4x);
 
   padding: var(--padding-0_5x);


### PR DESCRIPTION
# Motivation

On small devices the header button activated looks not round which is visually unpleasant.

# Screenshots

Current
<img width="1536" alt="Capture d’écran 2023-06-29 à 08 20 59" src="https://github.com/dfinity/gix-components/assets/16886711/ee131b11-9d1f-4ddd-b1c3-0c668c1c250d">

PR
<img width="1536" alt="Capture d’écran 2023-06-29 à 08 21 49" src="https://github.com/dfinity/gix-components/assets/16886711/c2b460ee-3f34-43a8-a848-0e4c434c231b">