### PR TITLE
Fix: Colors

### DIFF
--- a/src/lib/components/HeaderTitle.svelte
+++ b/src/lib/components/HeaderTitle.svelte
@@ -6,11 +6,6 @@
 
   h4 {
     margin: 0;
-    color: var(--body-color);
-
-    @include media.min-width(large) {
-      color: var(--content-color);
-    }
 
     @include text.truncate;
 

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -12,7 +12,7 @@
     --input-focus-background: var(--cp-light-75);
     --button-primary: var(--cp-light-accent);
     --table-background: var(--cp-light-75);
-    --table-header-background: var(--cp-light-124);
+    --table-header-background: var(--cp-light-100);
     --table-row-background: var(--cp-light-75);
     --table-row-background-hover: var(--cp-light-100);
 
@@ -22,7 +22,7 @@
     --check-tint: var(--green-tint);
     --pending-color: var(--orange);
     --pending-background: var(--orange-tint);
-    --island-card-background: var(--cp-light-124);
+    --island-card-background: var(--cp-light-125);
 
     // -------- OLD CSS VARIABLES ----------------
     // Shadows
@@ -46,7 +46,7 @@
     --button-secondary-color: var(--primary);
     --button-card-focus-color: var(--primary);
     --button-card-focus-background: var(--cp-light-100);
-    --button-disable-background: var(--cp-light-124);
+    --button-disable-background: var(--cp-light-125);
     --button-disable-color: var(--disable-contrast);
 
     // Text color
@@ -133,16 +133,16 @@
     --card-background-contrast-rgb: var(--text-color-rgb);
     --card-background-shade: var(--cp-light-100);
     --card-background-tint: var(--cp-light-50);
-    --card-background-disabled: var(--cp-light-124);
+    --card-background-disabled: var(--cp-light-125);
 
     /* Design: Light/Bg/Background-01 */
     --background: var(--cp-light-100);
     --background-contrast: var(--text-color);
     --background-contrast-rgb: var(--text-color-rgb);
-    --background-shade: var(--cp-light-124);
+    --background-shade: var(--cp-light-125);
 
     /* Design: Light/Bg/Background-03 */
-    --background-disable: var(--cp-light-124);
+    --background-disable: var(--cp-light-125);
     --background-disable-rgb: 225, 217, 243;
     --background-disable-contrast: var(--disable-contrast);
 

--- a/src/routes/(split)/components/header-title/+page.md
+++ b/src/routes/(split)/components/header-title/+page.md
@@ -1,3 +1,7 @@
+<script lang="ts">
+    import HeaderTitle from "$lib/components/HeaderTitle.svelte";
+</script>
+
 # Title
 
 An opinionated container to display a title in the nav header of the dapp.
@@ -5,6 +9,8 @@ An opinionated container to display a title in the nav header of the dapp.
 ```javascript
 <HeaderTitle>Hello World 👋</HeaderTitle>
 ```
+
+<HeaderTitle>Hello World 👋</HeaderTitle>
 
 ## Slots
 


### PR DESCRIPTION
# Motivation

There were some issues with the new light theme colors.

# Changes

* Fix typo with color `-124` when it shuold have been `-125`.
* Remove setting the color for the HeaderTitle.
* Change `--table-header-background` to `--cp-light-100`.
* Add the header title in the gix component page. This would have helped catch the issue.

# Screenshots

Using the HeaderTitle in the component document page.

![Screenshot 2024-01-15 at 14 43 47](https://github.com/dfinity/gix-components/assets/4550653/6eff0468-7fe0-4355-9808-7c114899e69e)

