### PR TITLE
Elements divider colours update

### DIFF
--- a/src/lib/components/SplitBlock.svelte
+++ b/src/lib/components/SplitBlock.svelte
@@ -28,7 +28,7 @@
   hr {
     margin: 0;
     height: 1px;
-    background: var(--line);
+    background: var(--elements-divider);
     border: none;
 
     @include media.min-width(large) {

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -3,7 +3,7 @@
 :root {
   // -------- NEW CSS VARIABLES ----------------
   // We want to migrate to a new set of CSS variables for colors more adapted to our Figma.
-  --elements-divider: var(--cp-dark-400);
+  --elements-divider: var(--cp-dark-550);
   --elements-icons: var(--cp-dark-200);
   --text-description: var(--cp-dark-200);
   --text-description-tint: var(--cp-dark-100);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -4,7 +4,7 @@
   &[theme="light"] {
     // -------- NEW CSS VARIABLES ----------------
     // We want to migrate to a new set of CSS variables for colors more adapted to our Figma.
-    --elements-divider: var(--cp-light-150);
+    --elements-divider: var(--cp-light-125);
     --elements-icons: var(--cp-light-600);
     --text-description: var(--cp-light-600);
     --text-description-tint: var(--cp-light-250);


### PR DESCRIPTION
# Motivation

To ensure consistent styling for dividers on the proposal/proposal-details page, we have updated the style in this PR.

# Changes

- Change the `--elements-divider` CSS variable (approved by designer).
- Apply this class SplitBlock divider.

# Screenshots

