### PR TITLE
Do not use token on fork PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,27 +10,46 @@ jobs:
   formatting:
     runs-on: ubuntu-20.04
 
+    # In order to trigger the CLA after committing formatting changes, we need to
+    # use the GIX_CREATE_PR_PAT token. This token is not available on PRs
+    # created from a fork. So on PRs created from a fork, we don't commit
+    # changes and instead just fail if the formatting is incorrect.
     steps:
+      - name: Check if PR is from a fork
+        id: check_fork
+        run: |
+          echo "is_pr_from_fork=${{ github.event.pull_request.head.repo.full_name != github.repository }}" >> $GITHUB_OUTPUT
+
       - name: Checkout
+        if: steps.check_fork.outputs.is_pr_from_fork == 'false'
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
+      - name: Checkout Fork
+        if: steps.check_fork.outputs.is_pr_from_fork == 'true'
+        uses: actions/checkout@v2
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt
-
       - name: Format shell scripts
         run: ./scripts/fmt-sh
 
       - name: Install ts dependencies
         run: npm ci
-
-      - name: Format
+      - name: Format ts
         run: npm run format
 
+      - name: Check formatting changes
+        id: check_format
+        run: |
+          if git diff --exit-code; then
+            echo "formatting_needed=false" >> $GITHUB_OUTPUT
+          else
+            echo "formatting_needed=true" >> $GITHUB_OUTPUT
+          fi
       - name: Commit Formatting changes
+        if: steps.check_fork.outputs.is_pr_from_fork == 'false' && steps.check_format.outputs.formatting_needed == 'true'
         uses: EndBug/add-and-commit@v7.2.0
-        if: ${{ github.event_name == 'pull_request' }}
         with:
           add: .
           default_author: github_actions
@@ -39,6 +58,11 @@ jobs:
           # the pushing fail
           pull_strategy: "NO-PULL"
 
+      - name: Fail for formatting issues in forks
+        if: steps.check_fork.outputs.is_pr_from_fork == 'true' && steps.check_format.outputs.formatting_needed == 'true'
+        run: |
+          echo "Formatting changes are needed but couldn't be committed because the PR was created from a fork."
+          exit 1
 
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Motivation

This is the change analogous to https://github.com/dfinity/ic-js/pull/660 in ic-js.

When dependabot tries to make changes, CI fails because the personal access token can't be used on PRs made from forks.
See for example: https://github.com/dfinity/gix-components/pull/439

# Changes

1. Check of the PR was made from a fork.
2. If so, don't use the token on checkout and fail instead of committing formatting changes if needed.