### PR TITLE
Change tooltip colors to dropdown colors

### DIFF
--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -98,13 +98,13 @@
     display: flex;
     flex-direction: column;
 
-    background-color: var(--tooltip-background);
+    background-color: var(--dropdown-background);
     color: var(--background-contrast);
 
     border-radius: var(--border-radius);
 
     &.with-border {
-      border: var(--tooltip-border-size) solid var(--tooltip-border-color);
+      border: var(--dropdown-border-size) solid var(--dropdown-border-color);
     }
   }
 

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -60,10 +60,12 @@
   --input-border-color: var(--cp-dark-400);
   --input-border-size: 1.5px;
 
-  //Tooltip
-  --tooltip-border-color: var(--cp-dark-400);
-  --tooltip-border-size: 1.5px;
-  --tooltip-background: var(--cp-dark-500);
+  // Dropdown (used for Popover)
+  --dropdown-background: var(--cp-dark-500);
+  --dropdown-focus-background: var(--cp-dark-450);
+  --dropdown-border-color: var(--cp-dark-400);
+  --dropdown-focus-border-color: var(--cp-dark-accent);
+  --dropdown-border-size: 1.5px;
 
   // Buttons custom colors
   --button-secondary-color: var(--secondary);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -43,9 +43,11 @@
     /* Design Light/7969C0 (8%)-light */
     --input-border-color: var(--cp-light-150);
 
-    // Tooltip
-    --tooltip-border-color: var(--cp-light-150);
-    --tooltip-background: var(--cp-light-100);
+    // Dropdown (used for Popover)
+    --dropdown-background: var(--cp-light-100);
+    --dropdown-focus-background: var(--cp-light-75);
+    --dropdown-border-color: var(--cp-light-150);
+    --dropdown-focus-border-color: var(--cp-light-accent);
 
     // Buttons custom colors
     --button-secondary-color: var(--primary);


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/gix-components/pull/393 I added colors with the `--tooltip` prefix but these don't currently match the Tooltip colors in Figma. They match the Dropdown colors in Figma, but they are used for the `Popover` component. We also have Popup colors in Figma but no Popover colors.
In the [design](https://www.figma.com/design/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?node-id=1851-9872&t=YgFrTo6bb8sZXPJE-4) for the `Hide zero balances` feature, the popup uses the Dropdown colors. The implementation of the feature uses the `Popover` component. I'm not sure all of this is correct but now at least our CSS matches Figma regarding these colors.

I've also decided to just add all the Dropdown colors that are currently in Figma rather than only the ones we use.

# Changes

1. Change names of CSS variables with `--tooltip` prefix to `--dropdown` prefix.
2. Add additional `--dropdown` colors.
3. Update usage of these variables.

# Screenshots

unchanged

Tested manually in nns-dapp.
