### PR TITLE
Fix: Change light island-card-background

### DIFF
--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -22,7 +22,7 @@
     --check-tint: var(--green-tint);
     --pending-color: var(--orange);
     --pending-background: var(--orange-tint);
-    --island-card-background: var(--cp-light-125);
+    --island-card-background: var(--cp-light-50);
 
     // -------- OLD CSS VARIABLES ----------------
     // Shadows


### PR DESCRIPTION
# Motivation

The card is not visible within an island for light theme.

In this PR, change the color of `--island-card-background` for the light theme.

# Changes

* Change `--island-card-background` color for light theme.

# Screenshots

There is how it will look now in NNS Dapp:

![Screenshot 2024-01-16 at 11 20 33](https://github.com/dfinity/gix-components/assets/4550653/5431140c-7e08-487f-a3c1-6ad498d9ce99)

