### PR TITLE
Close modal on esc

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -30,7 +30,15 @@
 
   const modalTitleId = nextElementId("modal-title-");
   const modalContentId = nextElementId("modal-content-");
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (visible && !disablePointerEvents && event.key === "Escape") {
+      close();
+    }
+  };
 </script>
+
+<svelte:window on:keydown={handleKeyDown} />
 
 {#if visible}
   <div

--- a/src/tests/lib/components/Modal.spec.ts
+++ b/src/tests/lib/components/Modal.spec.ts
@@ -123,6 +123,19 @@ describe("Modal", () => {
       backdrop && fireEvent.click(backdrop);
     }));
 
+  it("should trigger close modal on Esc", () =>
+    new Promise<void>((done) => {
+      const { container, component } = render(Modal, {
+        props,
+      });
+
+      component.$on("nnsClose", () => {
+        done();
+      });
+
+      fireEvent.keyDown(container, { key: "Escape" });
+    }));
+
   it("should not have a data-tid attribute", () => {
     const { container } = render(Modal, {
       props: {


### PR DESCRIPTION
# Motivation

To improve use experience the modal can be closed also on pressing `Esc` button.

# Changes

- Listen for keydown and close.

# Test

- Tested manually using upgraded `nns-dapp`.
- Added a test.

# Screenshots

No visual changes.
