### PR TITLE
Use get instead of $

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -35,7 +35,7 @@
 
   const handleKeyDown = ({ key }: KeyboardEvent) => {
     // Check for $busy to mock the same behavior as the close button being covered by the busy overlay
-    if (visible && !disablePointerEvents && get(busy) && key === "Escape") {
+    if (visible && !disablePointerEvents && !get(busy) && key === "Escape") {
       close();
     }
   };

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -7,6 +7,7 @@
   import { nonNullish } from "@dfinity/utils";
   import { nextElementId } from "$lib/utils/html.utils";
   import { busy } from "$lib/stores/busy.store";
+  import { get } from "svelte/store";
 
   export let visible = true;
   export let role: "dialog" | "alert" = "dialog";
@@ -34,7 +35,7 @@
 
   const handleKeyDown = ({ key }: KeyboardEvent) => {
     // Check for $busy to mock the same behavior as the close button being covered by the busy overlay
-    if (visible && !disablePointerEvents && !$busy && key === "Escape") {
+    if (visible && !disablePointerEvents && get(busy) && key === "Escape") {
       close();
     }
   };


### PR DESCRIPTION
# Motivation

There is a bug that causes nns-dapp to crash. It’s possible to reproduce it locally against the dev version. It seems to be a weird Svelte behavior during unsubscribing from the store inside the window listener, but no real proof of this has been found. However, removing the store subscription leads to normal nns-dapp behavior without crashes.

How to reproduce the bug:

1. Sign into https://nns.ic0.app/
2. Click on Internet Computer
3. Click on “Receive”
4. Click on “Finish”
5. The site crashes.

# Changes

- Replacing `$` with `get(store)`.

# Test

- Manually tested.