### PR TITLE
Add resetScrollPosition function

### DIFF
--- a/src/lib/components/SplitContent.svelte
+++ b/src/lib/components/SplitContent.svelte
@@ -9,6 +9,13 @@
   import ContentBackdrop from "$lib/components/ContentBackdrop.svelte";
 
   export let back = false;
+  export const resetScrollPosition = () => {
+    if (scrollableElement) {
+      scrollableElement.scrollTop = 0;
+    }
+  };
+
+  let scrollableElement: HTMLElement | undefined;
 
   // Same as in <Content />
   onDestroy(() => ($layoutBottomOffset = 0));
@@ -33,7 +40,7 @@
       <slot name="toolbar-end" slot="toolbar-end" />
     </Header>
 
-    <div class="scrollable-content-end">
+    <div class="scrollable-content-end" bind:this={scrollableElement}>
       <ContentBackdrop />
 
       <slot name="end" />

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -18,9 +18,10 @@ A component that renders a header, a column and your content.
 
 ## Properties
 
-| Property | Description                                                     | Type      | Default |
-| -------- | --------------------------------------------------------------- | --------- | ------- |
-| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false` |
+| Property              | Description                                                     | Type       | Default    |
+| --------------------- | --------------------------------------------------------------- | ---------- | ---------- |
+| `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`    |
+| `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function` |
 
 ## Slots
 

--- a/src/tests/lib/components/SplitContent.spec.ts
+++ b/src/tests/lib/components/SplitContent.spec.ts
@@ -26,8 +26,10 @@ describe("SplitContent", () => {
 
   it("should reset content scroll position", () => {
     const { container, component } = render(SplitContentTest);
-    
-    const scrollableContent = container.querySelector(".scrollable-content-end") as HTMLElement;
+
+    const scrollableContent = container.querySelector(
+      ".scrollable-content-end",
+    ) as HTMLElement;
     scrollableContent.scrollTop = 100;
     expect(scrollableContent.scrollTop).toEqual(100);
 

--- a/src/tests/lib/components/SplitContent.spec.ts
+++ b/src/tests/lib/components/SplitContent.spec.ts
@@ -23,4 +23,15 @@ describe("SplitContent", () => {
     const { container } = render(SplitContentTest);
     expect(container.querySelector("header")).not.toBeNull();
   });
+
+  it("should reset content scroll position", () => {
+    const { container, component } = render(SplitContentTest);
+    
+    const scrollableContent = container.querySelector(".scrollable-content-end") as HTMLElement;
+    scrollableContent.scrollTop = 100;
+    expect(scrollableContent.scrollTop).toEqual(100);
+
+    component.originalComponent.resetScrollPosition();
+    expect(scrollableContent.scrollTop).toEqual(0);
+  });
 });

--- a/src/tests/lib/components/SplitContentTest.svelte
+++ b/src/tests/lib/components/SplitContentTest.svelte
@@ -1,8 +1,9 @@
-<svelte:options accessors/>
+<svelte:options accessors />
+
 <script lang="ts">
   import SplitContent from "$lib/components/SplitContent.svelte";
 
-export let originalComponent: SplitContent;
+  export let originalComponent: SplitContent;
 </script>
 
 <SplitContent bind:this={originalComponent}>

--- a/src/tests/lib/components/SplitContentTest.svelte
+++ b/src/tests/lib/components/SplitContentTest.svelte
@@ -1,8 +1,11 @@
+<svelte:options accessors/>
 <script lang="ts">
   import SplitContent from "$lib/components/SplitContent.svelte";
+
+export let originalComponent: SplitContent;
 </script>
 
-<SplitContent>
+<SplitContent bind:this={originalComponent}>
   <div data-tid="content-test-start-slot" slot="start" />
   <div data-tid="content-test-end-slot" slot="end" />
   <div data-tid="content-test-title-slot" slot="title" />


### PR DESCRIPTION
# Motivation

When switching between universes, the user would find themselves somewhere in the middle of the list. This issue went unnoticed before due to paginated loading, which resulted in the list being empty immediately after switching. However, with actionables now being preloaded, this has become a significant UX issue. 

The proposals are rendered inside the `SplitContent` component. To reset the scroll position without having to search through the DOM, we have added a `resetScrollPosition` function.

# Changes

- new `resetScrollPosition` function.

# Screenshots

No visual changes. Tested in nns-dapp.
