### PR TITLE
Make the progress bar value straight instead of rounded

### DIFF
--- a/src/lib/components/ProgressBar.svelte
+++ b/src/lib/components/ProgressBar.svelte
@@ -116,7 +116,6 @@
     }
 
     &::-webkit-progress-value {
-      border-radius: var(--current-height);
       box-shadow: var(--input-box-shadow);
     }
 


### PR DESCRIPTION
# Motivation

This was requested to make the progress appear more precise.

# Changes

Remove the `border-radius` style from `-webkit-progress-value`.

# Screenshots

See updated e2e screenshot.
