### PR TITLE
testId on Island component

### DIFF
--- a/src/lib/components/Island.svelte
+++ b/src/lib/components/Island.svelte
@@ -3,6 +3,8 @@
   import { layoutContentScrollY } from "../stores/layout.store";
   import { BREAKPOINT_LARGE } from "../constants/constants";
 
+  export let testId: string | undefined = undefined;
+
   let innerWidth = 0;
   $: innerWidth,
     layoutContentScrollY.set(innerWidth < BREAKPOINT_LARGE ? "auto" : "hidden");
@@ -12,7 +14,7 @@
 
 <svelte:window bind:innerWidth />
 
-<div class="island">
+<div class="island" data-tid={testId}>
   <div class="scrollable-island">
     <slot />
   </div>


### PR DESCRIPTION
# Motivation

I want to be able to make page objects for components which have an `<Island>` as their outer most element.
For this I need to be able to test a `data-tid` attribute on the outer element.

# Changes

Add a `testId` prop to `Island` which sets a `data-tid` attribute on the outer `div`.