### PR TITLE
chore: prevent console log usage with eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ module.exports = {
       },
     ],
     "no-underscore-dangle": "off",
+    'no-console': ['error', { allow: ['error', 'warn'] }],
   },
   globals: {
     NodeJS: true,

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -281,8 +281,6 @@ describe("Input", () => {
       props: { ...props, ignore1Password: false },
     });
 
-    console.log(container.outerHTML);
-
     testHasAttribute({
       container,
       attribute: "data-1p-ignore",


### PR DESCRIPTION
# Motivation

Prevent usage of `console.log` with eslint (given that I spotted a console.log in a test while developing an unrelated feature).
