### PR TITLE
Some more color constants

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -15,6 +15,12 @@
   --table-row-background: var(--purple-dark-550);
   --table-row-background-hover: var(--purple-dark-500);
 
+  --check: var(--green);
+  --check-tint: var(--green-dark);
+  --pending-color: var(--orange-mid);
+  --pending-background: var(--deep-violet-tint);
+  --island-card-background: var(--purple-dark-550);
+
   // -------- OLD CSS VARIABLES ----------------
   // Shadows
   // TODO-colors: Remove along the dark shadows.

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -16,6 +16,12 @@
     --table-row-background: var(--purple-75);
     --table-row-background-hover: var(--purple-100);
 
+    --check: var(--green);
+    --check-tint: var(--green-tint);
+    --pending-color: var(--orange);
+    --pending-background: var(--orange-tint);
+    --island-card-background: var(--purple-125);
+
     // -------- OLD CSS VARIABLES ----------------
     // Shadows
     // TODO-colors: Remove along the dark shadows.
@@ -152,8 +158,5 @@
     --positive-emphasis-light: var(--green-tint);
     --negative-emphasis: var(--pink);
     --negative-emphasis-contrast: var(--purple-50);
-
-    --pending-color: var(--orange);
-    --pending-background: var(--orange-tint);
   }
 }


### PR DESCRIPTION
# Motivation

1. When I added pending orange colors in https://github.com/dfinity/gix-components/pull/334, I forgot to add them to the dark theme.
2. In NNS-dapp we have an explicit [selector for dark theme](https://github.com/dfinity/nns-dapp/blob/39ce835d00c876698d60df839743f70b98dc3eb9/frontend/src/lib/components/accounts/TransactionCard.svelte#L152C3-L152C28) in the `TransactionCard`. Instead we should use themed color constants. Otherwise the dark theme selector has higher specificity than the `.pending` selector and pending transaction won't be styled properly on the dark them.
3. I need a constant for the background color of [this card component](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=475-5799&mode=design&t=N3yI2FVqKa2H2zmw-4).

# Changes

1. Move `--pending-color` and `--pending-background` that were added in https://github.com/dfinity/gix-components/pull/334 to the `NEW CSS VARIABLES` section.
2. Add missing `--pending-color` and `--pending-background` to the dark theme.
3. Add `--check` and `--check-tint` to be used for the receive icon as defined [here](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=475-5516&mode=design&t=N3yI2FVqKa2H2zmw-4).
4. Add `--island-card-background` for the card component mentioned above.

# Screenshots

Used in an NNS branch:

On light theme:
<img width="789" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/a4c2db03-3f98-436f-b504-992992f4d944">


On dark theme:
<img width="792" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/ae7aef59-d5d9-4e75-87f0-5f0b559956a6">

