### PR TITLE
docs: correct typo in global import

### DIFF
--- a/src/routes/(page)/styling/usage/+page.md
+++ b/src/routes/(page)/styling/usage/+page.md
@@ -6,7 +6,7 @@ Within a `script` tag in your layout or app, import the `global.scss` of the lib
 
 ```html
 <_style lang="scss" global>
-  @import "@dfinity/gix-components/styles/global.scss";
+  @import "@dfinity/gix-components/dist/styles/global.scss";
 </_style>
 ```
 


### PR DESCRIPTION
# Motivation

The styles are shipped within a dist folder.

# Changes

- correct typo in documentation
