### PR TITLE
Add test IDs to Toasts and Toast

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -89,6 +89,7 @@
 </script>
 
 <div
+  data-tid="toast-component"
   role="dialog"
   class={`toast ${theme ?? "themed"}`}
   in:fly|global={{ y: (position === "top" ? -1 : 1) * 100, duration: 200 }}
@@ -105,6 +106,7 @@
   </div>
 
   <p
+    data-tid="toast-message"
     class="msg"
     class:truncate
     class:clamp
@@ -121,8 +123,11 @@
     {/if}
   </p>
 
-  <button class="close" on:click={close} aria-label={$i18n.core.close}
-    ><IconClose /></button
+  <button
+    data-tid="close-button"
+    class="close"
+    on:click={close}
+    aria-label={$i18n.core.close}><IconClose /></button
   >
 </div>
 

--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -19,6 +19,7 @@
 
 {#if toasts.length > 0}
   <div
+    data-tid="toasts-component"
     class={`wrapper ${position}`}
     class:error={hasErrors}
     style={`--layout-bottom-offset: ${$layoutBottomOffset}px`}


### PR DESCRIPTION
# Motivation

Easily finding the components in the DOM for testing.

# Changes

Add `data-tid` attributes in `Toasts` and `Toast` components.

# Screenshots

N/A
