### PR TITLE
Feat: Underline text and ghost button

### DIFF
--- a/src/lib/styles/global/button.scss
+++ b/src/lib/styles/global/button.scss
@@ -14,13 +14,13 @@ button {
     width: fit-content;
 
     @include fonts.standard;
+    text-decoration: underline;
 
     color: inherit;
 
     &:hover,
     &:active,
     &:focus {
-      text-decoration: underline;
       color: var(--value-color);
     }
 


### PR DESCRIPTION
# Motivation

Users have complained that the "ghost" and "text" buttons don't look like buttons at all.

Specially since the release of the "Select All" and "Clear" buttons for the filter modal.

# Changes

* Underline the text of the "ghost" and "text" buttons.

# Screenshots

Before:

![Screenshot 2023-07-11 at 10 36 03](https://github.com/dfinity/gix-components/assets/4550653/1bd03fb2-d734-4a31-b5ef-1eb80cb954a3)

Now:

![Screenshot 2023-07-11 at 10 36 52](https://github.com/dfinity/gix-components/assets/4550653/07da361d-df2a-4dd8-bdca-1b632437f3fd)

