### PR TITLE
GIX-1847: Change card disabled color

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -111,8 +111,8 @@
     }
 
     &.disabled {
-      background: var(--input-background);
-      color: rgba(var(--disable-contrast-rgb), 0.8);
+      background: var(--card-background-disabled);
+      color: var(--disable-contrast);
 
       :global(*) {
         color: inherit;

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -129,6 +129,7 @@
   --card-background-contrast-rgb: var(--text-color-rgb);
   --card-background-shade: var(--purple-dark-450);
   --card-background-tint: var(--purple-dark-400);
+  --card-background-disabled: var(--purple-dark-550);
 
   /* Design: Dark/Bg/Background-02 */
   --background: var(--purple-dark-550);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -104,6 +104,7 @@
     --card-background-contrast-rgb: var(--text-color-rgb);
     --card-background-shade: var(--purple-100);
     --card-background-tint: var(--purple-50);
+    --card-background-disabled: var(--purple-125);
 
     /* Design: Light/Bg/Background-01 */
     --background: var(--purple-100);


### PR DESCRIPTION
# Motivation

Change the background color for the disabed cards. Those are used for the landing pages also.

# Changes

* Add a new variable in both themes: `--card-background-disabled`.
* Use new variable in the Card when `disabled`.

# Screenshots

Dark theme (before):
![Screenshot 2023-09-01 at 14 24 10](https://github.com/dfinity/gix-components/assets/4550653/959faf55-c776-438f-82dd-96b911bd2d02)

Dark theme (now):
![Screenshot 2023-09-01 at 14 23 49](https://github.com/dfinity/gix-components/assets/4550653/8ad42c24-a479-47ba-9b38-86d4ecd378a7)

Light theme (before):
![Screenshot 2023-09-01 at 14 24 17](https://github.com/dfinity/gix-components/assets/4550653/649c2d18-4bcf-4d56-9144-e5d564d36e34)

Light theme (now):
![Screenshot 2023-09-01 at 14 23 38](https://github.com/dfinity/gix-components/assets/4550653/7a920daa-616d-49bf-bb14-c9148768491f)

