### PR TITLE
Feat: Add size to IconExpandCircleDown

### DIFF
--- a/src/lib/icons/IconExpandCircleDown.svelte
+++ b/src/lib/icons/IconExpandCircleDown.svelte
@@ -1,13 +1,15 @@
 <!-- source: https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Aexpand_circle_down%3A -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = `${DEFAULT_ICON_SIZE}px`;
 </script>
 
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  height={DEFAULT_ICON_SIZE}
+  height={size}
   viewBox="0 0 24 24"
-  width={DEFAULT_ICON_SIZE}
+  width={size}
   fill="currentColor"
   ><rect fill="none" height="24" width="24" /><path
     d="M15.08,9.59L12,12.67L8.92,9.59L7.5,11l4.5,4.5l4.5-4.5L15.08,9.59z M12,2C6.48,2,2,6.48,2,12c0,5.52,4.48,10,10,10 s10-4.48,10-10C22,6.48,17.52,2,12,2z M12,20c-4.42,0-8-3.58-8-8s3.58-8,8-8s8,3.58,8,8S16.42,20,12,20z"


### PR DESCRIPTION
# Motivation

We need different sizes of this icon.

# Changes

* Add `size` prop to `IconExpandCircleDown`

# Screenshots

No screenshot changes because default is the same.
