### PR TITLE
style: force content-box for Checkbox

### DIFF
--- a/src/lib/components/Checkbox.svelte
+++ b/src/lib/components/Checkbox.svelte
@@ -142,6 +142,7 @@
       display: block;
       content: "";
       position: absolute;
+      box-sizing: content-box;
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

It is useful to "force" the Checkbox component to have the CSS property `box-sizing: content-box;`. That is because, if for instance it is used in a context where the property is set as border-box, the results are not so pretty:

![Screenshot 2024-12-05 at 19 38 11](https://github.com/user-attachments/assets/a8353936-d877-48f2-aa6e-79009370b9e1)


While, after this change, we have the intended results in all type of contexts:

![Screenshot 2024-12-05 at 19 38 59](https://github.com/user-attachments/assets/14771630-0280-41db-85b7-ded84997480d)

