### PR TITLE
build: fix prettier format command not processing svelte files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write './**/*.{ts,js,mjs,json,scss,svelte,html}'",
+    "format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}'",
     "test": "vitest --config ./vitest.config.ts",
     "download:samples": "./scripts/download-samples.sh",
     "i18n": "node scripts/i18n.types.mjs && prettier --write ./src/lib/types/i18n.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write .",
+    "format": "prettier --write './**/*.{ts,js,mjs,json,scss,svelte,html}'",
     "test": "vitest --config ./vitest.config.ts",
     "download:samples": "./scripts/download-samples.sh",
     "i18n": "node scripts/i18n.types.mjs && prettier --write ./src/lib/types/i18n.d.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check . && eslint .",
+    "lint": "prettier --check './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}' && eslint .",
     "format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}'",
     "test": "vitest --config ./vitest.config.ts",
     "download:samples": "./scripts/download-samples.sh",

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -23,10 +23,10 @@
 
   const onIntersection = (
     entries: IntersectionObserverEntry[],
-    observer: IntersectionObserver
+    observer: IntersectionObserver,
   ) => {
     const intersecting: IntersectionObserverEntry | undefined = entries.find(
-      ({ isIntersecting }: IntersectionObserverEntry) => isIntersecting
+      ({ isIntersecting }: IntersectionObserverEntry) => isIntersecting,
     );
 
     if (isNullish(intersecting)) {
@@ -41,7 +41,7 @@
 
   const observer: IntersectionObserver = new IntersectionObserver(
     onIntersection,
-    options
+    options,
   );
 
   // Svelte workaround: beforeUpdate is called twice when bindings are used -> https://github.com/sveltejs/svelte/issues/6016

--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -89,7 +89,8 @@
       margin-left: 0;
     }
 
-    transition: margin-left var(--animation-time-normal)
+    transition:
+      margin-left var(--animation-time-normal)
         var(--menu-animation-timing-function),
       width var(--animation-time-normal) var(--menu-animation-timing-function);
 

--- a/src/lib/components/ProgressBar.svelte
+++ b/src/lib/components/ProgressBar.svelte
@@ -76,7 +76,7 @@
       border-radius: var(--current-height);
       box-shadow: var(--input-box-shadow);
       border: 0;
-      
+
       &::-moz-progress-bar {
         background-color: #fff;
         box-shadow: var(--input-box-shadow);

--- a/src/lib/components/QRCode.svelte
+++ b/src/lib/components/QRCode.svelte
@@ -90,7 +90,7 @@
         // We draw the canvas larger and scale its container down to avoid blurring on high-density displays
         size: size.width * 2,
       },
-      canvas
+      canvas,
     );
 
     dispatch("nnsQRCodeRendered");

--- a/src/lib/components/Tag.svelte
+++ b/src/lib/components/Tag.svelte
@@ -5,7 +5,10 @@
   export let testId = "tag";
 </script>
 
-<svelte:element this={tagName} data-tid={testId} class={`tag ${size === "large" ? "tag--large" : ""} ${intent}`}
+<svelte:element
+  this={tagName}
+  data-tid={testId}
+  class={`tag ${size === "large" ? "tag--large" : ""} ${intent}`}
   ><slot /></svelte:element
 >
 

--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -8,7 +8,7 @@
 
   let toasts: ToastMsg[] = [];
   $: toasts = $toastsStore.filter(
-    ({ position: pos }) => (pos ?? "bottom") === position
+    ({ position: pos }) => (pos ?? "bottom") === position,
   );
 
   let hasErrors: boolean;


### PR DESCRIPTION
# Motivation

I noticed that Svelte files are not included in the `format` script anymore.

Opened an issue in the Svelte prettier plugin: https://github.com/sveltejs/prettier-plugin-svelte/issues/407

Meanwhile enforcing the types of the file to format solve the issue.
