### PR TITLE
NNS1-3435: adds a new semantic color variable to the themes

### DIFF
--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -217,4 +217,5 @@
   --positive-emphasis-light: var(--green-200-a25);
   --negative-emphasis: var(--pink-200);
   --negative-emphasis-contrast: var(--neutral-50);
+  --negative-emphasis-light: var(--pink-200-a25);
 }

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -226,5 +226,6 @@
     --positive-emphasis-light: var(--green-200-a25);
     --negative-emphasis: var(--pink-200);
     --negative-emphasis-contrast: var(--neutral-50);
+    --negative-emphasis-light: var(--pink-200-a25);
   }
 }


### PR DESCRIPTION
# Motivation

A new theme requires a new light variable to be used for negative emphasis connotation.

# Changes

-  A new semantic color variable has been added to the themes.