### PR TITLE
Add icon ArrowsSwitch

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -2,6 +2,7 @@ export { default as IconAccountBalance } from "./icons/IconAccountBalance.svelte
 export { default as IconAccountsPage } from "./icons/IconAccountsPage.svelte";
 export { default as IconAdd } from "./icons/IconAdd.svelte";
 export { default as IconAddCircle } from "./icons/IconAddCircle.svelte";
+export { default as IconArrowsSwitch } from "./icons/IconArrowsSwitch.svelte";
 export { default as IconBack } from "./icons/IconBack.svelte";
 export { default as IconBin } from "./icons/IconBin.svelte";
 export { default as IconCanistersPage } from "./icons/IconCanistersPage.svelte";

--- a/src/lib/icons/IconArrowsSwitch.svelte
+++ b/src/lib/icons/IconArrowsSwitch.svelte
@@ -1,0 +1,23 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15.006 18.3319V4.71411" />
+  <path d="M19.0838 14.2357L15.006 18.3324L10.9282 14.2357" />
+  <path d="M5.07777 2.00061V15.6184" />
+  <path d="M1 6.09667L5.07778 2L9.15556 6.09667" />
+</svg>


### PR DESCRIPTION
# Motivation

This icon is needed for the USD values design to switch the USD and ICP amounts.

# Changes

1. Add `src/lib/icons/IconArrowsSwitch.svelte`

# Screenshots

<img width="124" alt="image" src="https://github.com/user-attachments/assets/86e35cad-e90c-4e39-a828-d53c313f7bde">

