### PR TITLE
chore: solve lint error type 'undefined' is not assignable to type 'Node'

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { notEmptyString } from "@dfinity/utils";
+  import { nonNullish, notEmptyString } from "@dfinity/utils";
   import { translateTooltip } from "$lib/utils/tooltip.utils";
 
   export let id: string;
@@ -66,7 +66,7 @@
 
   onMount(async () => {
     // Move tooltip to the body to avoid it being cut off by overflow: hidden.
-    document.body.appendChild(tooltipComponent);
+    nonNullish(tooltipComponent) && document.body.appendChild(tooltipComponent);
   });
 
   let destroyed = false;


### PR DESCRIPTION
# Motivation

Lint currently detects an error on `main`:

```
/Users/daviddalbusco/projects/dfinity/gix-components/src/lib/components/Tooltip.svelte:69:31
Error: Argument of type 'HTMLDivElement | undefined' is not assignable to parameter of type 'Node'.
  Type 'undefined' is not assignable to type 'Node'. (ts)
    // Move tooltip to the body to avoid it being cut off by overflow: hidden.
    document.body.appendChild(tooltipComponent);
  });
```
