### PR TITLE
Disable triggering events if checkbox is disabled

### DIFF
--- a/src/lib/components/Checkbox.svelte
+++ b/src/lib/components/Checkbox.svelte
@@ -15,11 +15,13 @@
    * Emit an event when the checkbox or container is clicked. The state should be updated by consumer.
    */
   const onClick = ($event: MouseEvent | TouchEvent) => {
-    if (preventDefault) {
-      $event.preventDefault();
-    }
+    if (!disabled) {
+      if (preventDefault) {
+        $event.preventDefault();
+      }
 
-    change();
+      change();
+    }
   };
 
   const change = () => dispatch("nnsChange");
@@ -28,7 +30,8 @@
 <div
   tabindex="0"
   on:click|preventDefault={onClick}
-  on:keypress={($event) => handleKeyPress({ $event, callback: change })}
+  on:keypress={($event) =>
+    !disabled && handleKeyPress({ $event, callback: change })}
   class="checkbox"
   class:disabled
   role="button"

--- a/src/tests/lib/components/Checkbox.spec.ts
+++ b/src/tests/lib/components/Checkbox.spec.ts
@@ -111,4 +111,36 @@ describe("Checkbox", () => {
 
     expect(label?.classList.contains("block")).toBeTruthy();
   });
+
+  it("should not trigger nnsChange event when disabled and clicked", async () => {
+    const mockChange = vi.fn();
+    const { container, component } = render(Checkbox, {
+      props: { ...props, disabled: true },
+    });
+
+    component.$on("nnsChange", mockChange);
+
+    await fireEvent.click(container.querySelector("div.checkbox") as Element);
+
+    expect(mockChange).not.toHaveBeenCalled();
+  });
+
+  it("should not trigger nnsChange event when disabled and key pressed", async () => {
+    const mockChange = vi.fn();
+    const { container, component } = render(Checkbox, {
+      props: { ...props, disabled: true },
+    });
+
+    component.$on("nnsChange", mockChange);
+
+    await fireEvent.keyPress(
+      container.querySelector("div.checkbox") as Element,
+      {
+        key: "Enter",
+        code: "Enter",
+      },
+    );
+
+    expect(mockChange).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Motivation

 Checkbox currently triggers keypress event on keypress and nnsChange event on click, eventhought it is disabled. Disabled input elements shouldn't trigger these events, if we need information related to disabled Checkbox events, those should be implemented separately.

# Changes

Update Checkbox to not trigger events if disabled.

# Screenshots

no change
