### PR TITLE
chore: bump version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/gix-components",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dfinity/gix-components",
   "description": "A UI kit developed by the GIX team",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",


### PR DESCRIPTION
# Motivation

We want to release a version of gix-cmp.

# Changes

- Bump version number to `4.6.0`.