### PR TITLE
Chore: Improve Section when no description

### DIFF
--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   export let testId: string | undefined = undefined;
+
+  let noDescription = false;
+  $: noDescription = $$slots.description === undefined;
 </script>
 
 <div class="container" data-tid={testId}>
-  <div class="section-title">
+  <div class="section-title" class:noDescription>
     <slot name="title" />
     <slot name="end" />
   </div>
   <slot name="description" />
-  <div class="content-wrapper"><slot /></div>
+  <div class="content-wrapper" class:noDescription><slot /></div>
 </div>
 
 <style lang="scss">
@@ -26,9 +29,17 @@
     justify-content: space-between;
 
     margin-bottom: var(--padding);
+
+    &.noDescription {
+      margin-bottom: 0;
+    }
   }
 
   .content-wrapper {
     margin-top: var(--padding-3x);
+
+    &.noDescription {
+      margin-top: var(--padding-2x);
+    }
   }
 </style>

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -28,10 +28,8 @@
     align-items: center;
     justify-content: space-between;
 
-    margin-bottom: var(--padding);
-
-    &.noDescription {
-      margin-bottom: 0;
+    &:not(.noDescription) {
+      margin-bottom: var(--padding);
     }
   }
 

--- a/src/routes/(split)/components/section/+page.md
+++ b/src/routes/(split)/components/section/+page.md
@@ -125,7 +125,7 @@ Below is the code for the real production example:
     background-color: var(--card-background);
     margin: var(--padding-2x) 0;
     & p,
-    h3 {
+    h3, h5 {
       margin: 0;
     }
   }
@@ -143,7 +143,7 @@ Below is the code for the real production example:
   .wrapper {
     background-color: var(--card-background);
     margin: var(--padding-2x) 0;
-    & p, h3 {
+    & p, h3, h5 {
       margin: 0;
     }
   }

--- a/src/routes/(split)/components/section/+page.md
+++ b/src/routes/(split)/components/section/+page.md
@@ -53,6 +53,18 @@ The component is within a `div` with a background to highlight the component exa
   </Section>
 </div>
 
+#### No description example
+
+<div class="wrapper">
+  <Section>
+    <h3 slot="title">Title</h3>
+    <h5 slot="end">123</h5>
+    <p>Here would go any content that we want.</p>
+    <p>It can be more than one element.</p>
+    <p>They would all go here.</p>
+  </Section>
+</div>
+
 ### Real production example
 
 <div class="wrapper">


### PR DESCRIPTION
# Motivation

There is too much spacing when there is no description in the Section.

# Changes

* New class to change margins when description slot is not present.

# Screenshots

Before:
![Screenshot 2023-08-09 at 07 31 40](https://github.com/dfinity/gix-components/assets/4550653/6f7c4072-4f08-4215-b938-ff8d9cec0c53)

Now:
![Screenshot 2023-08-09 at 07 31 46](https://github.com/dfinity/gix-components/assets/4550653/81484707-dc4d-4ba7-a5a4-6a66724d12ef)

Now with and without:
![Screenshot 2023-08-09 at 07 29 35](https://github.com/dfinity/gix-components/assets/4550653/b4a5c1c3-a271-4c25-88b5-07ab80321911)

