### PR TITLE
build: copy workers after build instead of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",
-    "build": "npm run i18n && vite build",
+    "build": "npm run i18n && vite build && npm run copy:workers",
     "package": "svelte-kit sync && svelte-package",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -18,7 +18,7 @@
     "e2e:ci": "npm run download:samples && playwright test --reporter=html",
     "e2e:snapshots": "npm run download:samples && npx playwright test --update-snapshots --reporter=list",
     "e2e:report": "npx playwright show-report",
-    "postinstall": "node ./scripts/copy-workers.mjs"
+    "copy:workers": "node ./scripts/copy-workers.mjs"
   },
   "exports": {
     ".": {

--- a/scripts/copy-workers.mjs
+++ b/scripts/copy-workers.mjs
@@ -8,5 +8,11 @@ await cp(
     recursive: true,
     filter: (source, destination) => extname(source) !== ".map",
   },
-  (err) => console.error(err),
+  (err) => {
+    if (err === null) {
+      return;
+    }
+
+    console.error("Copy workers error:", err);
+  },
 );


### PR DESCRIPTION
# Motivation

When we locally install gix-cmp in NNS dapp

```
$ npm install /Users/dskloet/dev/gix-components
```

the installation runs also the pre/post scripts of gix-cmp. As I added a post scripts to copy the web workers for the analyytics of the showcase, this script gets executed which is not necessary.

So to avoid this issue and because we only needs the web workers for the showcase, we can move the script from `postinstall` to a manually call after build.

# Changes

- move script from `postinstall` to `build`
- do not print error in script if no error
