### PR TITLE
chore: set about phrase as description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dfinity/gix-components",
+  "description": "A UI kit developed by the GIX team",
   "version": "4.4.0",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
# Motivation

Npmjs displays a not well formatted description (see screenshot). I assume this happens because we do not have a `description` field in `package.json` and npmjs automatically fallbacks on the text provided in the README. It's an assumption but, in any case, it is worth to have such a field in the package.

# Changes

- Add `"description": "A UI kit developed by the GIX team"` to `package.json`

# Screenshots

<img width="1536" alt="Capture d’écran 2024-07-22 à 11 51 33" src="https://github.com/user-attachments/assets/83f7ac1d-9692-4945-8468-d2f51ec31feb">

