### PR TITLE
build: migrate to scss modern-compiler

### DIFF
--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -83,6 +83,21 @@
     display: flex;
     flex-direction: column;
 
+    width: 0;
+    max-width: 100vw;
+    height: 100%;
+
+    overflow-y: auto;
+    margin-left: -100%;
+
+    transition:
+      margin-left var(--animation-time-normal)
+        var(--menu-animation-timing-function),
+      width var(--animation-time-normal) var(--menu-animation-timing-function);
+
+    // On large screen the header is not sticky but within the content that's why we align the inner menu start
+    box-sizing: border-box;
+
     .top-logo {
       color: var(--menu-color);
       box-sizing: border-box;
@@ -105,11 +120,11 @@
       // otherwise the first selected menu entry would be cut off in mobile view.
       padding-top: var(--menu-selection-outer-radius);
 
+      padding-left: var(--menu-small-left-padding);
+
       @include media.min-width(large) {
         padding-top: var(--padding-4x);
       }
-
-      padding-left: var(--menu-small-left-padding);
 
       @include media.min-width(large) {
         padding-left: var(--menu-large-left-padding);
@@ -123,21 +138,6 @@
       padding-top: var(--padding-3x);
       padding-bottom: var(--padding-3x);
     }
-
-    width: 0;
-    max-width: 100vw;
-    height: 100%;
-
-    overflow-y: auto;
-    margin-left: -100%;
-
-    transition:
-      margin-left var(--animation-time-normal)
-        var(--menu-animation-timing-function),
-      width var(--animation-time-normal) var(--menu-animation-timing-function);
-
-    // On large screen the header is not sticky but within the content that's why we align the inner menu start
-    box-sizing: border-box;
 
     &.sticky {
       // On large screen the menu can be always open

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,9 +16,9 @@ const config = {
   css: {
     preprocessorOptions: {
       scss: {
-        api: 'modern-compiler'
-      }
-    }
+        api: "modern-compiler",
+      },
+    },
   },
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,13 @@ const config = {
   define: {
     "process.env.VITE_BUILD_TIME": JSON.stringify(new Date().toISOString()),
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler'
+      }
+    }
+  },
 };
 
 export default config;


### PR DESCRIPTION
# Motivation

Similar to what was done for OISY repo with PR #https://github.com/dfinity/oisy-wallet/pull/2441, we resolve the warnings

![Screenshot 2024-10-30 at 17 02 01](https://github.com/user-attachments/assets/b29fa4b0-528e-4807-929e-36ae50d932af)


Source: https://stackoverflow.com/a/79003101/5404186


# Changes

- Use modern compiler for `sass`
- Move the sub-classes after the class declarations.

