### PR TITLE
chore: modal lint error

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -32,7 +32,7 @@
   const modalTitleId = nextElementId("modal-title-");
   const modalContentId = nextElementId("modal-content-");
 
-  const handleKeyDown = ({ key }) => {
+  const handleKeyDown = ({ key }: KeyboardEvent) => {
     // Check for $busy to mock the same behavior as the close button being covered by the busy overlay
     if (visible && !disablePointerEvents && !$busy && key === "Escape") {
       close();


### PR DESCRIPTION
# Motivation

Fix lint error:

> /Users/daviddalbusco/projects/dfinity/gix-components/src/lib/components/Modal.svelte:35:28
> Error: Binding element 'key' implicitly has an 'any' type. (ts)
>
>  const handleKeyDown = ({ key }) => {
>    // Check for $busy to mock the same behavior as the close button being covered by the busy overlay

