### PR TITLE
Use access token when updating screenshots

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Install dependencies
         run: npm ci
       - name: Run Playwright tests


### PR DESCRIPTION
# Motivation

When updating the screenshots, the CLA can get stuck because CI doesn't run again.
The solution is to use the personal access token, similar to how we do when [formatting](https://github.com/dfinity/gix-components/blob/34247fb67b9fb0945e3d3ceee065a13a5e36723c/.github/workflows/checks.yml#L27).

# Changes

Use the `secrets.GIX_CREATE_PR_PAT` in the snapshots workflow.

# Tested

https://github.com/dfinity/gix-components/actions/runs/9581570545/job/26418670825
