### PR TITLE
feat: improve mobile and desktop detection for QRCode reader mirroring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "svelte-preprocess": "^5.0.4",
         "svelte2tsx": "^0.6.23",
         "typescript": "^5.2.2",
+        "user-agent-data-types": "^0.4.2",
         "vite": "^5.0.12",
         "vitest": "^1.0.4"
       },
@@ -6296,6 +6297,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/user-agent-data-types": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/user-agent-data-types/-/user-agent-data-types-0.4.2.tgz",
+      "integrity": "sha512-jXep3kO/dGNmDOkbDa8ccp4QArgxR4I76m3QVcJ1aOF0B9toc+YtSXtX5gLdDTZXyWlpQYQrABr6L1L2GZOghw==",
+      "dev": true
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11021,6 +11028,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "user-agent-data-types": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/user-agent-data-types/-/user-agent-data-types-0.4.2.tgz",
+      "integrity": "sha512-jXep3kO/dGNmDOkbDa8ccp4QArgxR4I76m3QVcJ1aOF0B9toc+YtSXtX5gLdDTZXyWlpQYQrABr6L1L2GZOghw==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "svelte-preprocess": "^5.0.4",
     "svelte2tsx": "^0.6.23",
     "typescript": "^5.2.2",
+    "user-agent-data-types": "^0.4.2",
     "vite": "^5.0.12",
     "vitest": "^1.0.4"
   },

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="@sveltejs/kit" />
+/// <reference types="user-agent-data-types" />
 
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces

--- a/src/lib/components/QRCodeReader.svelte
+++ b/src/lib/components/QRCodeReader.svelte
@@ -1,14 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from "svelte";
   import type { Html5Qrcode } from "html5-qrcode";
-  import {
-    isAndroid,
-    isAndroidTablet,
-    isDesktop,
-    isIOS,
-    isIPad,
-    isMobile,
-  } from "$lib/utils/device.utils";
+  import { isDesktop } from "$lib/utils/device.utils";
   import { nextElementId } from "$lib/utils/html.utils";
   import type { Html5QrcodeScannerState } from "html5-qrcode";
 

--- a/src/lib/components/QRCodeReader.svelte
+++ b/src/lib/components/QRCodeReader.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from "svelte";
   import type { Html5Qrcode } from "html5-qrcode";
-  import { isAndroidTablet, isIPad, isMobile } from "$lib/utils/device.utils";
+  import {
+    isAndroid,
+    isAndroidTablet,
+    isDesktop,
+    isIOS,
+    isIPad,
+    isMobile,
+  } from "$lib/utils/device.utils";
   import { nextElementId } from "$lib/utils/html.utils";
   import type { Html5QrcodeScannerState } from "html5-qrcode";
 
@@ -82,7 +89,7 @@
   });
 
   // We optimistically assume that if the QR code reader is used on desktop, it has most probably only a single "user" facing camera and that we can invert the displayed video
-  let mirror = !isMobile() && !isIPad() && !isAndroidTablet();
+  const mirror = isDesktop();
 </script>
 
 <article class="reader" {id} class:mirror />

--- a/src/lib/utils/device.utils.ts
+++ b/src/lib/utils/device.utils.ts
@@ -1,4 +1,5 @@
 import { isNode } from "$lib/utils/env.utils";
+import { nonNullish } from "@dfinity/utils";
 
 export const isPortrait = (): boolean => {
   if (isNode()) {
@@ -56,18 +57,27 @@ export const isAndroidTablet = (): boolean => {
   return isAndroid() && !/mobile/i.test(a);
 };
 
+/**
+ * Current loophole (Feb 2024):
+ * - Firefox used on a desktop with touch screen will be identified as a mobile device.
+ */
 export const isMobile = (): boolean => {
   if (isNode()) {
     return false;
   }
 
-  const isTouchScreen: boolean = window.matchMedia(
-    "(any-pointer:coarse)",
-  ).matches;
-  const isMouseScreen: boolean =
-    window.matchMedia("(any-pointer:fine)").matches;
+  // Available in Chrome on any devices (Feb 2024)
+  // https://caniuse.com/mdn-api_navigator_useragentdata
+  if ("userAgentData" in navigator && nonNullish(navigator.userAgentData)) {
+    return navigator.userAgentData.mobile;
+  }
 
-  return isTouchScreen && !isMouseScreen;
+  // Legacy
+  const isTouchScreen = window.matchMedia("(any-pointer:coarse)").matches;
+
+  return isTouchScreen;
 };
+
+export const isDesktop = (): boolean => !isMobile();
 
 const userAgent = (): string => navigator.userAgent;


### PR DESCRIPTION
# Motivation

We received reports from users complaining about the QRCode reader being incorrectly mirrored on their devices. This issue was specifically noted on Samsung devices that support a stylus. The presence of a stylus leads the device to report to the user agent that it supports `any-pointer:fine`, i.e. it indicates support for a "mouse", which we previously used to detect desktop environments.

This PR revises our method for detecting mobile devices by utilizing the `NavigatorUAData` agent, which is available in Chrome. It also updates our approach for identifying desktop devices to correct the QRCode reader mirroring issue.

# Tradeoff

This implementation comes with a tradeoff. Since `NavigatorUAData` is not yet supported in Firefox, using this browser on a touchscreen device will result in it being detected as a mobile device.

This might be considered an edge case, given the current state of the APIs, this implementation represents our most accurate method for device detection available at this time.

# Resources

- https://caniuse.com/mdn-api_navigator_useragentdata
- https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData
- https://stackoverflow.com/questions/11381673/detecting-a-mobile-browser

# Changes

- mirror qrcode reader if `isDesktop`
- review `isMobile`
- add TS support for experimental feature