### PR TITLE
fix: nesting selectors in menu item

### DIFF
--- a/src/lib/components/MenuItem.svelte
+++ b/src/lib/components/MenuItem.svelte
@@ -89,11 +89,6 @@
       color: var(--menu-select-color);
     }
 
-    :global(& > :first-child) {
-      // preserve icon size
-      flex: none;
-    }
-
     :global(svg) {
       width: var(--padding-3x);
       min-width: var(--padding-3x);


### PR DESCRIPTION
# Motivation

Fix an error - that blocks the build - detected when migrating to Svelte v5 in #541:

> error during build:
[vite-plugin-svelte] [plugin vite-plugin-svelte] src/lib/components/MenuItem.svelte (73:10): src/lib/components/MenuItem.svelte:73:10 Nesting selectors can only be used inside a rule or as the first selector inside a lone `:global(...)`

It seems that the rule is actually unused / not applied. Therefore I remove it.

# Changes

- Remove nested CSS global rule.