### PR TITLE
style: increase popover max-width

### DIFF
--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -10,7 +10,6 @@
   export let visible = false;
   export let direction: "ltr" | "rtl" = "ltr";
   export let closeButton = false;
-  export let noMaxWidth = false;
 
   let bottom: number;
   let left: number;
@@ -31,7 +30,6 @@
     aria-orientation="vertical"
     transition:fade|global
     class="popover"
-    class:noMaxWidth
     tabindex="-1"
     style="--popover-top: {`${bottom}px`}; --popover-left: {`${left}px`}; --popover-right: {`${
       window.innerWidth - right
@@ -85,7 +83,8 @@
     --size: min(calc(20 * var(--padding)), calc(100vw - var(--padding)));
 
     min-width: var(--size);
-    max-width: var(--size);
+    // limited by `100vw - right padding`
+    max-width: calc(100vw - var(--padding));
 
     width: fit-content;
     height: auto;
@@ -100,11 +99,6 @@
     border-radius: var(--border-radius);
 
     box-shadow: var(--overlay-box-shadow);
-
-    &.noMaxWidth {
-      // 100vw - right padding
-      max-width: calc(100vw - var(--padding));
-    }
   }
 
   .close {

--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -10,6 +10,7 @@
   export let visible = false;
   export let direction: "ltr" | "rtl" = "ltr";
   export let closeButton = false;
+  export let noMaxWidth = false;
 
   let bottom: number;
   let left: number;
@@ -30,6 +31,7 @@
     aria-orientation="vertical"
     transition:fade|global
     class="popover"
+    class:noMaxWidth
     tabindex="-1"
     style="--popover-top: {`${bottom}px`}; --popover-left: {`${left}px`}; --popover-right: {`${
       window.innerWidth - right
@@ -98,6 +100,11 @@
     border-radius: var(--border-radius);
 
     box-shadow: var(--overlay-box-shadow);
+
+    &.noMaxWidth {
+      // 100vw - right padding
+      max-width: calc(100vw - var(--padding));
+    }
   }
 
   .close {


### PR DESCRIPTION
# Motivation

Increase `Popover` max-width to support wider content (like a redesigned account menu - screenshot)

# Changes

- replace fixed width with all `available space - right` to make it nicely shrink on mobile (screen 2).

# Screenshots

## Enough space
<img width="381" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/77c4d28b-e4c0-4242-9a22-f466ddb6de7e">


## Not enough space
<img width="235" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/9606d574-efe0-44df-9b3c-1f31a649d38b">

