### PR TITLE
Chore: Export breakpoint constants

### DIFF
--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -1,5 +1,9 @@
 export const DEFAULT_ICON_SIZE = 20;
 
+// 576 is the CSS $breakpoint-small size
+export const BREAKPOINT_SMALL = 576;
+// 768 is the CSS $breakpoint-medium size
+export const BREAKPOINT_MEDIUM = 768;
 // 1024 is the CSS $breakpoint-large size
 export const BREAKPOINT_LARGE = 1024;
 // 1300 is the CSS $breakpoint-extra-large size


### PR DESCRIPTION
# Motivation

Export the rest of the breakpoints as JS constants.

# Changes

* Add `BREAKPOINT_SMALL` and `BREAKPOINT_MEDIUM` to `constants.ts`.

# Screenshots

No changes.