### PR TITLE
Remove buttons default padding

### DIFF
--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -147,7 +147,6 @@
     width: var(--padding-4x);
 
     margin: 0;
-    padding: 0;
 
     display: flex;
     align-items: center;

--- a/src/lib/components/KeyValuePairInfo.svelte
+++ b/src/lib/components/KeyValuePairInfo.svelte
@@ -59,7 +59,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0;
 
     &.alignIconRight {
       padding-left: var(--padding-0_5x);

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -225,7 +225,6 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      padding: 0;
 
       justify-self: flex-end;
 

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -208,7 +208,6 @@
     }
 
     button.close {
-      padding: 0;
       line-height: 0;
       color: inherit;
     }

--- a/src/lib/icons/IconLockOpen.svelte
+++ b/src/lib/icons/IconLockOpen.svelte
@@ -8,18 +8,39 @@
 <svg
   width={size}
   height={size}
-  viewBox="0 0 20 20"
+  viewBox="0 0 21 21"
   fill="none"
   stroke="currentColor"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path
-    d="M2.75 9C2.75 7.75736 3.75736 6.75 5 6.75H15C16.2426 6.75 17.25 7.75736 17.25 9V15C17.25 16.2426 16.2426 17.25 15 17.25H5C3.75736 17.25 2.75 16.2426 2.75 15V9Z"
-    stroke-width="1.5"
-  />
-  <path
-    d="M13 3V3C13 1.89543 12.1046 1 11 1H9C7.89543 1 7 1.89543 7 3V7"
-    stroke-width="1.5"
-  />
-  <circle cx="10" cy="12" r="1" fill="currentColor" />
+  <g clip-path="url(#clip0_32_69)">
+    <path
+      d="M6.70651 8.00232H15.0373C16.0032 8.00232 16.7865 8.78561 16.7865 9.75232V15.5857C16.7865 16.5524 16.0032 17.3357 15.0373 17.3357H6.70651C5.74065 17.3357 4.95728 16.5524 4.95728 15.5857V9.75232C4.95728 8.78561 5.74065 8.00232 6.70651 8.00232Z"
+      stroke="currentColor"
+      stroke-width="1.5"
+    />
+    <path
+      d="M13.6492 7.25232V4.83899C13.6492 3.39585 14.8191 2.22595 16.2622 2.22595V2.22595C17.7053 2.22595 18.8752 3.39585 18.8752 4.83899V5.09517"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+    />
+    <path
+      d="M10.8699 12.6691H10.8749"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+  <defs>
+    <clipPath id="clip0_32_69">
+      <rect
+        width="20"
+        height="20"
+        fill="currentColor"
+        transform="translate(0.875 0.585693)"
+      />
+    </clipPath>
+  </defs>
 </svg>

--- a/src/lib/styles/global/theme.scss
+++ b/src/lib/styles/global/theme.scss
@@ -44,11 +44,10 @@ button {
   background: transparent;
 
   margin: 0;
+  padding: 0;
 
   cursor: pointer;
   user-select: none;
-
-  padding: 0 var(--padding-0_5x);
 }
 
 section {


### PR DESCRIPTION
# Motivation

Currently, a `button` tag by default has a small (0.5rem) horizontal padding. This breaks the alignment in the account menu because some entries are rendered with an `a` tag, which has no extra padding, while others use a `button` tag.

There are not so many affected buttons. For many buttons the padding is overwritten: g.e.`.primary, .secondary, .success, .danger, .warning` (based on the `button.base` mixin), `icon-only`, 'icon'.

The buttons that are affected by the changes in this PR: `.full-width`, `.ghost`, `.text`, `.with-icon`, `.card`.

# Changes

- Set the padding 0 by default for buttons. This will not affect most of the buttons, only that who uses no @button.base mixin (copy button, 
- Remove `padding: 0` from the places where the default padding is not needed.

# Screenshots

<!-- Please provide any information or screenshots about the changes that have been done -->
