### PR TITLE
GIX-2293: Update table colors

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -10,9 +10,9 @@
   --text-text: var(--cp-light-900);
   --input-focus-background: var(--cp-dark-450);
   --button-primary: var(--cp-dark-accent);
-  --table-background: var(--cp-dark-550);
-  --table-header-background: var(--cp-dark-450);
-  --table-row-background: var(--cp-dark-550);
+  --table-background: var(--cp-dark-500);
+  --table-header-background: var(--cp-dark-500);
+  --table-row-background: var(--cp-dark-450);
   --table-row-background-hover: var(--cp-dark-500);
 
   --alert: var(--pink);


### PR DESCRIPTION
# Motivation

UX asked to update these colors.

# Changes

Changed some dark theme variables.
Light theme should remain as is.

# Screenshots

Old:
<img width="786" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/2d6f7da0-7b61-40ec-89fc-a7f49aa47493">

New:
<img width="787" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/263de034-1d65-478c-a6ed-69658661d2c4">
