### PR TITLE
Add pending orange color constants

### DIFF
--- a/src/lib/styles/global/colors.scss
+++ b/src/lib/styles/global/colors.scss
@@ -44,7 +44,7 @@
   --blue-tint: #c1d4f1;
   --orange: #e38b1b;
   --orange-mid: #fdc087;
-  --orange-tint: #f3dd8b;
+  --orange-tint: #f3ddbb;
   --green-dark: #3c586d;
   --green: #30af91;
   --green-tint: #c7e3e1;

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -152,5 +152,8 @@
     --positive-emphasis-light: var(--green-tint);
     --negative-emphasis: var(--pink);
     --negative-emphasis-contrast: var(--purple-50);
+
+    --pending-color: var(--orange);
+    --pending-background: var(--orange-tint);
   }
 }


### PR DESCRIPTION
# Motivation

Making color constants available to render icons like this:
<img width="740" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/15bcc4fa-ea1e-4864-8377-b5ac36649201">

Also the existing color of `--orange-tint` does not quite match what is defined in Figma.

# Changes

1. Fix the value of `--orange-tint`.
2. Define `--pending-color` and `--pending-background`.