### PR TITLE
feat: input type currency

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -158,9 +158,7 @@
 
   $: step = inputType === "number" ? step ?? "any" : undefined;
   $: autocomplete =
-    inputType !== "number" && !isCurrency()
-      ? autocomplete ?? "off"
-      : undefined;
+    inputType !== "number" && !isCurrency() ? autocomplete ?? "off" : undefined;
 
   let displayInnerEnd: boolean;
   $: displayInnerEnd = nonNullish($$slots["inner-end"]);

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -13,7 +13,7 @@
   export let value: string | number | undefined = undefined;
   export let placeholder: string;
   export let testId: string | undefined = undefined;
-  export let icpDecimals = 8;
+  export let decimals = 8;
 
   const dispatch = createEventDispatcher();
 
@@ -42,7 +42,7 @@
     value.includes("e")
       ? Number(value).toLocaleString("en", {
           useGrouping: false,
-          maximumFractionDigits: icpDecimals,
+          maximumFractionDigits: decimals,
         })
       : value;
   // To show undefined as "" (because of the type="text")
@@ -81,7 +81,7 @@
     value = isNullish(lastValidICPValue)
       ? undefined
       : typeof lastValidICPValue === "number"
-      ? lastValidICPValue.toFixed(icpDecimals)
+      ? lastValidICPValue.toFixed(decimals)
       : +lastValidICPValue;
     icpValue = fixUndefinedValue(lastValidICPValue);
 
@@ -99,7 +99,7 @@
   };
 
   const isValidICPFormat = (text: string): boolean => {
-    const regex = new RegExp(`^\\d*(\\.\\d{0,${icpDecimals}})?$`);
+    const regex = new RegExp(`^\\d*(\\.\\d{0,${decimals}})?$`);
     return regex.test(text);
   };
 

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -121,7 +121,10 @@
         internalValueChange = true;
         // for inputType="icp" value is a number
         // TODO: do we need to fix lost precision for too big for number inputs?
-        value = +currentValue;
+        const valueAsNumber = +currentValue;
+        value = `${valueAsNumber}`.includes("e")
+          ? exponentToPlainNumberString(`${valueAsNumber}`)
+          : valueAsNumber;
       }
     } else {
       internalValueChange = true;

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -59,16 +59,12 @@
   let lastValidCurrencyValue: string | number | undefined = value;
   let internalValueChange = true;
 
-  // Used for render purpose only
   let currency = false;
   $: currency = ["icp", "currency"].includes(inputType);
 
-  // Used for imperative logic
-  const isCurrency = (): boolean => ["icp", "currency"].includes(inputType);
-
   $: value,
     (() => {
-      if (!internalValueChange && isCurrency()) {
+      if (!internalValueChange && currency) {
         if (typeof value === "number") {
           currencyValue = exponentToPlainNumberString(`${value}`);
         } else {
@@ -82,7 +78,7 @@
     })();
 
   const restoreFromValidValue = (noValue = false) => {
-    if (isNullish(inputElement) || !isCurrency()) {
+    if (isNullish(inputElement) || !currency) {
       return;
     }
 
@@ -117,7 +113,7 @@
   };
 
   const handleInput = ({ currentTarget }: InputEventHandler) => {
-    if (isCurrency()) {
+    if (currency) {
       const currentValue = exponentToPlainNumberString(currentTarget.value);
 
       // handle invalid input
@@ -158,7 +154,7 @@
 
   $: step = inputType === "number" ? step ?? "any" : undefined;
   $: autocomplete =
-    inputType !== "number" && !isCurrency() ? autocomplete ?? "off" : undefined;
+    inputType !== "number" && !currency ? autocomplete ?? "off" : undefined;
 
   let displayInnerEnd: boolean;
   $: displayInnerEnd = nonNullish($$slots["inner-end"]);

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -13,6 +13,8 @@
   export let value: string | number | undefined = undefined;
   export let placeholder: string;
   export let testId: string | undefined = undefined;
+  export let icpDecimals = 8;
+
   const dispatch = createEventDispatcher();
 
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
@@ -40,7 +42,7 @@
     value.includes("e")
       ? Number(value).toLocaleString("en", {
           useGrouping: false,
-          maximumFractionDigits: 8,
+          maximumFractionDigits: icpDecimals,
         })
       : value;
   // To show undefined as "" (because of the type="text")
@@ -79,7 +81,7 @@
     value = isNullish(lastValidICPValue)
       ? undefined
       : typeof lastValidICPValue === "number"
-      ? lastValidICPValue.toFixed(8)
+      ? lastValidICPValue.toFixed(icpDecimals)
       : +lastValidICPValue;
     icpValue = fixUndefinedValue(lastValidICPValue);
 
@@ -96,8 +98,10 @@
     currentTarget: EventTarget & HTMLInputElement;
   };
 
-  const isValidICPFormat = (text: string): boolean =>
-    /^[\d]*(\.[\d]{0,8})?$/.test(text);
+  const isValidICPFormat = (text: string): boolean => {
+    const regex = new RegExp(`^[\\d]*(\\.[\\d]{0,${icpDecimals})?$`);
+    return regex.test(text);
+  };
 
   const handleInput = ({ currentTarget }: InputEventHandler) => {
     if (inputType === "icp") {

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -99,7 +99,7 @@
   };
 
   const isValidICPFormat = (text: string): boolean => {
-    const regex = new RegExp(`^[\\d]*(\\.[\\d]{0,${icpDecimals})?$`);
+    const regex = new RegExp(`^\\d*(\\.\\d{0,${icpDecimals}})?$`);
     return regex.test(text);
   };
 

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -50,6 +50,8 @@ Both slots are displayed `flex` with `space-between`.
 
     <Input placeholder="Enter ICP" inputType="icp" value="" />
 
+    <Input placeholder="Enter ETH" inputType="icp" value="" icpDecimals={18} />
+
     <Input placeholder="Disabled" disabled value="This is a disabled value" inputType="text" />
 
     <Input placeholder="Input text" inputType="text" value="" showInfo>

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -14,21 +14,22 @@ The input component is a wrapper to the HTML input element with custom styling a
 
 ## Properties
 
-| Property       | Description                                                                               | Type                                | Default     |
-| -------------- | ----------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
-| `name`         | HTML input `name` field.                                                                  | `string`                            |             |
-| `inputType`    | HTML input `type` field extended with a custom `icp` type.                                | `text` or `number` or `icp`         | `number`    |
-| `required`     | HTML input `required` field.                                                              | `boolean`                           | `true`      |
-| `spellcheck`   | HTML input `spellcheck` field.                                                            | `boolean` or `undefined`            | `undefined` |
-| `step`         | HTML input `step` field.                                                                  | `number` or `any` or `undefined`    | `undefined` |
-| `disabled`     | HTML input `disabled` field.                                                              | `boolean`                           | `false`     |
-| `minLength`    | HTML input `minlength` field.                                                             | `number` or `undefined`             | `undefined` |
-| `max`          | HTML input `max` field.                                                                   | `number` or `undefined`             | `undefined` |
-| `value`        | HTML input `value` field.                                                                 | `string` or `number` or `undefined` | `undefined` |
-| `placeholder`  | HTML input `placeholder` field.                                                           | `string`                            |             |
-| `autocomplete` | HTML input `autocomplete` field.                                                          | `off` or `on` or `undefined`        | `undefined` |
-| `showInfo`     | Display additional information related to the input. Should be used in addition to slots. | `boolean`                           | `false`     |
-| `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                           | `string` or `undefined`             | `undefined` |
+| Property       | Description                                                                                                                            | Type                                | Default     |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|-------------|
+| `name`         | HTML input `name` field.                                                                                                               | `string`                            |             |
+| `inputType`    | HTML input `type` field extended with a custom `icp` type.                                                                             | `text` or `number` or `icp`         | `number`    |
+| `required`     | HTML input `required` field.                                                                                                           | `boolean`                           | `true`      |
+| `spellcheck`   | HTML input `spellcheck` field.                                                                                                         | `boolean` or `undefined`            | `undefined` |
+| `step`         | HTML input `step` field.                                                                                                               | `number` or `any` or `undefined`    | `undefined` |
+| `disabled`     | HTML input `disabled` field.                                                                                                           | `boolean`                           | `false`     |
+| `minLength`    | HTML input `minlength` field.                                                                                                          | `number` or `undefined`             | `undefined` |
+| `max`          | HTML input `max` field.                                                                                                                | `number` or `undefined`             | `undefined` |
+| `value`        | HTML input `value` field.                                                                                                              | `string` or `number` or `undefined` | `undefined` |
+| `placeholder`  | HTML input `placeholder` field.                                                                                                        | `string`                            |             |
+| `autocomplete` | HTML input `autocomplete` field.                                                                                                       | `off` or `on` or `undefined`        | `undefined` |
+| `decimals`     | Can be used together with the `inputType` set as `icp` type to define a particular number of decimals supported.                       | `number`                            | `8`         |
+| `showInfo`     | Display additional information related to the input. Should be used in addition to slots.                                              | `boolean`                           | `false`     |
+| `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                                                                        | `string` or `undefined`             | `undefined` |
 
 ## Slots
 

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -14,22 +14,26 @@ The input component is a wrapper to the HTML input element with custom styling a
 
 ## Properties
 
-| Property       | Description                                                                                                                            | Type                                | Default     |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|-------------|
-| `name`         | HTML input `name` field.                                                                                                               | `string`                            |             |
-| `inputType`    | HTML input `type` field extended with a custom `icp` type.                                                                             | `text` or `number` or `icp`         | `number`    |
-| `required`     | HTML input `required` field.                                                                                                           | `boolean`                           | `true`      |
-| `spellcheck`   | HTML input `spellcheck` field.                                                                                                         | `boolean` or `undefined`            | `undefined` |
-| `step`         | HTML input `step` field.                                                                                                               | `number` or `any` or `undefined`    | `undefined` |
-| `disabled`     | HTML input `disabled` field.                                                                                                           | `boolean`                           | `false`     |
-| `minLength`    | HTML input `minlength` field.                                                                                                          | `number` or `undefined`             | `undefined` |
-| `max`          | HTML input `max` field.                                                                                                                | `number` or `undefined`             | `undefined` |
-| `value`        | HTML input `value` field.                                                                                                              | `string` or `number` or `undefined` | `undefined` |
-| `placeholder`  | HTML input `placeholder` field.                                                                                                        | `string`                            |             |
-| `autocomplete` | HTML input `autocomplete` field.                                                                                                       | `off` or `on` or `undefined`        | `undefined` |
-| `decimals`     | Can be used together with the `inputType` set as `icp` type to define a particular number of decimals supported.                       | `number`                            | `8`         |
-| `showInfo`     | Display additional information related to the input. Should be used in addition to slots.                                              | `boolean`                           | `false`     |
-| `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                                                                        | `string` or `undefined`             | `undefined` |
+| Property       | Description                                                                                                                              | Type                                      | Default     |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------- |
+| `name`         | HTML input `name` field.                                                                                                                 | `string`                                  |             |
+| `inputType`    | HTML input `type` field extended with a custom `icp` type.                                                                               | `text` or `number` or `icp` or `currency` | `number`    |
+| `required`     | HTML input `required` field.                                                                                                             | `boolean`                                 | `true`      |
+| `spellcheck`   | HTML input `spellcheck` field.                                                                                                           | `boolean` or `undefined`                  | `undefined` |
+| `step`         | HTML input `step` field.                                                                                                                 | `number` or `any` or `undefined`          | `undefined` |
+| `disabled`     | HTML input `disabled` field.                                                                                                             | `boolean`                                 | `false`     |
+| `minLength`    | HTML input `minlength` field.                                                                                                            | `number` or `undefined`                   | `undefined` |
+| `max`          | HTML input `max` field.                                                                                                                  | `number` or `undefined`                   | `undefined` |
+| `value`        | HTML input `value` field.                                                                                                                | `string` or `number` or `undefined`       | `undefined` |
+| `placeholder`  | HTML input `placeholder` field.                                                                                                          | `string`                                  |             |
+| `autocomplete` | HTML input `autocomplete` field.                                                                                                         | `off` or `on` or `undefined`              | `undefined` |
+| `decimals`     | Can be used together with the `inputType` set as `currency` type to define a particular number of decimals supported by the input field. | `number`                                  | `8`         |
+| `showInfo`     | Display additional information related to the input. Should be used in addition to slots.                                                | `boolean`                                 | `false`     |
+| `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                                                                          | `string` or `undefined`                   | `undefined` |
+
+### Notes
+
+If the `inputType` is set to `icp`, the `value` bind by the component is a `number`. On the contrary, if bind to `currenty`, the value is a `string`. This to avoid issue with scientific notation enforced by JavaScript. It is then up to you to parse the currency according your need, for example to `bigint` or `BigNumber`.
 
 ## Slots
 

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -55,7 +55,7 @@ Both slots are displayed `flex` with `space-between`.
 
     <Input placeholder="Enter ICP" inputType="icp" value="" />
 
-    <Input placeholder="Enter ETH" inputType="icp" value="" icpDecimals={18} />
+    <Input placeholder="Enter ETH" inputType="currency" value="" icpDecimals={18} />
 
     <Input placeholder="Disabled" disabled value="This is a disabled value" inputType="text" />
 

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -321,7 +321,7 @@ describe("Input", () => {
         const { container, component } = render(InputValueTest, {
           props: {
             ...props,
-            inputType: "icp",
+            inputType: "currency",
             decimals: 18,
           },
         });
@@ -329,7 +329,7 @@ describe("Input", () => {
         const input: HTMLInputElement | null = container.querySelector("input");
         assertNonNullish(input);
 
-        const ethValue = "0.00000009482900424";
+        const ethValue = "0.000000094829004242";
 
         fireEvent.input(input, { target: { value: ethValue } });
         expect(input.value).toBe(ethValue);
@@ -460,7 +460,7 @@ describe("Input", () => {
         props: {
           ...props,
           value: "1",
-          inputType: "icp",
+          inputType: "currency",
           decimals: 12,
         },
       });

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -322,7 +322,7 @@ describe("Input", () => {
           props: {
             ...props,
             inputType: "icp",
-            icpDecimals: 18,
+            decimals: 18,
           },
         });
 
@@ -461,7 +461,7 @@ describe("Input", () => {
           ...props,
           value: "1",
           inputType: "icp",
-          icpDecimals: 12,
+          decimals: 12,
         },
       });
 

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -1,5 +1,5 @@
 import Input from "$lib/components/Input.svelte";
-import { isNullish, nonNullish } from "@dfinity/utils";
+import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
 import { fireEvent, render } from "@testing-library/svelte";
 import { tick } from "svelte";
 import InputTest from "./InputTest.svelte";
@@ -429,6 +429,23 @@ describe("Input", () => {
         },
       });
       expect(container.querySelector("input")?.value).toBe("11111111.11111111");
+    });
+
+    it("should accept custom decimals in icp mode", () => {
+      const { container } = render(InputValueTest, {
+        props: {
+          ...props,
+          value: "1",
+          inputType: "icp",
+          icpDecimals: 12,
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+      assertNonNullish(input);
+
+      fireEvent.input(input, { target: { value: "111.1234567891" } });
+      expect(input.value).toBe("111.1234567891");
     });
   });
 });

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -341,9 +341,6 @@ describe("Input", () => {
       expect(input.value).toBe("123");
 
       fireEvent.input(input, { target: { value: ".0000001" } });
-
-      console.log(input.value)
-
       expect(input.value).toBe(".0000001");
 
       fireEvent.input(input, { target: { value: ".000000001" } });

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -341,6 +341,9 @@ describe("Input", () => {
       expect(input.value).toBe("123");
 
       fireEvent.input(input, { target: { value: ".0000001" } });
+
+      console.log(input.value)
+
       expect(input.value).toBe(".0000001");
 
       fireEvent.input(input, { target: { value: ".000000001" } });
@@ -376,7 +379,7 @@ describe("Input", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
-          value: 0,
+          value: `0`,
           inputType: "icp",
         },
       });
@@ -388,7 +391,7 @@ describe("Input", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
-          value: 0.00000001,
+          value: `0.00000001`,
           inputType: "icp",
         },
       });
@@ -424,7 +427,7 @@ describe("Input", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
-          value: 11111111.11111111,
+          value: `11111111.11111111`,
           inputType: "icp",
         },
       });

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -316,6 +316,30 @@ describe("Input", () => {
         });
       }));
 
+    it("should bind value as string", () =>
+      new Promise<void>((done) => {
+        const { container, component } = render(InputValueTest, {
+          props: {
+            ...props,
+            inputType: "icp",
+            icpDecimals: 18,
+          },
+        });
+
+        const input: HTMLInputElement | null = container.querySelector("input");
+        assertNonNullish(input);
+
+        const ethValue = "0.00000009482900424";
+
+        fireEvent.input(input, { target: { value: ethValue } });
+        expect(input.value).toBe(ethValue);
+
+        component.$on("testAmount", ({ detail }) => {
+          expect(detail.amount).toBe(ethValue);
+          done();
+        });
+      }));
+
     it("should not accept not icp formatted changed", async () => {
       const { container } = render(Input, {
         props: {

--- a/src/tests/lib/components/InputValueTest.svelte
+++ b/src/tests/lib/components/InputValueTest.svelte
@@ -5,7 +5,7 @@
 
   const dispatch = createEventDispatcher();
 
-  export let inputType: "text" | "icp" = "text";
+  export let inputType: "text" | "icp" | "currency" = "text";
   export let name: string;
   export let value: string | undefined = undefined;
   export let placeholder = "test.placeholder";

--- a/src/tests/lib/components/InputValueTest.svelte
+++ b/src/tests/lib/components/InputValueTest.svelte
@@ -9,7 +9,7 @@
   export let name: string;
   export let value: string | undefined = undefined;
   export let placeholder = "test.placeholder";
-  export let icpDecimals = 8;
+  export let decimals = 8;
 
   let amount: string | undefined = value;
   $: amount, (() => dispatch("testAmount", { amount }))();
@@ -23,4 +23,4 @@
 <!-- eslint-disable svelte/valid-compile -->
 <span on:click={changeValue} id="test" />
 
-<Input bind:value={amount} {inputType} {name} {placeholder} {icpDecimals} />
+<Input bind:value={amount} {inputType} {name} {placeholder} {decimals} />

--- a/src/tests/lib/components/InputValueTest.svelte
+++ b/src/tests/lib/components/InputValueTest.svelte
@@ -9,6 +9,7 @@
   export let name: string;
   export let value: string | undefined = undefined;
   export let placeholder = "test.placeholder";
+  export let icpDecimals = 8;
 
   let amount: string | undefined = value;
   $: amount, (() => dispatch("testAmount", { amount }))();
@@ -22,4 +23,4 @@
 <!-- eslint-disable svelte/valid-compile -->
 <span on:click={changeValue} id="test" />
 
-<Input bind:value={amount} {inputType} {name} {placeholder} />
+<Input bind:value={amount} {inputType} {name} {placeholder} {icpDecimals} />


### PR DESCRIPTION
# Motivation

I need more decimals in the input field of type icp and I don't want to ship a breaking change. 

So my first idea was to tweak the `inputType` set to `icp` but it leads to the issue with the scientific notation and I was concerned about making `icp` bind `value` of type `string` given that would break NNS dapp.

So ultimately I dediced to add a new `inputType` called `currency` which basically does the same thing as `icp` but, map the value to a `string`. That way we can avoid the issue of scientific notation. It's up to the consumer to use it correctly.

This PR also add a property to tweak the number of `decimals` accepted for input field type `currency`.

Both number of decimals and value parsed as number for `icp` remains that way the same.

# Changes

- add new type `currency` which basically does the same stuffs as `icp` but parse a `string`
- introduce an option `decimals` set to 8 per default which can be used with `currency`
- update few `value` prop in test reported as in error by webstorm (need string instead of number)
- update doc

# Screenshot

Need more decimals there.

<img width="1536" alt="Capture d’écran 2024-01-16 à 16 22 34" src="https://github.com/dfinity/gix-components/assets/16886711/fc188b72-91f9-489f-84d8-aaa9d4b821ae">
