### PR TITLE
update theme toggle and tests

### DIFF
--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -1,54 +1,40 @@
 <script lang="ts">
-  import Toggle from "./Toggle.svelte";
   import { Theme } from "$lib/types/theme";
   import { themeStore } from "$lib/stores/theme.store";
   import { i18n } from "$lib/stores/i18n";
   import IconLightMode from "$lib/icons/IconLightMode.svelte";
   import IconDarkMode from "$lib/icons/IconDarkMode.svelte";
 
-  const switchTheme = ({ detail }: CustomEvent<boolean>) =>
-    themeStore.select(detail ? Theme.DARK : Theme.LIGHT);
+  const switchTheme = () => {
+    themeStore.select($themeStore === Theme.LIGHT ? Theme.DARK : Theme.LIGHT);
+  };
 
-  let checked: boolean;
-  $: checked = $themeStore !== Theme.LIGHT;
+  $: isDarkMode = $themeStore === Theme.DARK;
 </script>
 
-<div class="theme-toggle" data-tid="theme-toggle">
-  <div class="toggle">
+<button
+  data-tid="theme-toggle"
+  class="theme-toggle icon-only"
+  on:click={switchTheme}
+  aria-label={$i18n.theme.switch_theme}
+>
+  {#if isDarkMode}
     <IconLightMode />
-    <Toggle
-      bind:checked
-      on:nnsToggle={switchTheme}
-      ariaLabel={$i18n.theme.switch_theme}
-    />
+  {:else}
     <IconDarkMode />
-  </div>
-</div>
+  {/if}
+</button>
 
 <style lang="scss">
   .theme-toggle {
-    display: flex;
-    align-items: center;
+    color: var(--text-color);
+    padding: var(--padding);
+    background: var(--sidebar-button-background);
 
-    font-size: var(--font-size-h4);
-    line-height: var(--line-height-h4);
-
-    padding: 0 var(--padding-0_5x);
-    gap: var(--padding);
-  }
-
-  .toggle {
-    display: flex;
-    align-items: center;
-    grid-template-columns: repeat(3, auto);
-    grid-column-gap: 2px;
-
-    :global(svg) {
-      width: var(--padding-2x);
-      height: var(--padding-2x);
-
-      &:first-of-type {
-        margin-right: calc(var(--padding-0_5x) / 2);
+    &:hover {
+      background: var(--sidebar-button-background-hover);
+      :global(svg) {
+        fill: var(--text-color);
       }
     }
   }

--- a/src/tests/lib/components/ThemeToggle.spec.ts
+++ b/src/tests/lib/components/ThemeToggle.spec.ts
@@ -1,4 +1,6 @@
 import ThemeToggle from "$lib/components/ThemeToggle.svelte";
+import IconDarkMode from "$lib/icons/IconDarkMode.svelte";
+import IconLightMode from "$lib/icons/IconLightMode.svelte";
 import { themeStore } from "$lib/stores/theme.store";
 import { Theme } from "$lib/types/theme";
 import { fireEvent, render } from "@testing-library/svelte";
@@ -6,30 +8,51 @@ import { get } from "svelte/store";
 import en from "../mocks/i18n.mock";
 
 describe("ThemeToggle", () => {
-  it("should render a toggle", () => {
+  it("should render a toggle button", () => {
     const { container } = render(ThemeToggle);
 
-    const input = container.querySelector("input") as HTMLInputElement;
+    const input = container.querySelector("button") as HTMLButtonElement;
     expect(input).not.toBeNull();
-    expect(input.getAttribute("type")).toEqual("checkbox");
   });
 
-  it("should render an accessible toggle", () => {
+  it("should render an accessible toggle button", () => {
     const { container } = render(ThemeToggle);
 
-    const input = container.querySelector("input") as HTMLInputElement;
+    const input = container.querySelector("button") as HTMLButtonElement;
     expect(input.getAttribute("aria-label")).toEqual(en.theme.switch_theme);
   });
 
   it("should switch theme", () => {
     const { container } = render(ThemeToggle);
 
-    const input = container.querySelector("input") as HTMLInputElement;
+    const input = container.querySelector("button") as HTMLButtonElement;
 
     fireEvent.click(input);
     expect(get(themeStore)).toEqual(Theme.LIGHT);
 
     fireEvent.click(input);
     expect(get(themeStore)).toEqual(Theme.DARK);
+  });
+
+  it("should render IconLightMode when theme is dark", () => {
+    themeStore.select(Theme.DARK);
+    const { container } = render(ThemeToggle);
+
+    const lightModeIcon = container.querySelector("svg");
+    expect(lightModeIcon).toBeInstanceOf(SVGSVGElement);
+    expect(container.innerHTML).toContain(
+      render(IconLightMode).container.innerHTML,
+    );
+  });
+
+  it("should render IconDarkMode when theme is light", () => {
+    themeStore.select(Theme.LIGHT);
+    const { container } = render(ThemeToggle);
+
+    const darkModeIcon = container.querySelector("svg");
+    expect(darkModeIcon).toBeInstanceOf(SVGSVGElement);
+    expect(container.innerHTML).toContain(
+      render(IconDarkMode).container.innerHTML,
+    );
   });
 });


### PR DESCRIPTION
# Motivation

Update theme toggle according to new figma designs

# Changes

ThemeToggle is now a button instead of an input
Tests has been updated accordingly

# Screenshots
<img width="1325" alt="Screenshot 2024-09-17 at 14 16 49" src="https://github.com/user-attachments/assets/9f142485-467c-4561-a3ae-638662fb724d">
<img width="1327" alt="Screenshot 2024-09-17 at 14 15 09" src="https://github.com/user-attachments/assets/a4ba4458-ca81-43ed-8d0c-b231dc63ec58">

