### PR TITLE
Feat: Remove z-index from button

### DIFF
--- a/src/lib/styles/global/button.scss
+++ b/src/lib/styles/global/button.scss
@@ -9,8 +9,6 @@ button {
 
   &.ghost,
   &.text {
-    z-index: var(--z-index);
-
     width: fit-content;
 
     @include fonts.standard;


### PR DESCRIPTION
# Motivation

There is an issue with the content of the button going over another element.

![Screenshot 2024-01-12 at 11 43 17](https://github.com/dfinity/gix-components/assets/4550653/d1cedc9d-3f27-4a29-82f1-82f1d7bece74)

The problem is the `z-index` set in the `ghost` and `text` button utilities.

# Changes

* Remove the `z-index` from the button styles.

# Screenshots

No UI changes.
