### PR TITLE
Add resetForTesting to menuStore

### DIFF
--- a/src/lib/stores/menu.store.ts
+++ b/src/lib/stores/menu.store.ts
@@ -9,7 +9,7 @@ export interface MenuStore extends Readable<Menu | undefined> {
 }
 
 export const initMenuStore = (): MenuStore => {
-  const { subscribe, update } = writable<Menu | undefined>(initialMenu);
+  const { subscribe, set, update } = writable<Menu | undefined>(initialMenu);
 
   return {
     subscribe,
@@ -21,6 +21,10 @@ export const initMenuStore = (): MenuStore => {
         applyMenu({ menu, preserve: true });
         return menu;
       });
+    },
+
+    resetForTesting: () => {
+      set(Menu.EXPANDED);
     },
   };
 };

--- a/src/tests/lib/stores/menu.store.spec.ts
+++ b/src/tests/lib/stores/menu.store.spec.ts
@@ -3,12 +3,11 @@ import { Menu } from "$lib/types/menu";
 import { get } from "svelte/store";
 
 describe("menu-store", () => {
+  beforeEach(() => {
+    menuStore.resetForTesting();
+  });
+
   it("should derive collapsed", async () => {
-    const store = get(menuStore);
-    expect(store).toBeUndefined();
-
-    menuStore.toggle();
-
     const storeExpanded = get(menuStore);
     expect(storeExpanded).toBe(Menu.EXPANDED);
 
@@ -22,5 +21,17 @@ describe("menu-store", () => {
 
     const derivedCollapsed2 = get(menuCollapsed);
     expect(derivedCollapsed2).toBeTruthy();
+  });
+
+  it("should reset to EXPANDED for testing", async () => {
+    expect(get(menuStore)).toBe(Menu.EXPANDED);
+
+    menuStore.toggle();
+
+    const storeCollapsed = get(menuStore);
+    expect(storeCollapsed).toBe(Menu.COLLAPSED);
+
+    menuStore.resetForTesting();
+    expect(get(menuStore)).toBe(Menu.EXPANDED);
   });
 });


### PR DESCRIPTION
# Motivation

Make it easier to write robust unit tests.

# Changes

Add `resetForTesting` to `menuStore` which sets the value to `Menu.EXPANDED`.

# Screenshots

N/A
