### PR TITLE
NNS1-2966: Empty title on tooltip target

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -85,6 +85,7 @@
     on:mouseenter={onMouseEnter}
     on:mouseleave={onMouseLeave}
     role="presentation"
+    title=""
   >
     <slot />
   </div>


### PR DESCRIPTION
# Motivation

If an element has a `title` attribute, the browser generates some kind of tooltip for it if you hover for a long time.
If this is done on the parent of a tooltip target, it can interfere with the actual tooltip.

# Changes

Add an empty `title` attribute on the tooltip target to prevent multiple tooltips from showing.

# Screenshots

Before:

https://github.com/dfinity/gix-components/assets/122978264/d3a82b5f-aac7-4293-9d4e-a84f28eae562

After:

https://github.com/dfinity/gix-components/assets/122978264/75c84c67-d4b9-4c4a-88b4-46a24fb167b2
