### PR TITLE
fix: prevent default behavior of copy button

### DIFF
--- a/src/lib/components/Copy.svelte
+++ b/src/lib/components/Copy.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <button
-  on:click|stopPropagation={copyToClipboard}
+  on:click|preventDefault|stopPropagation={copyToClipboard}
   aria-label={`${$i18n.core.copy}: ${value}`}
   class="icon-only"
 >


### PR DESCRIPTION
# Motivation

When the `Copy` component is used within an hyperlinks, as e.g. a card, it triggers both its copy action but also propagate the default behavior which has for effect to trigger the link.
