### PR TITLE
Move tooltip back to body in afterUpdate

### DIFF
--- a/e2e/tooltip.e2e.ts
+++ b/e2e/tooltip.e2e.ts
@@ -13,9 +13,13 @@ test("Should render tooltip", async ({ page }) => {
     showcase.getByTestId("tooltip-component").nth(2).locator(".tooltip"),
   ).not.toBeVisible();
 
-  showcase.locator("button.secondary").nth(2).hover();
+  const secondTarget = showcase.locator(".tooltip-target").nth(2)
+  const secondButton = await secondTarget.locator("button");
+  await secondButton.hover();
 
-  await expect(page.locator(".tooltip").nth(2)).toBeVisible();
+  const tooltipId = await secondTarget.getAttribute("aria-describedby");
+  const tooltip = await page.locator(`[id="${tooltipId}"]`);
+  await expect(tooltip).toBeVisible();
 
   await expect(page).toHaveScreenshot();
 });

--- a/e2e/tooltip.e2e.ts
+++ b/e2e/tooltip.e2e.ts
@@ -13,7 +13,7 @@ test("Should render tooltip", async ({ page }) => {
     showcase.getByTestId("tooltip-component").nth(2).locator(".tooltip"),
   ).not.toBeVisible();
 
-  const secondTarget = showcase.locator(".tooltip-target").nth(2)
+  const secondTarget = showcase.locator(".tooltip-target").nth(2);
   const secondButton = await secondTarget.locator("button");
   await secondButton.hover();
 

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
   import { isNullish, nonNullish, notEmptyString } from "@dfinity/utils";
-  import { onMount, onDestroy } from "svelte";
+  import { afterUpdate, onMount, onDestroy } from "svelte";
   import { translateTooltip } from "$lib/utils/tooltip.utils";
 
   export let id: string | undefined = undefined;
@@ -74,10 +74,14 @@
     targetIsHovered = false;
   };
 
-  onMount(async () => {
+  const moveTooltipToBody = () => {
     // Move tooltip to the body to avoid it being cut off by overflow: hidden.
     nonNullish(tooltipComponent) && document.body.appendChild(tooltipComponent);
-  });
+  };
+
+  onMount(moveTooltipToBody);
+
+  afterUpdate(moveTooltipToBody);
 
   let destroyed = false;
   onDestroy(() => {

--- a/src/tests/lib/components/Tooltip.spec.ts
+++ b/src/tests/lib/components/Tooltip.spec.ts
@@ -1,4 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import TooltipListTest from "./TooltipListTest.svelte";
 import TooltipTest from "./TooltipTest.svelte";
 
 describe("Tooltip", () => {
@@ -128,5 +130,32 @@ describe("Tooltip", () => {
 
     const tooltipElement = container.querySelector(".tooltip");
     expect(tooltipElement.parentElement).toBe(document.body);
+  });
+
+  it("should keep tooltips directly in body when rearranged", async () => {
+    const tooltip1 = { text: "tooltip1", id: "id1" };
+    const tooltip2 = { text: "tooltip2", id: "id2" };
+    const { container, component } = render(TooltipListTest, {
+      list: [tooltip1, tooltip2],
+    });
+
+    {
+      const tooltipElements = container.querySelectorAll(".tooltip");
+      expect(tooltipElements).toHaveLength(2);
+      expect(tooltipElements[0].parentElement).toBe(document.body);
+      expect(tooltipElements[1].parentElement).toBe(document.body);
+    }
+
+    // After rearranging the components, the tooltips should still be direct
+    // children of the body.
+    component.$set({ list: [tooltip2, tooltip1] });
+    await tick();
+
+    {
+      const tooltipElements = container.querySelectorAll(".tooltip");
+      expect(tooltipElements).toHaveLength(2);
+      expect(tooltipElements[0].parentElement).toBe(document.body);
+      expect(tooltipElements[1].parentElement).toBe(document.body);
+    }
   });
 });

--- a/src/tests/lib/components/TooltipListTest.svelte
+++ b/src/tests/lib/components/TooltipListTest.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Tooltip from "$lib/components/Tooltip.svelte";
+
+  export let list: Array<{ text: string; id: number }>;
+</script>
+
+<ul>
+  {#each list as { text, id } (id)}
+    <li>
+      <Tooltip {id} {text}>
+        <p>content {id}</p>
+      </Tooltip>
+    </li>
+  {/each}
+</ul>


### PR DESCRIPTION
# Motivation

I noticed in the neurons table that when the order of the rows is changed, the tooltips are moved inside the `overflow: hidden` container and end up being cut off.
We move tooltips directly to the document body in `onMount` to make sure they are not cut off.
The solution I found is to move the tooltips again in `afterUpdate`.

# Changes

Move tooltips to the document body in `afterUpdate` the same as in `onMount`.

# Tested

1. Unit test added.
2. Checked that the unit test failed with `afterUpdate` commented out.
3. Updated e2e test because the tooltips are no longer guaranteed to be in the same order in the DOM as the tooltip targets.
4. Tested manually in an nns-dapp branch.
