### PR TITLE
Key value info align icon right

### DIFF
--- a/src/lib/components/KeyValuePair.svelte
+++ b/src/lib/components/KeyValuePair.svelte
@@ -35,5 +35,6 @@
     display: flex;
     align-items: center;
     margin-inline-start: 0;
+    text-align: right;
   }
 </style>

--- a/src/lib/components/KeyValuePairInfo.svelte
+++ b/src/lib/components/KeyValuePairInfo.svelte
@@ -5,6 +5,7 @@
   import { nonNullish } from "@dfinity/utils";
 
   export let testId: string | undefined = undefined;
+  export let alignIconRight = false;
 
   let toggleContent: () => void;
 </script>
@@ -15,15 +16,24 @@
   externalToggle={true}
   bind:toggleContent
 >
-  <KeyValuePair slot="header">
+  <KeyValuePair slot="header" {alignIconRight}>
     <div class="wrapper" slot="key">
       <slot name="key" />
-      <button class="icon" on:click|stopPropagation={toggleContent}>
-        <IconInfo />
-      </button>
+      {#if !alignIconRight}
+        <button class="icon" on:click|stopPropagation={toggleContent}>
+          <IconInfo />
+        </button>
+      {/if}
     </div>
 
-    <svelte:fragment slot="value"><slot name="value" /></svelte:fragment>
+    <svelte:fragment slot="value">
+      <slot name="value" />
+      {#if alignIconRight}
+        <button class="icon alignIconRight" on:click|stopPropagation={toggleContent}>
+          <IconInfo />
+        </button>
+      {/if}
+    </svelte:fragment>
   </KeyValuePair>
 
   <p
@@ -47,6 +57,11 @@
     align-items: center;
     justify-content: center;
     padding: 0;
+
+    &.alignIconRight {
+      padding-left: var(--padding-0_5x);
+      align-self: start;
+    }
   }
 
   p {

--- a/src/routes/(split)/components/key-value-info/+page.md
+++ b/src/routes/(split)/components/key-value-info/+page.md
@@ -21,9 +21,10 @@ As [KeyValuePair](/components/key-value), this component renders a value and a l
 
 ## Properties
 
-| Property | Description                                                     | Type                    | Default     |
-| -------- | --------------------------------------------------------------- | ----------------------- | ----------- |
-| `testId` | Add a `data-tid` attribute to the DOM, useful for test purpose. | `string` or `undefined` | `undefined` |
+| Property         | Description                                                     | Type                     | Default     |
+| ---------------- | --------------------------------------------------------------- | ------------------------ | ----------- |
+| `testId`         | Add a `data-tid` attribute to the DOM, useful for test purpose. | `string` or `undefined`  | `undefined` |
+| `alignIconRight` | When true the info icon will be rendered on the right side.     | `boolean` or `undefined` | `false`     |
 
 ## Slots
 
@@ -35,8 +36,26 @@ As [KeyValuePair](/components/key-value), this component renders a value and a l
 
 ## Showcase
 
+### Default
+
 <KeyValuePairInfo>
   <svelte:fragment slot="key">How many apples?</svelte:fragment>
   <span slot="value" class="value">8</span>
+  <svelte:fragment slot="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia turpis mi, a facilisis risus elementum eu.</svelte:fragment>
+</KeyValuePairInfo>
+
+### alignIconRight
+
+<KeyValuePairInfo alignIconRight>
+  <svelte:fragment slot="key">How many apples?</svelte:fragment>
+  <span slot="value" class="value">8</span>
+  <svelte:fragment slot="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia turpis mi, a facilisis risus elementum eu.</svelte:fragment>
+</KeyValuePairInfo>
+
+<br>
+
+<KeyValuePairInfo alignIconRight>
+  <svelte:fragment slot="key">Demo container ID</svelte:fragment>
+  <span slot="value" class="value">tcszx-rqbbb-aaaaa-aabyq-cai</span>
   <svelte:fragment slot="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur lacinia turpis mi, a facilisis risus elementum eu.</svelte:fragment>
 </KeyValuePairInfo>


### PR DESCRIPTION
# Motivation

Add property `alignIconRight` to align info icons to the right

# Changes

- alignIconRight
- align value text right to improve long text alignment (mobile screenshot)

# Screenshots

## Mobile
<img width="379" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/d39162b9-8dbf-4b9b-8944-bed8a813ace9">

## Desktop
<img width="721" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/3f930900-b9a2-43d3-98b0-513d240d427b">


