### PR TITLE
fix: trim currency decimals as string

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -91,7 +91,9 @@
       ? undefined
       : typeof lastValidCurrencyValue === "number"
       ? lastValidCurrencyValue.toFixed(wrapDecimals)
-      : +lastValidCurrencyValue;
+      : inputType === "icp"
+      ? +lastValidCurrencyValue
+      : lastValidCurrencyValue;
     currencyValue = fixUndefinedValue(lastValidCurrencyValue);
 
     // force dom update (because no active triggers)

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -55,7 +55,7 @@ Both slots are displayed `flex` with `space-between`.
 
     <Input placeholder="Enter ICP" inputType="icp" value="" />
 
-    <Input placeholder="Enter ETH" inputType="currency" value="" icpDecimals={18} />
+    <Input placeholder="Enter ETH" inputType="currency" value="" decimals={18} />
 
     <Input placeholder="Disabled" disabled value="This is a disabled value" inputType="text" />
 

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -455,7 +455,7 @@ describe("Input", () => {
       expect(container.querySelector("input")?.value).toBe("11111111.11111111");
     });
 
-    it("should accept custom decimals in icp mode", () => {
+    it("should accept custom decimals in currency mode", () => {
       const { container } = render(InputValueTest, {
         props: {
           ...props,
@@ -470,6 +470,23 @@ describe("Input", () => {
 
       fireEvent.input(input, { target: { value: "111.1234567891" } });
       expect(input.value).toBe("111.1234567891");
+    });
+
+    it("should trim once custom decimals length is reached", () => {
+      const { container } = render(InputValueTest, {
+        props: {
+          ...props,
+          value: "0.000000011231232121",
+          inputType: "currency",
+          decimals: 18,
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+      assertNonNullish(input);
+
+      fireEvent.input(input, { target: { value: "0.0000000112312321219" } });
+      expect(input.value).toBe("0.000000011231232121");
     });
   });
 });


### PR DESCRIPTION
# Motivation

While testing the new input type `currency` in Oisy I landed on an that was parsed to number with scientific notation instead of binding the value to string. This happened when I entered a number with the max number of decimals and then trying to enter additional decimals.

For example: I entered 0.000000011231232121 in the input field, 18 decimals, and then tried to add a 19th decimals.

# Changes

- in the input field hook `restoreFromValidValue`, map to number only for the `inputType` is `icp` - i.e. if `currency` keep string
- use renamed `decimals` property in the showcase

# Screenshots

<img width="1536" alt="Capture d’écran 2024-01-17 à 07 43 26" src="https://github.com/dfinity/gix-components/assets/16886711/f8fcbda2-445e-458f-9880-6d76650e7bdd">

