### PR TITLE
Skip modal close on Esc when busy

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -6,6 +6,7 @@
   import Backdrop from "$lib/components/Backdrop.svelte";
   import { nonNullish } from "@dfinity/utils";
   import { nextElementId } from "$lib/utils/html.utils";
+  import {busy} from "$lib/stores/busy.store";
 
   export let visible = true;
   export let role: "dialog" | "alert" = "dialog";
@@ -31,8 +32,9 @@
   const modalTitleId = nextElementId("modal-title-");
   const modalContentId = nextElementId("modal-content-");
 
-  const handleKeyDown = ({ key }) => {
-    if (visible && !disablePointerEvents && key === "Escape") {
+  const handleKeyDown = ({key}) => {
+    // Check for $busy to mock the same behavior as the close button being covered by the busy overlay
+    if (visible && !disablePointerEvents && !$busy && key === "Escape") {
       close();
     }
   };

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -6,7 +6,7 @@
   import Backdrop from "$lib/components/Backdrop.svelte";
   import { nonNullish } from "@dfinity/utils";
   import { nextElementId } from "$lib/utils/html.utils";
-  import {busy} from "$lib/stores/busy.store";
+  import { busy } from "$lib/stores/busy.store";
 
   export let visible = true;
   export let role: "dialog" | "alert" = "dialog";
@@ -32,7 +32,7 @@
   const modalTitleId = nextElementId("modal-title-");
   const modalContentId = nextElementId("modal-content-");
 
-  const handleKeyDown = ({key}) => {
+  const handleKeyDown = ({ key }) => {
     // Check for $busy to mock the same behavior as the close button being covered by the busy overlay
     if (visible && !disablePointerEvents && !$busy && key === "Escape") {
       close();

--- a/src/tests/lib/components/Modal.spec.ts
+++ b/src/tests/lib/components/Modal.spec.ts
@@ -1,3 +1,4 @@
+import { startBusy } from "$lib";
 import Modal from "$lib/components/Modal.svelte";
 import { fireEvent, render } from "@testing-library/svelte";
 import ModalTest from "./ModalTest.svelte";
@@ -147,6 +148,20 @@ describe("Modal", () => {
 
     fireEvent.keyDown(container, { key: "Enter" });
     fireEvent.keyDown(container, { key: "Backspace" });
+  });
+
+  it("should not close modal on Esc when busy = true", () => {
+    const { container, component } = render(Modal, {
+      props,
+    });
+
+    startBusy({ initiator: "stake-neuron" });
+
+    component.$on("nnsClose", () => {
+      throw new Error("Should not close modal");
+    });
+
+    fireEvent.keyDown(container, { key: "Escape" });
   });
 
   it("should not have a data-tid attribute", () => {


### PR DESCRIPTION
# Motivation

Do not close the modal when the 'Escape' key is pressed if the busy store is active. This ensures the same behavior as when the close button is covered by the busy overlay.

# Changes

- Check for `busy` before close.
- Text added.

# Screenshots

- no visible changes
