### PR TITLE
style: remove colour exception on hover

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -167,10 +167,6 @@
 
   a.card {
     margin: 0;
-
-    &:not(.disabled):hover {
-      color: inherit;
-    }
   }
 
   .clickable {

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -140,7 +140,11 @@ List of the mixins:
 <div class="card-grid" style="margin-top: var(--padding)">
     <Card theme="highlighted">
         <h3>Highlighted</h3>
+        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
 
+    <Card theme="highlighted" href="https://gix.design">
+        <h3>Highlighted link</h3>
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -143,11 +143,6 @@ List of the mixins:
         <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
     </Card>
 
-    <Card theme="highlighted" href="https://gix.design">
-        <h3>Highlighted link</h3>
-        <p>Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
-    </Card>
-
     <Card theme="transparent">
         <h3>Transparent</h3>
 


### PR DESCRIPTION
# Motivation

Remove text color `inherit` on hover to have more predictable behaviour.

The plan is to avoid elements w/ inherit colors in the Card.link (e.g. `<dt>` should become `<dt class="description">`)

