### PR TITLE
style: narrower scrollbars

### DIFF
--- a/src/lib/styles/global/scrollbar.scss
+++ b/src/lib/styles/global/scrollbar.scss
@@ -1,13 +1,14 @@
 ::-webkit-scrollbar {
   background: var(--scrollbar-thumb-background);
-  width: var(--padding);
+  width: var(--padding-2x);
 }
 
 ::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb-color);
-  border: solid 2.5px var(--scrollbar-thumb-color);
+  border: calc(var(--padding) * 2 / 3) var(--scrollbar-thumb-background) solid;
   border-radius: 0.5em;
   -webkit-border-radius: 0.5em;
+  background-clip: padding-box;
 }
 
 ::-webkit-scrollbar-corner {


### PR DESCRIPTION
# Motivation

Narrower scrollbars to avoid those behind partially cut by the UI components such as the islands.

# Screenshots

<img width="1034" alt="Capture d’écran 2023-08-09 à 13 35 50" src="https://github.com/dfinity/gix-components/assets/16886711/1da27b2b-3c5f-424f-8e4d-9059045fce6e">
<img width="1034" alt="Capture d’écran 2023-08-09 à 13 35 47" src="https://github.com/dfinity/gix-components/assets/16886711/22fc47fd-a42a-46d4-8440-8e3a50f32636">
<img width="1034" alt="Capture d’écran 2023-08-09 à 13 35 44" src="https://github.com/dfinity/gix-components/assets/16886711/4f00159a-1810-40a3-9791-94547c7b95a7">
<img width="1034" alt="Capture d’écran 2023-08-09 à 13 35 42" src="https://github.com/dfinity/gix-components/assets/16886711/ade642be-04f4-45eb-b7bd-7b2b34f903db">
<img width="1534" alt="Capture d’écran 2023-08-09 à 13 35 34" src="https://github.com/dfinity/gix-components/assets/16886711/ac020b1f-9868-4ac7-b85c-f78ede93073e">
<img width="1534" alt="Capture d’écran 2023-08-09 à 13 35 31" src="https://github.com/dfinity/gix-components/assets/16886711/e90ba354-2275-40d3-99d7-81b85469b18c">
<img width="1534" alt="Capture d’écran 2023-08-09 à 13 35 24" src="https://github.com/dfinity/gix-components/assets/16886711/c6ffdf60-0e25-4542-8e6b-f6d937ce3b61">
<img width="1534" alt="Capture d’écran 2023-08-09 à 13 35 21" src="https://github.com/dfinity/gix-components/assets/16886711/85e1ab37-f213-412e-872d-c620b9f9e5d5">

