### PR TITLE
chore: lint 'element' is assigned a value but never used in a test

### DIFF
--- a/src/tests/lib/components/Tooltip.spec.ts
+++ b/src/tests/lib/components/Tooltip.spec.ts
@@ -28,8 +28,6 @@ describe("Tooltip", () => {
   it("should render tooltip text content", () => {
     const { container } = render(TooltipTest, { text: "text", id });
 
-    const element: HTMLParagraphElement | null = container.querySelector("p");
-
     const tooltipElement = container.querySelector(".tooltip");
     expect(tooltipElement).toBeInTheDocument();
     expect(tooltipElement.classList).not.toContain("not-rendered");
@@ -38,8 +36,6 @@ describe("Tooltip", () => {
 
   it("should render tooltip slot content", () => {
     const { container } = render(TooltipTest, { slotText: "slot text", id });
-
-    const element: HTMLParagraphElement | null = container.querySelector("p");
 
     const tooltipElement = container.querySelector(".tooltip");
     expect(tooltipElement).toBeInTheDocument();


### PR DESCRIPTION
# Motivation

> Checking formatting...
> All matched files use Prettier code style!
> 
> /Users/daviddalbusco/projects/dfinity/gix-components/src/tests/lib/components/Tooltip.spec.ts
>   31:11  warning  'element' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
>   42:11  warning  'element' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
> 
> ✖ 2 problems (0 errors, 2 warnings)

# Changes

- Remove two unused constants in a test.
