### PR TITLE
build: bump analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,15 +7,14 @@
     "": {
       "name": "@dfinity/gix-components",
       "version": "2.7.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@junobuild/analytics": "^0.0.9",
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       },
       "devDependencies": {
-        "@junobuild/analytics": "^0.0.5",
         "@playwright/test": "^1.32.2",
         "@sveltejs/adapter-static": "^2.0.2",
         "@sveltejs/kit": "^1.18.0",
@@ -1163,10 +1162,9 @@
       }
     },
     "node_modules/@junobuild/analytics": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.5.tgz",
-      "integrity": "sha512-3RQqke/buPM804OpbwJk5iz0Dq77Y03nctrP6lhYLKXtQZB7dL47yoY7EIyk49skU7TxHicLW8+hdsYAfHJceg==",
-      "dev": true,
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.9.tgz",
+      "integrity": "sha512-Gd3F/Dmx6OfjKN91DsCcOX8VMdgEpvfyny5jJt/uONezIbjjL6q7gnyIND4uUCwQ8Max9wgIvA5TOdwP4X2+vg==",
       "dependencies": {
         "@junobuild/utils": "*",
         "idb-keyval": "^6.2.1",
@@ -1178,7 +1176,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
       "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1193,10 +1190,9 @@
       }
     },
     "node_modules/@junobuild/utils": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.8.tgz",
-      "integrity": "sha512-F3YfMfJNmXguIqH9RnuuCO774ICDhju/GkACmnAC+AgslYhQZcN6kat1CPL0XUxY56moPfcALPmKiOlit8wbMg==",
-      "dev": true
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.12.tgz",
+      "integrity": "sha512-jUzuVYa/kGeWnSJ/Jv+B9y5COQaZfh5Tc8auy/bDsSeuMnHR9J9ye0EQ8fVDXJWKcFFfLyTcKu94eO+O2mA17Q=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3588,8 +3584,7 @@
     "node_modules/idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
-      "dev": true
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -3736,7 +3731,6 @@
       "version": "3.6.13",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.13.tgz",
       "integrity": "sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -6877,10 +6871,9 @@
       }
     },
     "@junobuild/analytics": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.5.tgz",
-      "integrity": "sha512-3RQqke/buPM804OpbwJk5iz0Dq77Y03nctrP6lhYLKXtQZB7dL47yoY7EIyk49skU7TxHicLW8+hdsYAfHJceg==",
-      "dev": true,
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.9.tgz",
+      "integrity": "sha512-Gd3F/Dmx6OfjKN91DsCcOX8VMdgEpvfyny5jJt/uONezIbjjL6q7gnyIND4uUCwQ8Max9wgIvA5TOdwP4X2+vg==",
       "requires": {
         "@junobuild/utils": "*",
         "idb-keyval": "^6.2.1",
@@ -6891,16 +6884,14 @@
         "nanoid": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-          "dev": true
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
         }
       }
     },
     "@junobuild/utils": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.8.tgz",
-      "integrity": "sha512-F3YfMfJNmXguIqH9RnuuCO774ICDhju/GkACmnAC+AgslYhQZcN6kat1CPL0XUxY56moPfcALPmKiOlit8wbMg==",
-      "dev": true
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.12.tgz",
+      "integrity": "sha512-jUzuVYa/kGeWnSJ/Jv+B9y5COQaZfh5Tc8auy/bDsSeuMnHR9J9ye0EQ8fVDXJWKcFFfLyTcKu94eO+O2mA17Q=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8648,8 +8639,7 @@
     "idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
-      "dev": true
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -8751,8 +8741,7 @@
     "isbot": {
       "version": "3.6.13",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.13.tgz",
-      "integrity": "sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg==",
-      "dev": true
+      "integrity": "sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg=="
     },
     "isexe": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@junobuild/analytics": "^0.0.9",
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       },
       "devDependencies": {
+        "@junobuild/analytics": "^0.0.9",
         "@playwright/test": "^1.32.2",
         "@sveltejs/adapter-static": "^2.0.2",
         "@sveltejs/kit": "^1.18.0",
@@ -1165,6 +1165,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.9.tgz",
       "integrity": "sha512-Gd3F/Dmx6OfjKN91DsCcOX8VMdgEpvfyny5jJt/uONezIbjjL6q7gnyIND4uUCwQ8Max9wgIvA5TOdwP4X2+vg==",
+      "dev": true,
       "dependencies": {
         "@junobuild/utils": "*",
         "idb-keyval": "^6.2.1",
@@ -1176,6 +1177,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
       "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1192,7 +1194,8 @@
     "node_modules/@junobuild/utils": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.12.tgz",
-      "integrity": "sha512-jUzuVYa/kGeWnSJ/Jv+B9y5COQaZfh5Tc8auy/bDsSeuMnHR9J9ye0EQ8fVDXJWKcFFfLyTcKu94eO+O2mA17Q=="
+      "integrity": "sha512-jUzuVYa/kGeWnSJ/Jv+B9y5COQaZfh5Tc8auy/bDsSeuMnHR9J9ye0EQ8fVDXJWKcFFfLyTcKu94eO+O2mA17Q==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3584,7 +3587,8 @@
     "node_modules/idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "dev": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -3731,6 +3735,7 @@
       "version": "3.6.13",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.13.tgz",
       "integrity": "sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -6874,6 +6879,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.9.tgz",
       "integrity": "sha512-Gd3F/Dmx6OfjKN91DsCcOX8VMdgEpvfyny5jJt/uONezIbjjL6q7gnyIND4uUCwQ8Max9wgIvA5TOdwP4X2+vg==",
+      "dev": true,
       "requires": {
         "@junobuild/utils": "*",
         "idb-keyval": "^6.2.1",
@@ -6884,14 +6890,16 @@
         "nanoid": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+          "dev": true
         }
       }
     },
     "@junobuild/utils": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.12.tgz",
-      "integrity": "sha512-jUzuVYa/kGeWnSJ/Jv+B9y5COQaZfh5Tc8auy/bDsSeuMnHR9J9ye0EQ8fVDXJWKcFFfLyTcKu94eO+O2mA17Q=="
+      "integrity": "sha512-jUzuVYa/kGeWnSJ/Jv+B9y5COQaZfh5Tc8auy/bDsSeuMnHR9J9ye0EQ8fVDXJWKcFFfLyTcKu94eO+O2mA17Q==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8639,7 +8647,8 @@
     "idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -8741,7 +8750,8 @@
     "isbot": {
       "version": "3.6.13",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.13.tgz",
-      "integrity": "sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg=="
+      "integrity": "sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@junobuild/analytics": "^0.0.5",
     "@playwright/test": "^1.32.2",
     "@sveltejs/adapter-static": "^2.0.2",
     "@sveltejs/kit": "^1.18.0",
@@ -65,6 +64,7 @@
     "vitest": "^0.33.0"
   },
   "dependencies": {
+    "@junobuild/analytics": "^0.0.9",
     "dompurify": "^3.0.4",
     "html5-qrcode": "^2.3.8",
     "qr-creator": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "LICENSE"
   ],
   "devDependencies": {
+    "@junobuild/analytics": "^0.0.9",
     "@playwright/test": "^1.32.2",
     "@sveltejs/adapter-static": "^2.0.2",
     "@sveltejs/kit": "^1.18.0",
@@ -64,7 +65,6 @@
     "vitest": "^0.33.0"
   },
   "dependencies": {
-    "@junobuild/analytics": "^0.0.9",
     "dompurify": "^3.0.4",
     "html5-qrcode": "^2.3.8",
     "qr-creator": "^1.0.0"


### PR DESCRIPTION
# Motivation

There were major improvements in the Juno's analytics canister to improve scalability of the data. Those changes lead to few structure changes in the keys and entities which are reflected in the last version of the library.

So we need to bump the library to reactive the analytics for gix-cmp.
