### PR TITLE
Fix minor color mismatches

### DIFF
--- a/src/lib/styles/global/colors.scss
+++ b/src/lib/styles/global/colors.scss
@@ -89,6 +89,7 @@
   --blue-accent-secondary: #456de5;
   --blue-50: #d4e7fa;
   --blue-250: #6f7fcd;
+  --blue-250-rgb: 111, 127, 205;
   --blue-600: #3d4d99;
   --blue-800: #0f0f4d;
   --blue-900: #151a33;

--- a/src/lib/styles/themes/dark.scss
+++ b/src/lib/styles/themes/dark.scss
@@ -69,9 +69,9 @@
   //Tooltip
   --tooltip-background: var(--neutral-50);
   --tooltip-border-color: var(--neutral-blue-a10);
-  --tooltip-divider: var(--neutral-50);
-  --tooltip-description-color: var(--night-600);
-  --tooltip-text-color: var(--night-550);
+  --tooltip-divider: var(--neutral-1000-a20);
+  --tooltip-description-color: var(--night-400);
+  --tooltip-text-color: var(--night-900);
   --tooltip-border-size: 1.5px;
 
   // Dropdown (used for Popover)

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -71,10 +71,10 @@
     --input-border-size: 1.5px;
 
     //Tooltip
-    --tooltip-background: var(--violet-900);
+    --tooltip-background: var(--blue-900);
     --tooltip-border-color: var(--cp-dark-hover-overlay);
-    --tooltip-divider: var(--violet-400);
-    --tooltip-description-color: var(--violet-50);
+    --tooltip-divider: var(--neutral-50-a15);
+    --tooltip-description-color: var(--neutral-250);
     --tooltip-text-color: var(--neutral-50);
     --tooltip-border-size: 1.5px;
 

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -110,7 +110,8 @@
     --disable: var(--neutral-100);
     --disable-contrast: var(--blue-250);
     // TODO-colors: Remove application of rgbs
-    --disable-contrast-rgb: 171, 153, 209;
+    // --blue-250 to RGB, uses in merge neurons icp number
+    --disable-contrast-rgb: var(--blue-250-rgb);
 
     // Line
     --line: var(--neutral-250);

--- a/src/lib/styles/themes/light.scss
+++ b/src/lib/styles/themes/light.scss
@@ -215,7 +215,7 @@
     --secondary-rgb: 124, 92, 194;
     --secondary-contrast: var(--blue-900);
 
-    --tertiary: var(--violet-50);
+    --tertiary: var(--blue-250);
 
     --warning-emphasis: var(--orange-mid);
     --warning-emphasis-contrast: var(--blue-900);


### PR DESCRIPTION
# Motivation

Fix minor color mismatches

# Changes

1. The variable --disable-contrast-rgb doesn’t match --disable-contrast.
2. When the new dark theme was introduced, the light theme was not updated. However, some colors, such as those for the tooltip, are derived from the opposite theme and need to be updated as well:
  - Update --tertiary to be blue instead of violet.
  - Update the light theme’s tooltip to suit the new dark theme.
3. Update the dark theme’s tooltip colors to match the new tooltip colors.

# Screenshots

Note: All the changes were visually reviewed with the designer.

## Founded changes

### Value in the disabled neuron card (1.00 icp)
<img width="560" alt="image" src="https://github.com/user-attachments/assets/4720f9b8-f992-4b72-9db8-2afbc930f9a8">

### --tertiary colour
<img width="81" alt="image" src="https://github.com/user-attachments/assets/7e9730af-a576-4737-a0de-d009f664af85">


| Before | To |
|--------|--------|
| <img width="365" alt="image" src="https://github.com/user-attachments/assets/dd6ff3ab-092a-4229-b0cf-f985f5e43259"> | <img width="301" alt="image" src="https://github.com/user-attachments/assets/3139aa86-853d-4a66-8526-584fb7c4385e"> | 


### Tooltip changes

| Before | After |
|--------|--------|
| <img width="143" alt="image" src="https://github.com/user-attachments/assets/a2ec2af5-5862-4c5c-aaeb-aafef2312c3c"> | <img width="121" alt="image" src="https://github.com/user-attachments/assets/feb8058b-7cd6-47df-b669-f955b2a7eb07"> |
| <img width="151" alt="image" src="https://github.com/user-attachments/assets/c92a875a-e881-4606-9f88-7105e9415b40"> | <img width="120" alt="image" src="https://github.com/user-attachments/assets/6596ea4a-2ca1-4859-9594-67979efff65f"> |












