### PR TITLE
style: card link hover color

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -86,7 +86,8 @@
   @use "../styles/mixins/display";
   @use "../styles/mixins/card";
 
-  article, a {
+  article,
+  a {
     display: flex;
     flex-direction: column;
 
@@ -167,7 +168,7 @@
   a.card {
     margin: 0;
 
-    &:hover {
+    &:not(.disabled):hover {
       color: inherit;
     }
   }

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -166,6 +166,10 @@
 
   a.card {
     margin: 0;
+
+    &:hover {
+      color: inherit;
+    }
   }
 
   .clickable {

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -89,7 +89,7 @@ List of the mixins:
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 
-    <Card disabled>
+    <Card disabled href="https://gix.design">
         <h3>Disabled</h3>
 
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -77,6 +77,12 @@ List of the mixins:
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 
+    <Card href="https://gix.design">
+        <h3 slot="start">A link</h3>
+
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
     <Card selected>
         <h3>Selected</h3>
 


### PR DESCRIPTION
# Motivation

Not really an issue when the all card is a text but, when only parts of it has no specific color, hover a card link has for effect to change the color which does not look that good on the NNS dapp launchpad.

# Screenshots

![hover](https://github.com/dfinity/gix-components/assets/16886711/2b321f80-7e01-4318-a29d-65dfa5a12ab4)
