### PR TITLE
Feat: ItemAction - do not stretch actions

### DIFF
--- a/src/lib/components/ItemAction.svelte
+++ b/src/lib/components/ItemAction.svelte
@@ -10,7 +10,7 @@
     </div>
     <slot />
   </div>
-  <div class="actions">
+  <div>
     <slot name="actions" />
   </div>
 </svelte:element>
@@ -49,12 +49,6 @@
       display: flex;
       align-items: center;
       justify-content: center;
-    }
-
-    .actions {
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

The ItemAction should not stretch the actions slot.

# Changes

* Remove `stretch` style in the actions slot.

# Screenshots

No UI changes in desktop.

New UI in mobile:
![Screenshot 2023-07-26 at 09 19 43](https://github.com/dfinity/gix-components/assets/4550653/55e66053-d943-4581-9eeb-4b610258e4ec)
