### PR TITLE
chore: bump version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/gix-components",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dfinity/gix-components",
   "description": "A UI kit developed by the GIX team",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",


### PR DESCRIPTION
# Motivation

Since we've updated the inherited agent-js v2 dependencies in `package-lock`, it would be beneficial to release a new version, that way the all eco-system uses v2.

# Changes

- Bump version number to `4.7.0`.
