### PR TITLE
feat: browser detection

### DIFF
--- a/src/routes/(page)/browser/+page.svelte
+++ b/src/routes/(page)/browser/+page.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { Value } from "$lib";
+  import { isAndroidTablet, isIPad, isMobile } from "$lib/utils/device.utils";
+</script>
+
+<h1>Browser</h1>
+
+<p>
+  This page shows you what your web browser is sending in the "User-Agent"
+  header for your HTTP requests and summarize few of its features.
+</p>
+
+<h2>User agent</h2>
+
+<pre class="language-javascript">
+<code class="language-javascript"
+    ><span
+      >{#if browser}{navigator.userAgent}{/if}</span
+    ></code
+  >
+</pre>
+
+<h2>Device</h2>
+
+<table>
+  <tr>
+    <td class="description">isMobile</td>
+    <td
+      ><Value>
+        {isMobile()}
+      </Value></td
+    >
+  </tr>
+
+  <tr>
+    <td class="description">isIPad</td>
+    <td
+      ><Value>
+        {isIPad()}
+      </Value></td
+    >
+  </tr>
+
+  <tr>
+    <td class="description">isAndroidTable</td>
+    <td
+      ><Value>
+        {isAndroidTablet()}
+      </Value></td
+    >
+  </tr>
+
+  <tr>
+    <td class="description">Touch screen</td>
+    <td
+      ><Value>
+        {#if browser}{window.matchMedia("(any-pointer:coarse)").matches}{/if}
+      </Value></td
+    >
+  </tr>
+
+  <tr>
+    <td class="description">Mouse screen</td>
+    <td
+      ><Value>
+        {#if browser}{window.matchMedia("(any-pointer:fine)").matches}{/if}
+      </Value></td
+    >
+  </tr>
+</table>
+
+<style lang="scss">
+  .language-javascript span {
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/routes/(page)/browser/+page.svelte
+++ b/src/routes/(page)/browser/+page.svelte
@@ -43,7 +43,7 @@
   </tr>
 
   <tr>
-    <td class="description">isAndroidTable</td>
+    <td class="description">isAndroidTablet</td>
     <td
       ><Value>
         {isAndroidTablet()}

--- a/src/routes/(page)/resources/+page.svelte
+++ b/src/routes/(page)/resources/+page.svelte
@@ -65,6 +65,9 @@
 
 <ul>
   <li>
+    <a href="/browser">Browser detection</a>
+  </li>
+  <li>
     Source code on <a
       href="https://github.com/dfinity/gix-components"
       rel="external noopener noreferrer"


### PR DESCRIPTION
# Motivation

A page that can be used to determine capatibilities of the browsers used by users of NNS dapp / gix-cmp.

Useful for example to debug issue related to device detection such as if a device is mobile or desktop.

Demo: https://gix.design/browser
