### PR TITLE
Chore: Remove unused text2 color

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -76,7 +76,7 @@
 
   // Custom backgrounds
   --body-background: var(--purple-dark-900);
-  --body-color: var(--text2-color);
+  --body-color: var(--purple-dark-100);
 
   --content-background: var(--purple-dark-600);
   --content-color: var(--text-color);
@@ -93,7 +93,7 @@
   --toast-inverted-background-contrast: var(--purple-dark-900);
 
   // Menu
-  --menu-color: var(--text2-color);
+  --menu-color: var(--purple-dark-100);
   --menu-select-color: var(--value-color);
   --menu-selected-background: var(--purple-dark-500);
 
@@ -104,9 +104,6 @@
   --theme-color: var(--card-background);
 
   // Palette
-
-  /* Light/Text/Text-02 */
-  --text2-color: var(--purple-dark-100);
 
   /* Light/Text/Text-xx? */
   --text-color: var(--purple-dark-50);


### PR DESCRIPTION
# Motivation

Color `--text2-color` was only set in dark mode and that caused an issue that was solved https://github.com/dfinity/nns-dapp/pull/3306

In this PR, this color is removed and the two references are substituted with the primitive color.

This has been agreed with Artem.

# Changes

* Remove `--text2-color` from dark colors and change references to primitive color.

# Screenshots

No changes. It wasn't used in any component.
