### PR TITLE
GIX-1864: Add property noPadding on Card

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -57,6 +57,8 @@
   {role}
   data-tid={testId}
   on:click={onClick}
+  on:mouseenter
+  on:mouseleave
   class={`card ${theme ?? ""}`}
   class:clickable
   class:icon={nonNullish(icon)}

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -14,6 +14,7 @@
   export let theme: "transparent" | "framed" | "highlighted" | undefined =
     undefined;
   export let href: string | undefined = undefined;
+  export let noPadding = false;
 
   let container: "article" | "a" = "article";
   $: container = nonNullish(href) ? "a" : "article";
@@ -57,13 +58,12 @@
   {role}
   data-tid={testId}
   on:click={onClick}
-  on:mouseenter
-  on:mouseleave
   class={`card ${theme ?? ""}`}
   class:clickable
   class:icon={nonNullish(icon)}
   class:selected
   class:disabled
+  class:noPadding
   aria-disabled={disabled}
   aria-checked={ariaChecked}
   aria-label={ariaLabel}
@@ -107,6 +107,10 @@
     box-sizing: border-box;
 
     border: var(--card-border-size) solid transparent;
+
+    &.noPadding {
+      padding: 0;
+    }
 
     &.selected {
       border: 2px solid var(--primary);

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -45,9 +45,11 @@ If a property `href` is set, the component renders a hyperlink within the DOM. I
 
 ## Events
 
-| Event   | Description                                | Detail    |
-| ------- | ------------------------------------------ | --------- |
-| `click` | Propagated click event (if not `disabled`. | Inherited |
+| Event        | Description                                 | Detail    |
+| ------------ | ------------------------------------------- | --------- |
+| `click`      | Propagated click event (if not `disabled`). | Inherited |
+| `mouseenter` | Propagated mouse enter event .              | Inherited |
+| `mouseleave` | Propagated mouse leave event.               | Inherited |
 
 ## Styling
 

--- a/src/routes/(split)/components/card/+page.md
+++ b/src/routes/(split)/components/card/+page.md
@@ -30,6 +30,7 @@ Cards are surfaces that display content and optionally actions on a single topic
 | `theme`     | Display a particular theme for surface of the card.                                                                 | `highlighted` or `transparent` or `framed` or `undefined` | `undefined` |
 | `icon`      | Render an icon / call to action next within the card on the right side.                                             | `expand` or `check` or `undefined`                        | `undefined` |
 | `href`      | If the card is intended to function as a link, you can use this property to specify the URL of the linked resource. | `string` or `undefined`                                   | `undefined` |
+| `noPadding` | Remove the default padding inside the card. Useful to catch onhover event with CSS from the content.                | `boolean`                                                 | `false`     |
 
 ### Notes
 
@@ -133,6 +134,12 @@ List of the mixins:
         </div>
 
         <p class="description">A description - Advanced smart contracts process HTTP requests, control other chains, and scale infinitely</p>
+    </Card>
+
+    <Card noPadding>
+        <h3>No padding</h3>
+
+        <p class="description">Example with no padding.</p>
     </Card>
 
 </div>


### PR DESCRIPTION
# Motivation

Fix the poor contrast on the token selector for ICP logo described here: https://dfinity.atlassian.net/browse/GIX-1864

Solution: add a stronger outline to the logo when selected and on hover.

Yet, to be able to know when the card is hovered, we can't rely on the hover of the content because the Card has some padding. Therefore, I'd like to add a `noPadding` prop to the Card component. This way, the child will manage the padding and can also manage the onhover of the whole Card.

# Changes

* Add prop `noPadding` in `Card` component.

# Screenshots

![Screenshot 2023-09-12 at 09 30 51](https://github.com/dfinity/gix-components/assets/4550653/3415ac51-362f-4be1-94fe-71abe48426eb)

