### PR TITLE
feat: revert two icons in Card

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import type { SvelteComponent } from "svelte";
+  import IconExpandMore from "$lib/icons/IconExpandMore.svelte";
+  import IconCheckCircle from "$lib/icons/IconCheckCircle.svelte";
   import { nonNullish } from "@dfinity/utils";
 
   export let role: "link" | "button" | "checkbox" | "radio" | undefined =
@@ -7,6 +10,7 @@
   export let selected = false;
   export let disabled: boolean | undefined = undefined;
   export let testId = "card";
+  export let icon: "expand" | "check" | undefined = undefined;
   export let theme: "transparent" | "framed" | "highlighted" | undefined =
     undefined;
 
@@ -21,6 +25,19 @@
 
   let ariaChecked: boolean | undefined = undefined;
   $: ariaChecked = role === "checkbox" ? selected : undefined;
+
+  let iconCmp: typeof SvelteComponent | undefined = undefined;
+
+  $: (() => {
+    switch (icon) {
+      case "expand":
+        iconCmp = IconExpandMore;
+        break;
+      case "check":
+        iconCmp = IconCheckCircle;
+        break;
+    }
+  })();
 </script>
 
 <article
@@ -29,12 +46,17 @@
   on:click
   class={`card ${theme ?? ""}`}
   class:clickable
+  class:icon={nonNullish(icon)}
   class:selected
   class:disabled
   aria-disabled={disabled}
   aria-checked={ariaChecked}
   aria-label={ariaLabel}
 >
+  {#if nonNullish(iconCmp)}
+    <svelte:component this={iconCmp} />
+  {/if}
+
   {#if showHeadline}
     <div class="meta">
       <slot name="start" />
@@ -103,6 +125,29 @@
       }
       :global(.description) {
         color: rgba(var(--primary-contrast-rgb), var(--very-light-opacity));
+      }
+    }
+
+    &.icon {
+      position: relative;
+      padding-right: var(--padding-6x);
+
+      > :global(svg:first-child) {
+        position: absolute;
+
+        height: var(--padding-3x);
+        width: auto;
+
+        right: var(--padding-2x);
+        top: 50%;
+        margin-top: calc(-1 * var(--padding-1_5x));
+
+        color: var(--tertiary);
+      }
+
+      &.selected {
+        --icon-check-circle-background: var(--primary);
+        --icon-check-circle-color: var(--primary-contrast);
       }
     }
   }

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -20,15 +20,15 @@ Cards are surfaces that display content and optionally actions on a single topic
 
 ## Properties
 
-| Property    | Description                                                                                    | Type                                                        | Default     |
-| ----------- | ---------------------------------------------------------------------------------------------- |-------------------------------------------------------------| ----------- |
-| `role`      | The semantic role of the `article` that will be rendered in the DOM when using this component. | `link` or `button` or `checkbox` or `radio` or `undefined`  | `undefined` |
-| `ariaLabel` | An accessible label for the card.                                                              | `string` or `undefined`                                     | `undefined` |
-| `selected`  | Display the surface as `selected`. Useful if used as a on/off call to action.                  | `boolean`                                                   | `false`     |
-| `disabled`  | Disable clickable events.                                                                      | `boolean` or `undefined`                                    | `undefined` |
-| `testId`    | Add a `data-tid` attribute to the DOM, useful for test purpose.                                | `string`                                                    | `card`      |
-| `theme`     | Display a particular theme for surface of the card.                                            | `highlighted` or `transparent` or `framed` or `undefined`   | `undefined` |
-| `icon`      | Render an icon / call to action next within the card on the right side.                        | `expand` or `check` or `undefined`                          | `undefined` |
+| Property    | Description                                                                                    | Type                                                       | Default     |
+| ----------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
+| `role`      | The semantic role of the `article` that will be rendered in the DOM when using this component. | `link` or `button` or `checkbox` or `radio` or `undefined` | `undefined` |
+| `ariaLabel` | An accessible label for the card.                                                              | `string` or `undefined`                                    | `undefined` |
+| `selected`  | Display the surface as `selected`. Useful if used as a on/off call to action.                  | `boolean`                                                  | `false`     |
+| `disabled`  | Disable clickable events.                                                                      | `boolean` or `undefined`                                   | `undefined` |
+| `testId`    | Add a `data-tid` attribute to the DOM, useful for test purpose.                                | `string`                                                   | `card`      |
+| `theme`     | Display a particular theme for surface of the card.                                            | `highlighted` or `transparent` or `framed` or `undefined`  | `undefined` |
+| `icon`      | Render an icon / call to action next within the card on the right side.                        | `expand` or `check` or `undefined`                         | `undefined` |
 
 ## Slots
 

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -20,15 +20,15 @@ Cards are surfaces that display content and optionally actions on a single topic
 
 ## Properties
 
-| Property    | Description                                                                                    | Type                                                       | Default     |
-| ----------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
-| `role`      | The semantic role of the `article` that will be rendered in the DOM when using this component. | `link` or `button` or `checkbox` or `radio` or `undefined` | `undefined` |
-| `ariaLabel` | An accessible label for the card.                                                              | `string` or `undefined`                                    | `undefined` |
-| `selected`  | Display the surface as `selected`. Useful if used as a on/off call to action.                  | `boolean`                                                  | `false`     |
-| `disabled`  | Disable clickable events.                                                                      | `boolean` or `undefined`                                   | `undefined` |
-| `testId`    | Add a `data-tid` attribute to the DOM, useful for test purpose.                                | `string`                                                   | `card`      |
-| `theme`     | Display a particular theme for surface of the card.                                            | `highlighted` or `transparent` or `framed` or `undefined`  | `undefined` |
-| `icon`      | Render an icon / call to action next within the card on the right side.                        | `arrow` or `expand` or `check` or `undefined`              | `undefined` |
+| Property    | Description                                                                                    | Type                                                        | Default     |
+| ----------- | ---------------------------------------------------------------------------------------------- |-------------------------------------------------------------| ----------- |
+| `role`      | The semantic role of the `article` that will be rendered in the DOM when using this component. | `link` or `button` or `checkbox` or `radio` or `undefined`  | `undefined` |
+| `ariaLabel` | An accessible label for the card.                                                              | `string` or `undefined`                                     | `undefined` |
+| `selected`  | Display the surface as `selected`. Useful if used as a on/off call to action.                  | `boolean`                                                   | `false`     |
+| `disabled`  | Disable clickable events.                                                                      | `boolean` or `undefined`                                    | `undefined` |
+| `testId`    | Add a `data-tid` attribute to the DOM, useful for test purpose.                                | `string`                                                    | `card`      |
+| `theme`     | Display a particular theme for surface of the card.                                            | `highlighted` or `transparent` or `framed` or `undefined`   | `undefined` |
+| `icon`      | Render an icon / call to action next within the card on the right side.                        | `expand` or `check` or `undefined`                          | `undefined` |
 
 ## Slots
 
@@ -141,6 +141,29 @@ List of the mixins:
 
     <Card theme="framed">
         <h3>Button</h3>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+</div>
+
+<p style="padding: var(--padding-4x) 0 var(--padding);">Icons:</p>
+
+<div class="card-grid" style="margin-top: var(--padding)">
+    <Card icon="check">
+        <h3>Checkmark</h3>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card icon="check" selected>
+        <h3>Checkmark and selected</h3>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card icon="expand">
+        <h3>Expand</h3>
 
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>


### PR DESCRIPTION
# Motivation

Turns out we still need two icons in the `Card` component because those are used in the universe selector of NNS dapp.

# PRs

- [x] Revert partially https://github.com/dfinity/gix-components/pull/261
