### PR TITLE
Button class text for links

### DIFF
--- a/src/lib/styles/global/button.scss
+++ b/src/lib/styles/global/button.scss
@@ -14,23 +14,7 @@ button {
 
   &.ghost,
   &.text {
-    width: fit-content;
-
-    @include fonts.standard;
-
-    color: inherit;
-
-    &:hover,
-    &:active,
-    &:focus {
-      text-decoration: underline;
-      color: var(--value-color);
-    }
-
-    &[disabled] {
-      color: var(--disable-contrast);
-      text-decoration: none;
-    }
+    @include button.text;
   }
 
   &.full-width {

--- a/src/lib/styles/global/link.scss
+++ b/src/lib/styles/global/link.scss
@@ -16,7 +16,13 @@ a {
   }
 
   &.button {
-    @include button.base;
+    &.primary,
+    &.secondary,
+    &.success,
+    &.danger,
+    &.warning {
+      @include button.base;
+    }
 
     // Default is `inline` and buttons are `inline-block` but they have a hidden flex implemented in the browser.
     // https://stackoverflow.com/questions/15764600/what-makes-the-text-on-a-button-element-vertically-centered/34612505#34612505
@@ -28,6 +34,10 @@ a {
     box-sizing: border-box;
 
     text-decoration: none;
+
+    &.text {
+      @include button.text;
+    }
 
     &.primary {
       @include button.primary;

--- a/src/lib/styles/mixins/_button.scss
+++ b/src/lib/styles/mixins/_button.scss
@@ -1,3 +1,5 @@
+@use "./fonts";
+
 @mixin base {
   padding: var(--padding) var(--padding-2x);
 
@@ -30,6 +32,27 @@
   &:not([disabled]):hover,
   &:not([disabled]):focus {
     background: var(--primary-shade);
+  }
+}
+
+@mixin text {
+  width: fit-content;
+
+  @include fonts.standard;
+
+  text-decoration: none;
+  color: inherit;
+
+  &:hover,
+  &:active,
+  &:focus {
+    text-decoration: underline;
+    color: var(--value-color);
+  }
+
+  &[disabled] {
+    color: var(--disable-contrast);
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
# Motivation

Add `a.button.text` class to mimic text buttons for links.

# Changes

- moved `button.text` to mixins to reuse for links
- add `a.button.text`

# Screenshots

<img width="828" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/72ef72ff-4de6-4299-b1e9-ab091627b39b">
