### PR TITLE
feat: VoteIcon size param

### DIFF
--- a/src/lib/icons/IconVote.svelte
+++ b/src/lib/icons/IconVote.svelte
@@ -1,7 +1,13 @@
 <!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
 <svg
-  width="20"
-  height="20"
+  height={size}
+  width={size}
   viewBox="0 0 20 20"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
# Motivation

We need to display a vote icon in a select actionable button at a non-standard size.

# Changes

- Add a `size` prop (tested manually).

# Screenshots

<img width="265" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/275cf920-8c19-436e-bb05-fea7fa707125">

