### PR TITLE
Remove out-dated comments

### DIFF
--- a/src/lib/styles/global/colors.scss
+++ b/src/lib/styles/global/colors.scss
@@ -14,7 +14,7 @@
   --cp-light-250: #6f7fcd;
   --cp-light-400: #34407c;
   --cp-light-500: #32449e;
-  --cp-light-600: #3d4d99; // never actually used
+  --cp-light-600: #3d4d99;
   --cp-light-900: #151a33;
   --cp-light-opaque: #ffffff40; // --cp-light-50 with 40% opacity
   --cp-light-gradient-1: #d4e7fa;
@@ -30,7 +30,7 @@
   --cp-dark-350: #4b3bf8;
   --cp-dark-400: #3d3061;
   --cp-dark-450: #2b1b4d;
-  --cp-dark-500: #342759; // not actually used
+  --cp-dark-500: #342759;
   --cp-dark-550: #3c2e66;
   --cp-dark-600: #170c36;
   --cp-dark-650: #150c31;


### PR DESCRIPTION
# Motivation

`--cp-light-600` and `--cp-dark-500` have comments saying they are not used.
`--cp-light-600` is used [here](https://github.com/dfinity/gix-components/blob/40f7fdf3c93210c58e59e566b1f73a9953b9990a/src/lib/styles/themes/light.scss#L8-L9).
`--cp-dark-500` is used [here](https://github.com/dfinity/gix-components/blob/40f7fdf3c93210c58e59e566b1f73a9953b9990a/src/lib/styles/themes/dark.scss#L14-L17). 
# Changes

Remove the incorrect comments.