### PR TITLE
style: apply extra styles to the buttons/tooltip only

### DIFF
--- a/src/lib/styles/mixins/_toolbar.scss
+++ b/src/lib/styles/mixins/_toolbar.scss
@@ -7,17 +7,21 @@
   display: flex;
   gap: var(--padding-2x);
 
-  & > :global(*) {
+  & > :global(button),
+  & > :global(.tooltip-wrapper) {
     // use 50% to avoid non even button sizes (a single button would be 100%)
     flex: 1 1 50%;
+  }
 
+  & > :global(.tooltip-wrapper) {
     :global(*) {
       width: 100%;
     }
   }
 
   @include media.min-width(small) {
-    & > :global(*) {
+    & > :global(button),
+    & > :global(.tooltip-wrapper) {
       flex: none;
     }
   }

--- a/src/lib/styles/mixins/_toolbar.scss
+++ b/src/lib/styles/mixins/_toolbar.scss
@@ -7,22 +7,25 @@
   display: flex;
   gap: var(--padding-2x);
 
-  & > :global(button),
-  & > :global(.tooltip-wrapper) {
-    // use 50% to avoid non even button sizes (a single button would be 100%)
+  :global(button) {
+    // all buttons inside the toolbar should be full width on mobile and be aligned by flex parameters.
+    width: 100%;
+  }
+
+  & > :global(*) {
+    // 50% to make sure the button is not smaller in the tooltip, because of the wrong width calculation.
     flex: 1 1 50%;
   }
 
-  & > :global(.tooltip-wrapper) {
-    :global(*) {
-      width: 100%;
-    }
-  }
-
   @include media.min-width(small) {
-    & > :global(button),
-    & > :global(.tooltip-wrapper) {
+    // stop using full width on anything wider than mobile
+    & > :global(*) {
       flex: none;
+    }
+
+    :global(button) {
+      // reset 100%
+      width: auto;
     }
   }
 


### PR DESCRIPTION
# Motivation

Update tooltip styles to fix multiple alignment issues:

- set width for all `button` tags `00% on  mobile and control 1 level elements width w/ flex
- reset width for bigger breakpoints to use buttons content size.

# Changes

- styles of .toolbar

# Screenshots

<img width="378" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/e20dbe1d-1639-4530-a4b1-22123d15ff70">

---

<img width="407" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/ee7e3be0-7067-45b6-b07c-2cb5dad80aa0">


---

<img width="382" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/2e66053d-fd40-432b-b77a-1bf64654fa4a">

---

<img width="379" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/d4b85fc3-d94e-4cca-bffd-ab3616d134cd">

---

<img width="432" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/8a31106f-ea47-4e84-b574-91f3139f04d2">


