### PR TITLE
Add IconSort

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -50,6 +50,7 @@ export { default as IconRight } from "./icons/IconRight.svelte";
 export { default as IconRocketLaunch } from "./icons/IconRocketLaunch.svelte";
 export { default as IconSettings } from "./icons/IconSettings.svelte";
 export { default as IconSettingsPage } from "./icons/IconSettingsPage.svelte";
+export { default as IconSort } from "./icons/IconSort.svelte";
 export { default as IconSouth } from "./icons/IconSouth.svelte";
 export { default as IconStackedLineChart } from "./icons/IconStackedLineChart.svelte";
 export { default as IconStakedMaturity } from "./icons/IconStakedMaturity.svelte";

--- a/src/lib/icons/IconSort.svelte
+++ b/src/lib/icons/IconSort.svelte
@@ -1,0 +1,25 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+>
+  <path d="M3.33301 14.166H9.33301" />
+  <path d="M3.3335 10L9.3335 10" />
+  <path d="M3.33301 5.83398L9.33301 5.83398" />
+  <path
+    d="M14.167 3.66602L14.167 16.666M14.167 3.66602L11.667 6.91602M14.167 3.66602L16.667 6.91602M14.167 16.666L16.667 13.416M14.167 16.666L11.667 13.416"
+    stroke-linejoin="round"
+  />
+</svg>


### PR DESCRIPTION
# Motivation

We want to use the icon to access table sorting on mobile.

# Changes

`IconSort.svelte`

# Screenshots

<img width="89" alt="image" src="https://github.com/dfinity/gix-components/assets/122978264/8c650bba-234b-431d-a4d7-57a0d2d0bf11">

