### PR TITLE
style: content-cell-island--highlighted style

### DIFF
--- a/src/lib/styles/global/utility-classes.scss
+++ b/src/lib/styles/global/utility-classes.scss
@@ -44,6 +44,11 @@
 
   padding: var(--padding-2x);
   border-radius: var(--border-radius);
+
+  &--highlighted {
+    background: var(--card-background-disabled);
+    color: var(--description-color);
+  }
 }
 
 // Spacing

--- a/src/lib/styles/global/utility-classes.scss
+++ b/src/lib/styles/global/utility-classes.scss
@@ -44,11 +44,13 @@
 
   padding: var(--padding-2x);
   border-radius: var(--border-radius);
+}
 
-  &--highlighted {
-    background: var(--card-background-disabled);
-    color: var(--description-color);
-  }
+.content-cell-island__card {
+  @extend .content-cell-island;
+
+  background: var(--island-card-background);
+  color: var(--description-color);
 }
 
 // Spacing

--- a/src/routes/(page)/utility-classes/cells/+page.md
+++ b/src/routes/(page)/utility-classes/cells/+page.md
@@ -41,10 +41,21 @@ Some pre-defined utilities to set spaces for grid's cells.
     </div>
 
     <div class="content-b content-cell-island">
+        <code>class="content-cell-island"</code>
         <h2 class="content-cell-title">Lorem ipsum</h2>
 
         <div class="content-cell-details">
             <DocsLoremIpsum length={2} />
+        </div>
+
+        <div class="content-cell-details">
+            <DocsLoremIpsum length={1} />
+
+            <div class="content-cell-island content-cell-island--highlighted">
+                <code>class="content-cell-island content-cell-island--highlighted"</code>
+                <DocsLoremIpsum length={1} />
+            </div>
+
         </div>
     </div>
 

--- a/src/routes/(page)/utility-classes/cells/+page.md
+++ b/src/routes/(page)/utility-classes/cells/+page.md
@@ -51,8 +51,8 @@ Some pre-defined utilities to set spaces for grid's cells.
         <div class="content-cell-details">
             <DocsLoremIpsum length={1} />
 
-            <div class="content-cell-island content-cell-island--highlighted">
-                <code>class="content-cell-island content-cell-island--highlighted"</code>
+            <div class="content-cell-island__card">
+                <code>class="content-cell-island__card"</code>
                 <DocsLoremIpsum length={1} />
             </div>
 


### PR DESCRIPTION
# Motivation

Add `content-cell-island__card` style to replace multiple custom styles (ex. `markdown-container`) in `nns-dapp`. 

# Changes

- class `content-cell-island__card`

# Screenshots

<img width="422" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/ea2bbb47-ad60-4045-b63f-e208f82ec5f7">