### PR TITLE
fix: <tr> cannot be a child of <table>

### DIFF
--- a/src/routes/(page)/browser/+page.svelte
+++ b/src/routes/(page)/browser/+page.svelte
@@ -24,50 +24,52 @@
 <h2>Device</h2>
 
 <table>
-  <tr>
-    <td class="description">isMobile</td>
-    <td
-      ><Value>
-        {isMobile()}
-      </Value></td
-    >
-  </tr>
+  <tbody>
+    <tr>
+      <td class="description">isMobile</td>
+      <td
+        ><Value>
+          {isMobile()}
+        </Value></td
+      >
+    </tr>
 
-  <tr>
-    <td class="description">isIPad</td>
-    <td
-      ><Value>
-        {isIPad()}
-      </Value></td
-    >
-  </tr>
+    <tr>
+      <td class="description">isIPad</td>
+      <td
+        ><Value>
+          {isIPad()}
+        </Value></td
+      >
+    </tr>
 
-  <tr>
-    <td class="description">isAndroidTablet</td>
-    <td
-      ><Value>
-        {isAndroidTablet()}
-      </Value></td
-    >
-  </tr>
+    <tr>
+      <td class="description">isAndroidTablet</td>
+      <td
+        ><Value>
+          {isAndroidTablet()}
+        </Value></td
+      >
+    </tr>
 
-  <tr>
-    <td class="description">Touch screen</td>
-    <td
-      ><Value>
-        {#if browser}{window.matchMedia("(any-pointer:coarse)").matches}{/if}
-      </Value></td
-    >
-  </tr>
+    <tr>
+      <td class="description">Touch screen</td>
+      <td
+        ><Value>
+          {#if browser}{window.matchMedia("(any-pointer:coarse)").matches}{/if}
+        </Value></td
+      >
+    </tr>
 
-  <tr>
-    <td class="description">Mouse screen</td>
-    <td
-      ><Value>
-        {#if browser}{window.matchMedia("(any-pointer:fine)").matches}{/if}
-      </Value></td
-    >
-  </tr>
+    <tr>
+      <td class="description">Mouse screen</td>
+      <td
+        ><Value>
+          {#if browser}{window.matchMedia("(any-pointer:fine)").matches}{/if}
+        </Value></td
+      >
+    </tr>
+  </tbody>
 </table>
 
 <style lang="scss">


### PR DESCRIPTION
# Motivation

Fix an error - that blocks the build - detected when migrating to Svelte v5 in #541:

> error during build:
[vite-plugin-svelte] [plugin vite-plugin-svelte] src/routes/(page)/browser/+page.svelte (27:2): src/routes/(page)/browser/+page.svelte:27:2 `<tr>` cannot be a child of `<table>`. `<table>` only allows these children: `<caption>`, `<colgroup>`, `<tbody>`, `<thead>`, `<tfoot>`, `<style>`, `<script>`, `<template>`. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components

# Changes

- Add `tbody`
