### PR TITLE
Move Menu padding inside slot-content

### DIFF
--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -77,20 +77,20 @@
     display: flex;
     flex-direction: column;
 
-    // More space for menu selection touches the edge;
-    // otherwise the first selected menu entry would be cut off in mobile view.
-    padding-top: var(--menu-selection-outer-radius);
-
-    @include media.min-width(large) {
-      padding-top: var(--padding-4x);
-    }
-
     .slot-content {
       display: flex;
       flex-direction: column;
       flex-grow: 1;
 
       gap: var(--padding-0_5x);
+
+      // More space for menu selection touches the edge;
+      // otherwise the first selected menu entry would be cut off in mobile view.
+      padding-top: var(--menu-selection-outer-radius);
+
+      @include media.min-width(large) {
+        padding-top: var(--padding-4x);
+      }
 
       padding-left: var(--menu-small-left-padding);
 


### PR DESCRIPTION
# Motivation

We want to remove the `MenuBackground` component.
I plan to put the top and bottom logo inside the `.inner` element above and blow the `.slot-content` element.
There is padding which is intended to go between the top logo and the menu items.
To simplify the review of the PR that removes the `MenuBackground` component, we can already move this padding from `.inner` to `.slot-content`.
Right now `.slot-content` is the only element of `.inner` so currently it doesn't make a difference.

# Changes

Move `padding-top` styles from `.inner` to `.slot-content`.

# Screenshots

No change.
