### PR TITLE
fix: showcase style workaround

### DIFF
--- a/src/docs/components/DocsComponentsNav.svelte
+++ b/src/docs/components/DocsComponentsNav.svelte
@@ -22,7 +22,7 @@
   }
 
   div {
-    :global(article:not(.selected)) {
+    :global(.card:not(.selected)) {
       display: none;
 
       @include media.min-width(large) {


### PR DESCRIPTION
# Motivation

For simplicity reason we do not have yet implemented the components picker in the showcase but just a style workaround. Because the card has become links, a selector should be updated.

# Screenshots

<img width="1534" alt="Capture d’écran 2023-08-02 à 09 56 03" src="https://github.com/dfinity/gix-components/assets/16886711/d188d3e9-fdff-4a3c-8941-5427c8ced7b8">
