### PR TITLE
build: fix running e2e locally with staging build env

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "npm run i18n && vite dev",
     "build": "npm run i18n && vite build && npm run copy:workers",
+    "staging": "npm run i18n && vite build --mode staging && npm run copy:workers",
     "package": "svelte-kit sync && svelte-package",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { devices } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
   webServer: {
-    command: "npm run build && npm run preview",
+    command: "npm run staging && npm run preview",
     port: 4173,
   },
   testDir: "e2e",

--- a/src/docs/services/analytics.services.ts
+++ b/src/docs/services/analytics.services.ts
@@ -2,8 +2,9 @@ import { initOrbiter } from "@junobuild/analytics";
 
 export const initAnalytics = async () => {
   const DEV = import.meta.env.DEV;
+  const STAGING = import.meta.env.MODE === "staging";
 
-  if (DEV) {
+  if (DEV || STAGING) {
     return;
   }
 


### PR DESCRIPTION
# Motivation

Fix e2e error `[WebServer] Error: Not found: /components/workers/analytics.worker.js` by introducing a staging mode that can be use to build and run the test in order to avoid loading the analytics.

# Changes

- add mode `stagin`
- build test with staging instead of build
- don't load anyltics on staging
