### PR TITLE
Remove box-shadow on Popover

### DIFF
--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -103,8 +103,6 @@
 
     border-radius: var(--border-radius);
 
-    box-shadow: var(--overlay-box-shadow);
-
     &.with-border {
       border: var(--tooltip-border-size) solid var(--tooltip-border-color);
     }


### PR DESCRIPTION
# Motivation

Artem asked me to remove the box-shadow on the Popover.
Until recently the Popover always had a visible dark backdrop where the box-shadow wasn't really visible anyway so this should only make a difference for the new cases where we hide the backdrop.

# Changes

Remove `box-shadow` style on `Popover`.

# Screenshots

Before:
<img width="514" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/4ed3df81-995f-42b3-ba2c-70ca7a0b67e5">

After:
<img width="518" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/c4985caf-59fb-4f7a-9f4c-e75de4fc38e7">
