### PR TITLE
chore: do not accept lint warnings in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --max-warnings 0
 
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Motivation

We do not want the CI to pass when `npm run lint` detects warnings.
