### PR TITLE
Support rich content in tooltip

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -3,8 +3,8 @@
 </script>
 
 <script lang="ts">
+  import { isNullish, nonNullish, notEmptyString } from "@dfinity/utils";
   import { onMount, onDestroy } from "svelte";
-  import { nonNullish, notEmptyString } from "@dfinity/utils";
   import { translateTooltip } from "$lib/utils/tooltip.utils";
 
   export let id: string | undefined = undefined;
@@ -24,6 +24,9 @@
 
   let idToUse = nonNullish(id) ? id : `${idPrefix}-${nextTooltipIdSuffix++}`;
 
+  let isAbsent: boolean;
+  $: isAbsent = isNullish($$slots["tooltip-content"]) && !notEmptyString(text);
+
   $: tooltipStyle = `--tooltip-transform-x: ${tooltipTransformX}px; --tooltip-transform-y: ${tooltipTransformY}px;`;
 
   const setPosition = () => {
@@ -33,7 +36,7 @@
       return;
     }
 
-    if (!notEmptyString(text)) {
+    if (isAbsent) {
       return;
     }
 
@@ -102,12 +105,12 @@
     id={idToUse}
     class:noWrap
     class:top
-    class:not-rendered={!notEmptyString(text)}
+    class:not-rendered={isAbsent}
     class:visible={targetIsHovered}
     bind:this={tooltipComponent}
     style={tooltipStyle}
   >
-    {text}
+    {#if nonNullish(text)}{text}{/if}<slot name="tooltip-content" />
   </div>
 </div>
 

--- a/src/routes/(split)/components/tooltip/+page.md
+++ b/src/routes/(split)/components/tooltip/+page.md
@@ -100,9 +100,11 @@ The tooltips will appear when the buttons are hovered or tapped.
       <Tooltip
         id="example-button"
         top={true}
-        text={tooltipText}
       >
         <button class="secondary" disabled>Disabled</button>
+        <div slot="tooltip-content">
+          This is tooltip has <b><i>rich</i></b> content.
+        </div>
       </Tooltip>
     </div>
   </div>

--- a/src/tests/lib/components/Tooltip.spec.ts
+++ b/src/tests/lib/components/Tooltip.spec.ts
@@ -12,10 +12,30 @@ describe("Tooltip", () => {
 
     expect(element).toBeInTheDocument();
     expect(element?.innerHTML).toBe("content");
+  });
+
+  it("should render tooltip text content", () => {
+    const { container } = render(TooltipTest, { text: "text", id });
+
+    const element: HTMLParagraphElement | null = container.querySelector("p");
 
     const tooltipElement = container.querySelector(".tooltip");
     expect(tooltipElement).toBeInTheDocument();
     expect(tooltipElement.classList).not.toContain("not-rendered");
+    expect(tooltipElement.innerHTML).toBe("text");
+  });
+
+  it("should render tooltip slot content", () => {
+    const { container } = render(TooltipTest, { slotText: "slot text", id });
+
+    const element: HTMLParagraphElement | null = container.querySelector("p");
+
+    const tooltipElement = container.querySelector(".tooltip");
+    expect(tooltipElement).toBeInTheDocument();
+    expect(tooltipElement.classList).not.toContain("not-rendered");
+    expect(tooltipElement.innerHTML).toBe(
+      '<div slot="tooltip-content">slot text</div>',
+    );
   });
 
   it("should render aria-describedby and relevant id", () => {

--- a/src/tests/lib/components/TooltipTest.svelte
+++ b/src/tests/lib/components/TooltipTest.svelte
@@ -4,8 +4,18 @@
   export let id: string | undefined = undefined;
   export let idPrefix: string | undefined = undefined;
   export let text: string | undefined = undefined;
+  export let slotText: string | undefined = undefined;
 </script>
 
-<Tooltip {id} {idPrefix} {text}>
-  <p>content</p>
-</Tooltip>
+{#if slotText === undefined}
+  <Tooltip {id} {idPrefix} {text}>
+    <p>content</p>
+  </Tooltip>
+{:else}
+  <Tooltip {id} {idPrefix}>
+    <p>content</p>
+    <div slot="tooltip-content">
+      {slotText}
+    </div>
+  </Tooltip>
+{/if}


### PR DESCRIPTION
# Motivation

Currently the contents of the tooltip is specified as a text string.
We want to be able to show richer tooltips with styling.

# Changes

Allow passing the tooltip content as a slot instead of just a `text` prop.

Note that with the `text` prop it's currently possible to disable the tooltip entirely by making the `text` prop empty or `undefined`.
When using the slot, there is currently no way to make the tooltip conditional.
This would require an additional boolean prop.
This might be useful but we'll add it when we need it.

# Screenshots

<img width="229" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/293bc552-5ec4-465e-a636-9d845d74a8f3">
