### PR TITLE
Compile test code

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}' && eslint .",
     "format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}'",
-    "test": "vitest --config ./vitest.config.ts",
+    "test": "tsc --noEmit -p ./tsconfig.spec.json && vitest --config ./vitest.config.ts",
     "download:samples": "./scripts/download-samples.sh",
     "i18n": "node scripts/i18n.types.mjs && prettier --write ./src/lib/types/i18n.d.ts",
     "e2e": "npm run download:samples && playwright test",

--- a/src/tests/lib/components/Popover.spec.ts
+++ b/src/tests/lib/components/Popover.spec.ts
@@ -33,7 +33,7 @@ describe("Popover", () => {
       container.querySelector("div.backdrop");
 
     expect(backdrop).not.toBeNull();
-    expect(backdrop.classList).toContain("visible");
+    expect(backdrop?.classList).toContain("visible");
   });
 
   it("should render a backdrop invisible", () => {
@@ -48,7 +48,7 @@ describe("Popover", () => {
       container.querySelector("div.backdrop");
 
     expect(backdrop).not.toBeNull();
-    expect(backdrop.classList).not.toContain("visible");
+    expect(backdrop?.classList).not.toContain("visible");
   });
 
   it("should render slotted content", () => {

--- a/src/tests/lib/utils/tooltip.utils.spec.ts
+++ b/src/tests/lib/utils/tooltip.utils.spec.ts
@@ -10,6 +10,9 @@ describe("translateTooltip", () => {
     left: 100,
     bottom: 800,
     right: 500,
+    toJSON: function () {
+      return JSON.stringify(this);
+    },
   };
 
   const targetWidth = 50;
@@ -18,7 +21,7 @@ describe("translateTooltip", () => {
   const tooltipWidth = 200;
   const tooltipHeight = 40;
 
-  const createTargetAndTooltipRects = ({ x, y }) => ({
+  const createTargetAndTooltipRects = ({ x, y }: { x: number; y: number }) => ({
     targetRect: {
       x,
       y,
@@ -28,6 +31,9 @@ describe("translateTooltip", () => {
       left: x,
       bottom: y + targetHeight,
       right: x + targetWidth,
+      toJSON: function () {
+        return JSON.stringify(this);
+      },
     },
     tooltipRect: {
       x,
@@ -38,6 +44,9 @@ describe("translateTooltip", () => {
       left: x,
       bottom: y + tooltipHeight,
       right: x + tooltipWidth,
+      toJSON: function () {
+        return JSON.stringify(this);
+      },
     },
   });
 


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/gix-components/pull/508 I had to add a missing type declaration.
This wasn't caught earlier because test are not compiled.

# Changes

1. Compile tests when running `npm run test` by adding `tsc --noEmit -p ./tsconfig.spec.json &&`.
2. Fix existing issues caught by the compiler.
    1. Make rectangles of type `DOMRect` by adding a `toJSON` method.
    2. Declare type of params of `createTargetAndTooltipRects`.
    3. Fix `backdrop might be undefined` because the compiler doesn't understand it's not possible after `expect(backdrop).not.toBeNull();`

# Screenshots

N/A
