### PR TITLE
style: add `tag` utility class

### DIFF
--- a/src/lib/components/Tag.svelte
+++ b/src/lib/components/Tag.svelte
@@ -10,30 +10,10 @@
 >
 
 <style lang="scss">
-  @use "../styles/mixins/fonts";
-
   .tag {
-    border-radius: var(--border-radius-0_5x);
-
-    display: flex;
-    align-items: center;
-    gap: var(--padding-0_5x);
-    
-    // Force fit-content for `li` tags.
-    width: fit-content;
-    padding: var(--padding-0_5x) var(--padding);
-
     // "info" intent is the default
     background-color: var(--elements-divider);
     color: var(--text-description);
-
-    &.large {
-      @include fonts.standard;
-    }
-
-    &.medium {
-      @include fonts.small;
-    }
 
     &.success {
       background-color: var(--positive-emphasis);
@@ -49,9 +29,5 @@
       background-color: var(--negative-emphasis);
       color: var(--text-light);
     }
-  }
-
-  li.tag {
-    display: list-item;
   }
 </style>

--- a/src/lib/components/Tag.svelte
+++ b/src/lib/components/Tag.svelte
@@ -5,7 +5,7 @@
   export let testId = "tag";
 </script>
 
-<svelte:element this={tagName} data-tid={testId} class={`tag ${size} ${intent}`}
+<svelte:element this={tagName} data-tid={testId} class={`tag ${size === "large" ? "tag--large" : ""} ${intent}`}
   ><slot /></svelte:element
 >
 

--- a/src/lib/styles/global.scss
+++ b/src/lib/styles/global.scss
@@ -5,6 +5,7 @@
 @import "./global/layout.scss";
 @import "./global/button.scss";
 @import "./global/link.scss";
+@import "./global/tag.scss";
 @import "./global/modal.scss";
 @import "./global/grid.scss";
 @import "./global/utility-classes.scss";

--- a/src/lib/styles/global/tag.scss
+++ b/src/lib/styles/global/tag.scss
@@ -16,7 +16,7 @@
   background-color: var(--content-background);
   color: var(--text-color);
 
-  &.large {
+  &.tag--large {
     @include fonts.standard;
   }
 }

--- a/src/lib/styles/global/tag.scss
+++ b/src/lib/styles/global/tag.scss
@@ -1,0 +1,26 @@
+@use "../mixins/fonts";
+
+.tag {
+  @include fonts.small;
+  border-radius: var(--border-radius-0_5x);
+
+  display: flex;
+  align-items: center;
+  gap: var(--padding-0_5x);
+
+  // Force fit-content for `li` tags.
+  width: fit-content;
+  padding: var(--padding-0_5x) var(--padding);
+
+  // "info" intent is the default
+  background-color: var(--content-background);
+  color: var(--text-color);
+
+  &.large {
+    @include fonts.standard;
+  }
+}
+
+li.tag {
+  display: list-item;
+}

--- a/src/routes/(page)/utility-classes/+page.svelte
+++ b/src/routes/(page)/utility-classes/+page.svelte
@@ -42,4 +42,10 @@
 
     <p>Format figures for display purpose.</p>
   </Card>
+
+  <Card href="/utility-classes/tag">
+    <h2 class="title" slot="start">Tag</h2>
+
+    <p>Tag styles.</p>
+  </Card>
 </div>

--- a/src/routes/(page)/utility-classes/tag/+page.md
+++ b/src/routes/(page)/utility-classes/tag/+page.md
@@ -3,18 +3,20 @@
 
 # Tag
 
-Apply tag styles to any element.
+Apply tag styles to any element. Used in the [Tag component](/components/tag).
 
-## Note
+## Usage
 
-Used in the [Tag](/components/tag) component.
+| Type       | CSS class    |
+|------------|--------------|
+| Size large | `tag--large` |
 
 ## Showcase
 
 | Styles                                        | Disabled                                    |
-| --------------------------------------------- | ------------------------------------------- |
+|-----------------------------------------------|---------------------------------------------|
 | `<div class="tag">Default</div>`              | <div class="tag">Default</div>              |
-| `<div class="tag large">Default</div>`        | <div class="tag large">Large</div>          |
+| `<div class="tag tag--large">Default</div>`   | <div class="tag tag--large">Large</div>     |
 | `<div class="tag custom-color">Default</div>` | <div class="tag custom-color">Default</div> |
 
 <style lang="scss">

--- a/src/routes/(page)/utility-classes/tag/+page.md
+++ b/src/routes/(page)/utility-classes/tag/+page.md
@@ -1,0 +1,25 @@
+<script lang="ts">
+</script>
+
+# Tag
+
+Apply tag styles to any element.
+
+## Note
+
+Used in the [Tag](/components/tag) component.
+
+## Showcase
+
+| Styles                                        | Disabled                                    |
+| --------------------------------------------- | ------------------------------------------- |
+| `<div class="tag">Default</div>`              | <div class="tag">Default</div>              |
+| `<div class="tag large">Default</div>`        | <div class="tag large">Large</div>          |
+| `<div class="tag custom-color">Default</div>` | <div class="tag custom-color">Default</div> |
+
+<style lang="scss">
+  .custom-color {
+      background-color: var(--warning-emphasis);
+      color: var(--warning-emphasis-contrast);
+  }
+</style>

--- a/src/routes/(page)/utility-classes/tag/+page.md
+++ b/src/routes/(page)/utility-classes/tag/+page.md
@@ -8,13 +8,13 @@ Apply tag styles to any element. Used in the [Tag component](/components/tag).
 ## Usage
 
 | Type       | CSS class    |
-|------------|--------------|
+| ---------- | ------------ |
 | Size large | `tag--large` |
 
 ## Showcase
 
 | Styles                                        | Disabled                                    |
-|-----------------------------------------------|---------------------------------------------|
+| --------------------------------------------- | ------------------------------------------- |
 | `<div class="tag">Default</div>`              | <div class="tag">Default</div>              |
 | `<div class="tag tag--large">Default</div>`   | <div class="tag tag--large">Large</div>     |
 | `<div class="tag custom-color">Default</div>` | <div class="tag custom-color">Default</div> |


### PR DESCRIPTION
# Motivation

Add `tag` utility class to be more customisable (e.g. themed colours).

# Changes

- new utility class
- refactor `Tag` component to use `tag` class

# Screenshots

## Doc page
<img width="789" alt="Screenshot 2023-10-17 at 13 18 55" src="https://github.com/dfinity/gix-components/assets/98811342/04b36574-0dea-4e63-8d56-2a6bdcf793cc">

## In nns-dapp
<img width="640" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/7965753c-affb-4f4b-9de0-bdf632932cb0">

