### PR TITLE
Fix: Show svg icon in Safari

### DIFF
--- a/src/lib/icons/IconAccountsPage.svelte
+++ b/src/lib/icons/IconAccountsPage.svelte
@@ -1,6 +1,7 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size: number | undefined = undefined;
+  // Default to 100% size to make sure Safari renders the SVG correctly
+  export let size = "100%";
 </script>
 
 <svg

--- a/src/lib/icons/IconCanistersPage.svelte
+++ b/src/lib/icons/IconCanistersPage.svelte
@@ -1,6 +1,7 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size: number | undefined = undefined;
+  // Default to 100% size to make sure Safari renders the SVG correctly
+  export let size = "100%";
 </script>
 
 <svg

--- a/src/lib/icons/IconNeuronsPage.svelte
+++ b/src/lib/icons/IconNeuronsPage.svelte
@@ -1,6 +1,7 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size: number | undefined = undefined;
+  // Default to 100% size to make sure Safari renders the SVG correctly
+  export let size = "100%";
 </script>
 
 <svg

--- a/src/lib/icons/IconSettingsPage.svelte
+++ b/src/lib/icons/IconSettingsPage.svelte
@@ -1,6 +1,7 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size: number | undefined = undefined;
+  // Default to 100% size to make sure Safari renders the SVG correctly
+  export let size = "100%";
 </script>
 
 <svg


### PR DESCRIPTION
# Motivation

The svg IconXxxPage was not appearing in Safari.

The problem is that the width and height were not defined in the svg and Safari needs it to be defined.

# Changes

* Set a default size of 100% in the svgs so that the parent controls the size.

# Screenshots

Both screenshots of Safari.

![Screenshot 2023-08-24 at 08 08 37](https://github.com/dfinity/gix-components/assets/4550653/9490c300-583d-4df0-b64c-0df5a8ac0632)
![Screenshot 2023-08-24 at 08 09 42](https://github.com/dfinity/gix-components/assets/4550653/cbad1d37-6810-49b7-8053-fc1948b9ceb1)

