### PR TITLE
feat: ignore 1Password in input fields

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -14,6 +14,7 @@
   export let placeholder: string;
   export let testId: string | undefined = undefined;
   export let decimals = 8;
+  export let ignore1Password = true;
 
   const dispatch = createEventDispatcher();
 
@@ -192,6 +193,7 @@
       on:input={handleInput}
       on:keydown={handleKeyDown}
       class:inner-end={displayInnerEnd}
+      data-1p-ignore={ignore1Password}
     />
     {#if displayInnerEnd}
       <div class="inner-end-slot">

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -17,22 +17,23 @@ The input component is a wrapper to the HTML input element with custom styling a
 
 ## Properties
 
-| Property       | Description                                                                                                                              | Type                                      | Default     |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------- |
-| `name`         | HTML input `name` field.                                                                                                                 | `string`                                  |             |
-| `inputType`    | HTML input `type` field extended with a custom `icp` type.                                                                               | `text` or `number` or `icp` or `currency` | `number`    |
-| `required`     | HTML input `required` field.                                                                                                             | `boolean`                                 | `true`      |
-| `spellcheck`   | HTML input `spellcheck` field.                                                                                                           | `boolean` or `undefined`                  | `undefined` |
-| `step`         | HTML input `step` field.                                                                                                                 | `number` or `any` or `undefined`          | `undefined` |
-| `disabled`     | HTML input `disabled` field.                                                                                                             | `boolean`                                 | `false`     |
-| `minLength`    | HTML input `minlength` field.                                                                                                            | `number` or `undefined`                   | `undefined` |
-| `max`          | HTML input `max` field.                                                                                                                  | `number` or `undefined`                   | `undefined` |
-| `value`        | HTML input `value` field.                                                                                                                | `string` or `number` or `undefined`       | `undefined` |
-| `placeholder`  | HTML input `placeholder` field.                                                                                                          | `string`                                  |             |
-| `autocomplete` | HTML input `autocomplete` field.                                                                                                         | `off` or `on` or `undefined`              | `undefined` |
-| `decimals`     | Can be used together with the `inputType` set as `currency` type to define a particular number of decimals supported by the input field. | `number`                                  | `8`         |
-| `showInfo`     | Display additional information related to the input. Should be used in addition to slots.                                                | `boolean`                                 | `false`     |
-| `testId`       | Add a `data-tid` attribute to the DOM, useful for test purpose.                                                                          | `string` or `undefined`                   | `undefined` |
+| Property          | Description                                                                                                                                           | Type                                      | Default     |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------- |
+| `name`            | HTML input `name` field.                                                                                                                              | `string`                                  |             |
+| `inputType`       | HTML input `type` field extended with a custom `icp` type.                                                                                            | `text` or `number` or `icp` or `currency` | `number`    |
+| `required`        | HTML input `required` field.                                                                                                                          | `boolean`                                 | `true`      |
+| `spellcheck`      | HTML input `spellcheck` field.                                                                                                                        | `boolean` or `undefined`                  | `undefined` |
+| `step`            | HTML input `step` field.                                                                                                                              | `number` or `any` or `undefined`          | `undefined` |
+| `disabled`        | HTML input `disabled` field.                                                                                                                          | `boolean`                                 | `false`     |
+| `minLength`       | HTML input `minlength` field.                                                                                                                         | `number` or `undefined`                   | `undefined` |
+| `max`             | HTML input `max` field.                                                                                                                               | `number` or `undefined`                   | `undefined` |
+| `value`           | HTML input `value` field.                                                                                                                             | `string` or `number` or `undefined`       | `undefined` |
+| `placeholder`     | HTML input `placeholder` field.                                                                                                                       | `string`                                  |             |
+| `autocomplete`    | HTML input `autocomplete` field.                                                                                                                      | `off` or `on` or `undefined`              | `undefined` |
+| `decimals`        | Can be used together with the `inputType` set as `currency` type to define a particular number of decimals supported by the input field.              | `number`                                  | `8`         |
+| `showInfo`        | Display additional information related to the input. Should be used in addition to slots.                                                             | `boolean`                                 | `false`     |
+| `testId`          | Add a `data-tid` attribute to the DOM, useful for test purpose.                                                                                       | `string` or `undefined`                   | `undefined` |
+| `ignore1Password` | Tell 1Password it should ignore the field (Reference: 1Password [documentation](https://developer.1password.com/docs/web/compatible-website-design/)) | `boolean`                                 | `true`      |
 
 ### Notes
 

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -49,7 +49,7 @@ describe("Input", () => {
     attribute: string;
     expected: boolean;
     container: HTMLElement;
-    expectedValue?: boolean;
+    expectedValue?: string;
   }) => {
     const input: HTMLInputElement | null = container.querySelector("input");
     expect(input?.hasAttribute(attribute)).toEqual(expected);
@@ -262,6 +262,33 @@ describe("Input", () => {
     });
 
     testHasAttribute({ container, attribute: "disabled", expected: true });
+  });
+
+  it("should render an attribute to ignore 1Password", () => {
+    const { container } = render(Input, {
+      props,
+    });
+
+    testHasAttribute({
+      container,
+      attribute: "data-1p-ignore",
+      expected: true,
+    });
+  });
+
+  it("should render an attribute that do not ignore 1Password", () => {
+    const { container } = render(Input, {
+      props: { ...props, ignore1Password: false },
+    });
+
+    console.log(container.outerHTML);
+
+    testHasAttribute({
+      container,
+      attribute: "data-1p-ignore",
+      expected: true,
+      expectedValue: "false",
+    });
   });
 
   it("should bind value", async () => {


### PR DESCRIPTION
# Motivation

Disable per default 1Password in input fields.

# Changes

- add ignore flag as described in 1Password documentation https://developer.1password.com/docs/web/compatible-website-design/

# Screenshots

This solve following:

<img width="1536" alt="Capture d’écran 2024-02-05 à 10 28 19" src="https://github.com/dfinity/gix-components/assets/16886711/17dd6c21-dd92-43fe-8826-c101fad4e965">

