### PR TITLE
ci: bump checkout action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Print chrome version
         run: |
           echo "google-chrome --version"

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Package next
         run: ./scripts/package-next
       - name: Set up npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -14,7 +14,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
       - name: Install dependencies


### PR DESCRIPTION
# Motivation

Bumping the `actions/checkout` to version 4, since we were receiving warnings.

![Screenshot 2024-10-30 at 16 55 20](https://github.com/user-attachments/assets/de7a5f54-9f16-490b-9475-290c34947edc)

