### PR TITLE
Do not publish 'next' every night.

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2,8 +2,6 @@ name: Next Publication
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   publish:


### PR DESCRIPTION
# Motivation

Whenever we make changes to gix-components, we almost always do a manual "Next Publication" in order to pull the new changes into NNS dapp.
Having an addition "Next Publication" every night does not really provide value.
And not having frequent next publications actually makes it easier to see when you've forgotten to do a publication before updating the gix-components dependency in nns-dapp.

# Changes

1. Remove the scheduled runs of "Next Publication".
2. Rename `nightly.yml` to `next.yml` to reflect the purpose more accurately.