### PR TITLE
Fix: PageBanner for Safari

### DIFF
--- a/src/lib/components/PageBanner.svelte
+++ b/src/lib/components/PageBanner.svelte
@@ -2,17 +2,22 @@
   export let testId: string | undefined = undefined;
 </script>
 
-<div class="container" data-tid={testId}>
-  <div class="image-wrapper">
-    <slot name="image" />
-  </div>
-  <div class="content-wrapper">
-    <div class="banner-content">
-      <h1><slot name="title" /></h1>
-      <slot name="description" />
+<!-- Safari doesn't handle well grid inside flexbox -->
+<!-- https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow -->
+<!-- Wrapping this avoids clients of gix-components having the problem -->
+<div>
+  <div class="container" data-tid={testId}>
+    <div class="image-wrapper">
+      <slot name="image" />
     </div>
-    <div class="banner-actions">
-      <slot name="actions" />
+    <div class="content-wrapper">
+      <div class="banner-content">
+        <h1><slot name="title" /></h1>
+        <slot name="description" />
+      </div>
+      <div class="banner-actions">
+        <slot name="actions" />
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Motivation

The PageBanner as is couldn't go directly inside a flex container because of a height overflow in Safari.

More on the issue: https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow

# Changes

The fix is to add a wrapper around the container of PageBanner.

# Screenshots

No changes.
