### PR TITLE
Chore: Expose new color variable

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -9,6 +9,7 @@
   --text-light: var(--purple-50);
   --text-text: var(--purple-900);
   --input-focus-background: var(--purple-dark-450);
+  --popup-background-tint: var(--purple-dark-450);
   --button-primary: var(--purple-dark-accent);
 
   // -------- OLD CSS VARIABLES ----------------

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -10,6 +10,7 @@
     --text-light: var(--purple-50);
     --text-text: var(--purple-900);
     --input-focus-background: var(--purple-75);
+    --popup-background-tint: var(--purple-75);
     --button-primary: var(--purple-accent);
 
     // -------- OLD CSS VARIABLES ----------------


### PR DESCRIPTION
# Motivation

Expose new color variable as set in Figma: https://www.figma.com/file/P4JbeFs6oGt2WmKeB4PHFc/Updated-NNS-Styles-%26-Components?type=design&node-id=514-220550&mode=design&t=I8mRm6HgwcW02Ef7-0

This is used in the [Tokens page](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=373-21&mode=design&t=yMJ0wTfcUlUV5uxt-0).

# Changes

* Add `--popup-background-tint` to CSS variables.

# Screenshots

No changes.
