### PR TITLE
build: fix copy workers

### DIFF
--- a/scripts/copy-workers.mjs
+++ b/scripts/copy-workers.mjs
@@ -3,7 +3,7 @@ import { extname } from "node:path";
 
 await cp(
   "node_modules/@junobuild/analytics/dist/workers/",
-  "./static/workers",
+  "./build/workers",
   {
     recursive: true,
     filter: (source, destination) => extname(source) !== ".map",


### PR DESCRIPTION
# Motivation

#289 moved the copy from the workers from `postinstall` to a post build script but, since `static` files are moved to `build` output folders, the post script that copy to `static` has no effect. That's why the script should directly copy the files to the output.
