### PR TITLE
Alert color variables

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -15,6 +15,8 @@
   --table-row-background: var(--purple-dark-550);
   --table-row-background-hover: var(--purple-dark-500);
 
+  --alert: var(--pink);
+  --alert-tint: var(--deep-violet-tint);
   --check: var(--green);
   --check-tint: var(--green-dark);
   --pending-color: var(--orange-mid);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -16,6 +16,8 @@
     --table-row-background: var(--purple-75);
     --table-row-background-hover: var(--purple-100);
 
+    --alert: var(--pink);
+    --alert-tint: var(--pink-tint);
     --check: var(--green);
     --check-tint: var(--green-tint);
     --pending-color: var(--orange);


### PR DESCRIPTION
# Motivation

Add themed color variables for failed transaction icons.

# Changes

Added `--alert` and `--alert-tint` variables to the light and dark them, as defined in [Figma](https://www.figma.com/file/P4JbeFs6oGt2WmKeB4PHFc/NNS-Styles-%26-Components?type=design&node-id=514-220550&mode=design&t=MnmKeOhX8YnM2gH6-0).

# Screenshots

Screenshot from NNS dapp branch where I used these variables:
<img width="784" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/8b4a601d-a7f0-445b-86a7-9b9c4118164c">

<img width="781" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/f762f62c-4746-4a7e-ab25-8f61c7a1bf86">

