### PR TITLE
Clean up menu padding

### DIFF
--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -27,7 +27,9 @@
     on:click={close}
     on:keypress={($event) => handleKeyPress({ $event, callback: close })}
   >
-    <slot />
+    <div class="slot-content">
+      <slot />
+    </div>
   </div>
 
   <button
@@ -72,15 +74,22 @@
   .inner {
     display: flex;
     flex-direction: column;
-    gap: var(--padding-0_5x);
 
     // More space for menu selection touches the edge;
     // otherwise the first selected menu entry would be cut off in mobile view.
     padding-top: var(--menu-selection-outer-radius);
-    padding-left: var(--padding);
 
-    @include media.min-width(large) {
-      padding-left: var(--padding-2x);
+    .slot-content {
+      display: flex;
+      flex-direction: column;
+
+      gap: var(--padding-0_5x);
+
+      padding-left: var(--padding);
+
+      @include media.min-width(large) {
+        padding-left: var(--padding-2x);
+      }
     }
 
     width: 0;

--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -61,13 +61,11 @@
 
     // Shift the menu on large screen e.g. if a banner is displayed
     @include media.min-width(large) {
-      padding: calc(
-          var(--menu-logo-height) + var(--padding-3x) +
-            var(--header-offset, 0px) - var(--menu-selection-outer-radius)
-        )
-        var(--padding-2x) 0;
-      // remove extra space because of menu selection touches the edge
-      padding-right: 0;
+      padding-top: calc(
+        var(--menu-logo-height) + var(--padding-3x) + var(--header-offset, 0px) - var(
+            --menu-selection-outer-radius
+          )
+      );
     }
   }
 
@@ -79,6 +77,11 @@
     // More space for menu selection touches the edge;
     // otherwise the first selected menu entry would be cut off in mobile view.
     padding-top: var(--menu-selection-outer-radius);
+    padding-left: var(--padding);
+
+    @include media.min-width(large) {
+      padding-left: var(--padding-2x);
+    }
 
     width: 0;
     max-width: 100vw;
@@ -98,15 +101,15 @@
     &.sticky {
       // On large screen the menu can be always open
       @include media.min-width(large) {
-        width: var(--menu-width);
+        width: calc(var(--menu-width) + var(--padding-2x));
         margin-left: 0;
       }
     }
 
     // On smaller screen the menu is open on demand
     &.open {
-      width: var(--menu-width);
-      margin-left: var(--padding);
+      width: calc(var(--menu-width) + var(--padding));
+      margin-left: 0;
     }
 
     @include media.min-width(large) {

--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -54,6 +54,8 @@
 
     --menu-logo-height: 65px;
     --menu-stack: 1em;
+    --menu-large-left-padding: var(--padding-2x);
+    --menu-small-left-padding: var(--padding);
 
     padding-top: calc(
       var(--menu-logo-height) + var(--padding-4x) + var(--header-offset, 0px)
@@ -82,13 +84,14 @@
     .slot-content {
       display: flex;
       flex-direction: column;
+      flex-grow: 1;
 
       gap: var(--padding-0_5x);
 
-      padding-left: var(--padding);
+      padding-left: var(--menu-small-left-padding);
 
       @include media.min-width(large) {
-        padding-left: var(--padding-2x);
+        padding-left: var(--menu-large-left-padding);
       }
     }
 
@@ -110,14 +113,14 @@
     &.sticky {
       // On large screen the menu can be always open
       @include media.min-width(large) {
-        width: calc(var(--menu-width) + var(--padding-2x));
+        width: calc(var(--menu-width) + var(--menu-large-left-padding));
         margin-left: 0;
       }
     }
 
     // On smaller screen the menu is open on demand
     &.open {
-      width: calc(var(--menu-width) + var(--padding));
+      width: calc(var(--menu-width) + var(--menu-small-left-padding));
       margin-left: 0;
     }
 


### PR DESCRIPTION
# Motivation

We want to merge the `MenuBackground` into the `Menu` component and make the `Menu` scrollable.
To limit the complexity of that PR, I want to first clean up the existing CSS.

The menu width is [specified as 200px](https://github.com/dfinity/gix-components/blob/8c5367f60e971b74508e62faefe48bfd4da107c7/src/lib/styles/global/variables.scss#L5), but the actual menu panel is `8px` or `16px` wider because of an extra padding or margin depending on the width of the viewport.

To simplify removing `MenuBackground`, we move the padding into `.inner` so that it's easier to center the logos.
And we use the same mechanism for large and small screens instead of using a margin in one case and a padding in the other case.

# Changes

1. Split `padding` in the menu for large screens in `padding-top`, `padding-left`, `padding-right` and `padding-bottom`.
    1. Move `padding-left` into `.inner`.
    2. Removing `padding-right` and `padding-bottom` because they are 0.
2. Change `margin-left: var(--padding);` for small screens to `padding-left: var(--padding);` in `.inner`.
3. Add `var(--padding)` or `var(--padding-2x)` to the actual menu width to keep the same actual final menu width and make it explicit.
4. Apply the left padding inside a `.slot-content` element instead of on `.inner` to avoid `.inner` having a width when its width should be 0. This will also help latter to avoid padding on `.inner` causing the logos to be off center.

# Screenshots

The behavior and visuals should be unchanged and can be tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/
