### PR TITLE
Fix: Modal content height

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -126,6 +126,7 @@
       display: flex;
       flex-direction: column;
       gap: var(--padding-1_5x);
+      flex: 1;
 
       overflow: hidden;
     }


### PR DESCRIPTION
# Motivation

Content of the modal was not covering all the height of the modal.

# Changes

* Add `flex: 1` to the content wrapper.

# Screenshots

Before:
![Screenshot 2023-06-29 at 09 17 10](https://github.com/dfinity/gix-components/assets/4550653/929e4d8c-74a2-4c2e-b38c-00ff88def769)

After:
![Screenshot 2023-06-29 at 09 17 25](https://github.com/dfinity/gix-components/assets/4550653/ec34e199-0c96-47e2-9bf8-319b92c69f9c)

