### PR TITLE
build: adapt alias for sveltekit v2

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,6 +15,9 @@ const config = {
 
   kit: {
     adapter: adapter(),
+    alias: {
+      $docs: "./src/docs",
+    },
     serviceWorker: {
       register: false,
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true,
-    "paths": {
-      "$lib": ["./src/lib"],
-      "$lib/*": ["./src/lib/*"],
-      "$docs": ["./src/docs"],
-      "$docs/*": ["./src/docs/*"]
-    }
+    "strict": true
   },
   "exclude": [
     "src/stories/**/*",


### PR DESCRIPTION
# Motivation

Resolve lint warning:

> You have specified a baseUrl and/or paths in your tsconfig.json which interferes with SvelteKit's auto-generated tsconfig.json. Remove it to avoid problems with intellisense. For path aliases, use `kit.alias` instead: https://kit.svelte.dev/docs/configuration#alias

<img width="1123" alt="Capture d’écran 2023-12-30 à 09 01 20" src="https://github.com/dfinity/gix-components/assets/16886711/62bf1050-86ab-4005-864a-ffe27f203b71">
