### PR TITLE
Add idPrefix prop to Tooltip

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -1,9 +1,14 @@
+<script lang="ts" context="module">
+  let nextTooltipIdSuffix = 0;
+</script>
+
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { nonNullish, notEmptyString } from "@dfinity/utils";
   import { translateTooltip } from "$lib/utils/tooltip.utils";
 
-  export let id: string;
+  export let id: string | undefined = undefined;
+  export let idPrefix = "tooltip";
   export let testId = "tooltip-component";
   export let text: string | undefined = undefined;
   export let noWrap = false;
@@ -16,6 +21,8 @@
   let tooltipTransformX = 0;
   let tooltipTransformY = 0;
   let tooltipStyle: string | undefined = undefined;
+
+  let idToUse = nonNullish(id) ? id : `${idPrefix}-${nextTooltipIdSuffix++}`;
 
   $: tooltipStyle = `--tooltip-transform-x: ${tooltipTransformX}px; --tooltip-transform-y: ${tooltipTransformY}px;`;
 
@@ -80,7 +87,7 @@
 <div class="tooltip-wrapper" data-tid={testId}>
   <div
     class="tooltip-target"
-    aria-describedby={id}
+    aria-describedby={idToUse}
     bind:this={target}
     on:mouseenter={onMouseEnter}
     on:mouseleave={onMouseLeave}
@@ -92,7 +99,7 @@
   <div
     class="tooltip"
     role="tooltip"
-    {id}
+    id={idToUse}
     class:noWrap
     class:top
     class:not-rendered={!notEmptyString(text)}

--- a/src/tests/lib/components/Tooltip.spec.ts
+++ b/src/tests/lib/components/Tooltip.spec.ts
@@ -2,8 +2,11 @@ import { render } from "@testing-library/svelte";
 import TooltipTest from "./TooltipTest.svelte";
 
 describe("Tooltip", () => {
+  const id = "tid";
+  const idPrefix = "id-prefix";
+
   it("should render target content", () => {
-    const { container } = render(TooltipTest, { text: "text" });
+    const { container } = render(TooltipTest, { text: "text", id });
 
     const element: HTMLParagraphElement | null = container.querySelector("p");
 
@@ -16,15 +19,59 @@ describe("Tooltip", () => {
   });
 
   it("should render aria-describedby and relevant id", () => {
-    const { container } = render(TooltipTest, { text: "text" });
+    const { container } = render(TooltipTest, { text: "text", id });
     expect(
       container.querySelector("[aria-describedby='tid']"),
     ).toBeInTheDocument();
     expect(container.querySelector("[id='tid']")).toBeInTheDocument();
   });
 
+  it("should render different ID per tooltip when using idPrefix", () => {
+    render(TooltipTest, { text: "text", idPrefix });
+    const { container } = render(TooltipTest, { text: "text", idPrefix });
+    const tooltipTargets = container.querySelectorAll(".tooltip-target");
+    expect(tooltipTargets).toHaveLength(2);
+    const describedBy1 = tooltipTargets[0].getAttribute("aria-describedby");
+    const describedBy2 = tooltipTargets[1].getAttribute("aria-describedby");
+    expect(describedBy1).not.toEqual(describedBy2);
+    expect(describedBy1).toMatch(new RegExp(`^${idPrefix}-\\d+$`));
+    expect(describedBy2).toMatch(new RegExp(`^${idPrefix}-\\d+$`));
+    expect(
+      container.querySelector(`[id="${describedBy1}"]`),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(`[id="${describedBy2}"]`),
+    ).toBeInTheDocument();
+  });
+
+  it("should render different ID per tooltip when not specifying any ID", () => {
+    render(TooltipTest, { text: "text", idPrefix });
+    const { container } = render(TooltipTest, { text: "text", idPrefix });
+    const tooltipTargets = container.querySelectorAll(".tooltip-target");
+    expect(tooltipTargets).toHaveLength(2);
+    const describedBy1 = tooltipTargets[0].getAttribute("aria-describedby");
+    const describedBy2 = tooltipTargets[1].getAttribute("aria-describedby");
+    expect(describedBy1).not.toEqual(describedBy2);
+    expect(
+      container.querySelector(`[id="${describedBy1}"]`),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(`[id="${describedBy2}"]`),
+    ).toBeInTheDocument();
+  });
+
+  it("should use id if both id and idPrefix are given", () => {
+    const { container } = render(TooltipTest, { text: "text", id, idPrefix });
+    const tooltipTarget = container.querySelector(".tooltip-target");
+    const describedBy = tooltipTarget.getAttribute("aria-describedby");
+    expect(describedBy).toBe(id);
+    expect(
+      container.querySelector(`[id="${describedBy}"]`),
+    ).toBeInTheDocument();
+  });
+
   it("should hide with empty text", () => {
-    const { container } = render(TooltipTest, { text: "" });
+    const { container } = render(TooltipTest, { text: "", id });
 
     // Content should still be rendered.
     const element: HTMLParagraphElement | null = container.querySelector("p");
@@ -37,7 +84,7 @@ describe("Tooltip", () => {
   });
 
   it("should hide with undefined text", () => {
-    const { container } = render(TooltipTest, { text: undefined });
+    const { container } = render(TooltipTest, { text: undefined, id });
 
     // Content should still be rendered.
     const element: HTMLParagraphElement | null = container.querySelector("p");
@@ -50,7 +97,7 @@ describe("Tooltip", () => {
   });
 
   it("should place tooltip directly in body element to evade overflow:hidden", () => {
-    const { container } = render(TooltipTest, { text: undefined });
+    const { container } = render(TooltipTest, { text: undefined, id });
 
     const tooltipElement = container.querySelector(".tooltip");
     expect(tooltipElement.parentElement).toBe(document.body);

--- a/src/tests/lib/components/Tooltip.spec.ts
+++ b/src/tests/lib/components/Tooltip.spec.ts
@@ -44,9 +44,9 @@ describe("Tooltip", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render different ID per tooltip when not specifying any ID", () => {
-    render(TooltipTest, { text: "text", idPrefix });
-    const { container } = render(TooltipTest, { text: "text", idPrefix });
+  it("should render different ID per tooltip when not specifying any id or idPrefix", () => {
+    render(TooltipTest, { text: "text" });
+    const { container } = render(TooltipTest, { text: "text" });
     const tooltipTargets = container.querySelectorAll(".tooltip-target");
     expect(tooltipTargets).toHaveLength(2);
     const describedBy1 = tooltipTargets[0].getAttribute("aria-describedby");

--- a/src/tests/lib/components/TooltipTest.svelte
+++ b/src/tests/lib/components/TooltipTest.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import Tooltip from "$lib/components/Tooltip.svelte";
 
+  export let id: string | undefined = undefined;
+  export let idPrefix: string | undefined = undefined;
   export let text: string | undefined = undefined;
 </script>
 
-<Tooltip id="tid" {text}>
+<Tooltip {id} {idPrefix} {text}>
   <p>content</p>
 </Tooltip>


### PR DESCRIPTION
# Motivation

Every tooltip must have a unique ID so the target can be correctly associated with the tooltip through `describedby`.
Giving a unique ID to a tooltip in a component that appears multiple times on the page, can be tedious.

# Changes

1. Add `idPrefix` prop to `Tooltip` and make `id` optional. If `id` is not specified, a unique ID is automatically generated by combining the prefix with a sequence number. For backwards compatibility, if `id` is specified, it's used as is.

# Tested

1. Unit tests were added.
2. Tested in nns-dapp repo.
