### PR TITLE
fix: layout-bottom-offset wrong value

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -16,7 +16,7 @@
 
 <div
   class="content"
-  style={`--layout-bottom-offset: ${$layoutBottomOffset}px; --content-overflow-y: ${$layoutContentScrollY}`}
+  style={`--layout-bottom-offset: calc(${$layoutBottomOffset}px - var(--content-margin)); --content-overflow-y: ${$layoutContentScrollY}`}
 >
   <Header {back} on:nnsBack>
     <slot name="title" slot="title" />

--- a/src/lib/styles/mixins/_layout.scss
+++ b/src/lib/styles/mixins/_layout.scss
@@ -1,6 +1,8 @@
 @use "./media";
 
 @mixin content {
+  --content-margin: var(--padding);
+
   position: relative;
   width: 100%;
 
@@ -15,7 +17,7 @@
   border-radius: var(--border-radius-2x);
 
   box-sizing: border-box;
-  margin: var(--padding);
+  margin: var(--content-margin);
   padding-top: 0;
 
   // If a bottom sheet is displayed the content pane height should be updated accordingly


### PR DESCRIPTION
# Motivation

Remove unexpected border on proposal detail page by fixing the bottom-offset calculation.

# Changes

- new global variable `--content-margin` 
- update `--layout-bottom-offset` calculation in `Content.svelte`
Note: this variable is also used by `SplitContent` and `Toast` but it's always `0`.

# Screenshots

## Before
<img width="440" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/2cb424b3-9026-48ac-ae90-5b4a5b1ce95a">

## After
![before](https://github.com/dfinity/gix-components/assets/98811342/e91ec43b-4e9a-43c3-bc65-3fca95cb7b29)

![after](https://github.com/dfinity/gix-components/assets/98811342/90ee83a5-c725-4f50-94c6-68ed5a97bc6f)




