### PR TITLE
Update colours 2024 04 22

### DIFF
--- a/src/lib/styles/global/colors.scss
+++ b/src/lib/styles/global/colors.scss
@@ -17,7 +17,6 @@
   --cp-light-600: #3d4d99; // never actually used
   --cp-light-900: #151a33;
   --cp-light-opaque: #ffffff40; // --cp-light-50 with 40% opacity
-  --cp-light-dense: #ffffff70; // --cp-light-50 with 45% opacity
   --cp-light-gradient-1: #d4e7fa;
   --cp-light-gradient-2: #f2dae2;
 
@@ -37,7 +36,6 @@
   --cp-dark-650: #150c31;
   --cp-dark-900: #130a2c;
   --cp-dark-opaque: #00000020;
-  --cp-dark-dense: #00000040;
   --cp-dark-gradient-1: #0f0f4d;
   --cp-dark-gradient-2: #4d1259;
 

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -112,7 +112,7 @@
 
   --content-background: var(--cp-dark-opaque);
   --content-color: var(--text-color);
-  --content-start-background: var(--cp-dark-450);
+  --content-start-background: var(--cp-dark-600);
   --content-start-color: var(--text-color);
 
   --overlay-background: var(--background);

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -127,7 +127,7 @@
   // Menu
   --menu-color: var(--cp-light-100);
   --menu-select-color: var(--cp-light-100);
-  --menu-selected-background: var(--cp-dark-dense);
+  --menu-selected-background: var(--cp-dark-600);
 
   --toolbar-color: var(--body-color); // Tab and segment
   --segment-selected-background: var(--overlay-content-background);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -103,7 +103,7 @@
     // Menu
     --menu-color: var(--cp-light-900);
     --menu-select-color: var(--cp-light-900);
-    --menu-selected-background: var(--cp-light-dense);
+    --menu-selected-background: var(--cp-light-75);
 
     --toolbar-color: var(--menu-color);
 


### PR DESCRIPTION
# Motivation

Change colours related to the main navigation to fix dots visibility and improve contrast.

nns-dapp sibling pr that will utilise this - https://github.com/dfinity/nns-dapp/pull/4753

# Changes

- change menu selection colour (will be also used for the mobile navigation dropdown background)
- update the colour of the split container (used only for universe list)
- cleanup

# Screenshots

<img width="541" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/1856ba10-91ac-4945-90a8-29aec1cd97dc">

<img width="709" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/4609602f-04ce-4852-aa87-590afe3db951">

<img width="468" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/396e99f3-4372-4f3d-8018-e671b9272be6">

<img width="463" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/447e0108-678e-42ba-9ef4-4ea47ba6947d">

