### PR TITLE
Revert svelte animation local to global

### DIFF
--- a/src/lib/components/Backdrop.svelte
+++ b/src/lib/components/Backdrop.svelte
@@ -17,8 +17,8 @@
   role="button"
   tabindex="-1"
   aria-label={$i18n.core.close}
-  in:fade|local={{ duration: FADE_IN_DURATION }}
-  out:fade|local={{ duration: FADE_OUT_DURATION }}
+  in:fade|global={{ duration: FADE_IN_DURATION }}
+  out:fade|global={{ duration: FADE_OUT_DURATION }}
   class="backdrop"
   on:click|stopPropagation={close}
   on:keypress={($event) => handleKeyPress({ $event, callback: close })}

--- a/src/lib/components/BusyScreen.svelte
+++ b/src/lib/components/BusyScreen.svelte
@@ -7,7 +7,7 @@
 
 <!-- Display spinner and lock UI if busyStore is not empty -->
 {#if $busy}
-  <div data-tid="busy" transition:fade|local>
+  <div data-tid="busy" transition:fade|global>
     <div class="content">
       {#if nonNullish($busyMessage)}
         <p>{$busyMessage}</p>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -35,7 +35,7 @@
 {#if visible}
   <div
     class="modal"
-    transition:fade|local={{ duration: 25 }}
+    transition:fade|global={{ duration: 25 }}
     on:introend
     {role}
     data-tid={testId}
@@ -45,8 +45,8 @@
   >
     <Backdrop {disablePointerEvents} on:nnsClose />
     <div
-      in:fade|local={{ duration: FADE_IN_DURATION }}
-      out:fade|local={{ duration: FADE_OUT_DURATION }}
+      in:fade|global={{ duration: FADE_IN_DURATION }}
+      out:fade|global={{ duration: FADE_OUT_DURATION }}
       class={`wrapper ${role}`}
     >
       {#if showHeader}

--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -28,7 +28,7 @@
   <div
     role="menu"
     aria-orientation="vertical"
-    transition:fade|local
+    transition:fade|global
     class="popover"
     tabindex="-1"
     style="--popover-top: {`${bottom}px`}; --popover-left: {`${left}px`}; --popover-right: {`${
@@ -39,7 +39,7 @@
   >
     <Backdrop on:nnsClose={() => (visible = false)} />
     <div
-      transition:scale|local={{ delay: 25, duration: 150, easing: quintOut }}
+      transition:scale|global={{ delay: 25, duration: 150, easing: quintOut }}
       class="wrapper"
       class:rtl={direction === "rtl"}
     >

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -76,8 +76,8 @@
 <div
   role="dialog"
   class={`toast ${theme ?? "themed"}`}
-  in:fly|local={{ y: (position === "top" ? -1 : 1) * 100, duration: 200 }}
-  out:fade|local={{ delay: 100 }}
+  in:fly|global={{ y: (position === "top" ? -1 : 1) * 100, duration: 200 }}
+  out:fade|global={{ delay: 100 }}
 >
   <div class="icon {level}" aria-hidden="true">
     {#if spinner}

--- a/src/lib/components/WizardTransition.svelte
+++ b/src/lib/components/WizardTransition.svelte
@@ -19,7 +19,7 @@
 {#key transition}
   <div
     bind:clientWidth={absolutOffset}
-    in:fly|local={{ x: slideOffset, duration: ANIMATION_DURATION }}
+    in:fly|global={{ x: slideOffset, duration: ANIMATION_DURATION }}
   >
     <slot />
   </div>


### PR DESCRIPTION
# Motivation

Set svelte animation `local` to `global` because of broken `introend` event.

# PRs

- Revert #246

# Changes

- local to global everywhere

# Screenshots

No visual changes
