### PR TITLE
New Dots, Bin and AddCircle icons

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,7 +1,9 @@
 export { default as IconAccountBalance } from "./icons/IconAccountBalance.svelte";
 export { default as IconAccountsPage } from "./icons/IconAccountsPage.svelte";
 export { default as IconAdd } from "./icons/IconAdd.svelte";
+export { default as IconAddCircle } from "./icons/IconAddCircle.svelte";
 export { default as IconBack } from "./icons/IconBack.svelte";
+export { default as IconBin } from "./icons/IconBin.svelte";
 export { default as IconCanistersPage } from "./icons/IconCanistersPage.svelte";
 export { default as IconChat } from "./icons/IconChat.svelte";
 export { default as IconCheck } from "./icons/IconCheck.svelte";
@@ -13,6 +15,7 @@ export { default as IconCollapseAll } from "./icons/IconCollapseAll.svelte";
 export { default as IconCopy } from "./icons/IconCopy.svelte";
 export { default as IconDarkMode } from "./icons/IconDarkMode.svelte";
 export { default as IconDissolving } from "./icons/IconDissolving.svelte";
+export { default as IconDots } from "./icons/IconDots.svelte";
 export { default as IconDown } from "./icons/IconDown.svelte";
 export { default as IconEast } from "./icons/IconEast.svelte";
 export { default as IconError } from "./icons/IconError.svelte";

--- a/src/lib/icons/IconAddCircle.svelte
+++ b/src/lib/icons/IconAddCircle.svelte
@@ -1,0 +1,33 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  stroke="currentColor"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M10 18C14.4183 18 18 14.4183 18 10C18 5.58172 14.4183 2 10 2C5.58172 2 2 5.58172 2 10C2 14.4183 5.58172 18 10 18Z"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M6 10H14"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M10 6V14"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/lib/icons/IconBin.svelte
+++ b/src/lib/icons/IconBin.svelte
@@ -1,0 +1,33 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  stroke="currentColor"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M2.5 5H17.5"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M15.8332 5V16.6667C15.8332 17.5 14.9998 18.3333 14.1665 18.3333H5.83317C4.99984 18.3333 4.1665 17.5 4.1665 16.6667V5"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M6.6665 5.00033V3.33366C6.6665 2.50033 7.49984 1.66699 8.33317 1.66699H11.6665C12.4998 1.66699 13.3332 2.50033 13.3332 3.33366V5.00033"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/lib/icons/IconDots.svelte
+++ b/src/lib/icons/IconDots.svelte
@@ -1,0 +1,20 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  stroke="none"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M11.5 4C11.5 4.82843 10.8284 5.5 10 5.5C9.17157 5.5 8.5 4.82843 8.5 4C8.5 3.17157 9.17157 2.5 10 2.5C10.8284 2.5 11.5 3.17157 11.5 4ZM11.5 10C11.5 10.8284 10.8284 11.5 10 11.5C9.17157 11.5 8.5 10.8284 8.5 10C8.5 9.17157 9.17157 8.5 10 8.5C10.8284 8.5 11.5 9.17157 11.5 10ZM10 17.5C10.8284 17.5 11.5 16.8284 11.5 16C11.5 15.1716 10.8284 14.5 10 14.5C9.17157 14.5 8.5 15.1716 8.5 16C8.5 16.8284 9.17157 17.5 10 17.5Z"
+  />
+</svg>


### PR DESCRIPTION
# Motivation

For the import token feature, we need three new icons: a Dots icon for the context menu, a Bin icon for the remove button, and an AddCircle icon for the redesigned add button.

# Changes

- Add and export the new icons.

# Screenshots

<img width="814" alt="Screenshot 2024-08-10 at 11 15 30" src="https://github.com/user-attachments/assets/8b62d505-3296-4c70-88b6-394aeaaba810">


