### PR TITLE
Feat: Improve PageHeader responsiveness

### DIFF
--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -35,6 +35,7 @@
     align-items: center;
 
     @include media.min-width(medium) {
+      flex-direction: row;
       justify-content: space-between;
     }
   }

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -19,6 +19,8 @@
 </div>
 
 <style lang="scss">
+  @use "../styles/mixins/media";
+
   .container {
     display: flex;
     flex-direction: column;
@@ -27,8 +29,14 @@
 
   .header {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: var(--padding);
+    justify-content: center;
     align-items: center;
+
+    @include media.min-width(medium) {
+      justify-content: space-between;
+    }
   }
 
   .content {


### PR DESCRIPTION
# Motivation

PageHeader responsiveness was not so great when the start and end slots had long content.

Solution: Change the rendering of the slots for small screens.

# Changes

* Add media query in PageHeader to render start and end slots differently.

# Screenshots

Desktop doesn't change.

Mobile:
![Screenshot 2023-07-11 at 11 39 29](https://github.com/dfinity/gix-components/assets/4550653/a98588d1-b92f-4938-b786-b0b4feee9fd7)

