### PR TITLE
Define --text-description-tint colors

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -6,6 +6,7 @@
   --elements-divider: var(--cp-dark-400);
   --elements-icons: var(--cp-dark-200);
   --text-description: var(--cp-dark-200);
+  --text-description-tint: var(--cp-dark-100);
   --text-light: var(--cp-light-50);
   --text-text: var(--cp-light-900);
   --input-focus-background: var(--cp-dark-450);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -7,6 +7,7 @@
     --elements-divider: var(--cp-light-150);
     --elements-icons: var(--cp-light-600);
     --text-description: var(--cp-light-600);
+    --text-description-tint: var(--cp-light-250);
     --text-light: var(--cp-light-50);
     --text-text: var(--cp-light-900);
     --input-focus-background: var(--cp-light-75);


### PR DESCRIPTION
# Motivation

These colors are used in the neurons table.

# Changes

Define `--text-description-tint` for light and dark theme as defined in Figma.