### PR TITLE
Improve clicked icon buttons visibility in light theme

### DIFF
--- a/src/lib/styles/mixins/_effect.scss
+++ b/src/lib/styles/mixins/_effect.scss
@@ -1,10 +1,16 @@
-@mixin ripple-effect($color) {
+@mixin ripple-effect($background, $color: null) {
   &:focus {
-    background: var($color)
-      radial-gradient(circle, transparent 1%, var($color) 1%) center/15000%;
+    @if $color != null {
+      color: $color;
+    }
+    background: var($background)
+      radial-gradient(circle, transparent 1%, var($background) 1%) center/15000%;
   }
 
   &:active {
+    @if $color != null {
+      color: $color;
+    }
     background-color: var(--tertiary);
     background-size: 100%;
     transition: background 0s;

--- a/src/lib/styles/mixins/_header.scss
+++ b/src/lib/styles/mixins/_header.scss
@@ -2,7 +2,7 @@
 @use "./text";
 @use "./media";
 
-@mixin button($color) {
+@mixin button($background) {
   width: var(--padding-4x);
   min-width: var(--padding-4x);
   height: var(--padding-4x);
@@ -14,11 +14,11 @@
     color: var(--content-color);
   }
 
-  @include effect.ripple-effect($color);
+  @include effect.ripple-effect($background, var(--primary-contrast));
 
   &:focus {
     background: var(--primary-tint);
-    @include effect.ripple-effect($color);
+    @include effect.ripple-effect($background, var(--primary-contrast));
   }
 }
 


### PR DESCRIPTION
# Motivation

The icon buttons that use the ripple-effect look good in the dark theme when focused or active (eg. after mouse down), but are too dim in the light theme. This happens because, in the light theme, the button’s background becomes dark when focused, and the icon color is also dark. To fix this and make the buttons clearly visible when clicked, this PR changes the text color of the button for affected states to provide more contrast with the background color.

# Changes

- Added a new optional argument to the `ripple-effect` mixin to provide a custom text color (to avoid introducing a breaking change).
- Provided a custom text color for header buttons.

# Screenshots

Note: the ripple effect remains without visual changes.

## Before

<img width="55" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/9f6010a0-2fe2-4355-a5a2-3e34c7f8829c">

## After

<img width="55" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/6bacb359-7694-450b-b648-078f1ff9a3d1">

