### PR TITLE
fix: Self-closing HTML tags

### DIFF
--- a/src/lib/components/Backdrop.svelte
+++ b/src/lib/components/Backdrop.svelte
@@ -26,7 +26,7 @@
   on:keypress={($event) => handleKeyPress({ $event, callback: close })}
   class:disablePointerEvents
   data-tid="backdrop"
-/>
+></div>
 
 <style lang="scss">
   @use "../styles/mixins/interaction";

--- a/src/lib/components/ProgressBar.svelte
+++ b/src/lib/components/ProgressBar.svelte
@@ -54,7 +54,7 @@
     aria-valuemax={max}
     aria-valuenow={totalValue}
     style={inlineStyle}
-  />
+  ></progress>
   <slot name="bottom" />
 </div>
 

--- a/src/lib/components/ProgressSteps.svelte
+++ b/src/lib/components/ProgressSteps.svelte
@@ -23,7 +23,7 @@
 
     <span class="text">{text}</span>
 
-    <div class:line={!last} />
+    <div class:line={!last}></div>
 
     {#if state === "completed"}
       <span class="state">{$i18n.progress.completed}</span>

--- a/src/lib/components/QRCode.svelte
+++ b/src/lib/components/QRCode.svelte
@@ -113,7 +113,7 @@
       style={`width: ${size.width > 0 ? `${size.width}px` : "100%"}; height: ${
         size.width > 0 ? `${size.width}px` : "100%"
       }`}
-    />
+    ></canvas>
   {/if}
 
   {#if showLogo}

--- a/src/lib/components/QRCodeReader.svelte
+++ b/src/lib/components/QRCodeReader.svelte
@@ -85,7 +85,7 @@
   const mirror = isDesktop();
 </script>
 
-<article class="reader" {id} class:mirror />
+<article class="reader" {id} class:mirror></article>
 
 <style lang="scss">
   .reader {

--- a/src/lib/components/Segment.svelte
+++ b/src/lib/components/Segment.svelte
@@ -82,7 +82,7 @@
 >
   {#if nonNullish(indicator)}
     <div class="indicator">
-      <div class="indicator-background" />
+      <div class="indicator-background"></div>
     </div>
   {/if}
 

--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -24,7 +24,7 @@
     aria-label={ariaLabel}
     {disabled}
   />
-  <label for={id} />
+  <label for={id}></label>
 </div>
 
 <style lang="scss">

--- a/src/tests/lib/components/ContentTest.svelte
+++ b/src/tests/lib/components/ContentTest.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <Content>
-  <div data-tid="content-test-slot" />
-  <div data-tid="content-test-title-slot" slot="title" />
-  <div data-tid="content-test-toolbar-end-slot" slot="toolbar-end" />
+  <div data-tid="content-test-slot"></div>
+  <div data-tid="content-test-title-slot" slot="title"></div>
+  <div data-tid="content-test-toolbar-end-slot" slot="toolbar-end"></div>
 </Content>

--- a/src/tests/lib/components/IslandTest.svelte
+++ b/src/tests/lib/components/IslandTest.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <Island>
-  <div data-tid="island-test-slot" />
+  <div data-tid="island-test-slot"></div>
 </Island>

--- a/src/tests/lib/components/MenuItemTest.svelte
+++ b/src/tests/lib/components/MenuItemTest.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <MenuItem href="https://test">
-  <div data-tid="menuitem-test-icon" slot="icon" />
-  <div data-tid="menuitem-test-default" />
-  <div data-tid="menuitem-test-status-icon" slot="statusIcon" />
+  <div data-tid="menuitem-test-icon" slot="icon"></div>
+  <div data-tid="menuitem-test-default"></div>
+  <div data-tid="menuitem-test-status-icon" slot="statusIcon"></div>
 </MenuItem>

--- a/src/tests/lib/components/MenuTest.svelte
+++ b/src/tests/lib/components/MenuTest.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <Menu>
-  <div data-tid="menu-test-slot" />
+  <div data-tid="menu-test-slot"></div>
 </Menu>

--- a/src/tests/lib/components/NavTest.svelte
+++ b/src/tests/lib/components/NavTest.svelte
@@ -3,6 +3,6 @@
 </script>
 
 <Nav>
-  <div data-tid="nav-test-1" />
-  <div data-tid="nav-test-2" />
+  <div data-tid="nav-test-1"></div>
+  <div data-tid="nav-test-2"></div>
 </Nav>

--- a/src/tests/lib/components/PopoverTest.svelte
+++ b/src/tests/lib/components/PopoverTest.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <Popover visible={true}>
-  <div data-tid="Popover-slot" />
+  <div data-tid="Popover-slot"></div>
 </Popover>

--- a/src/tests/lib/components/SplitBlockTest.svelte
+++ b/src/tests/lib/components/SplitBlockTest.svelte
@@ -3,6 +3,6 @@
 </script>
 
 <SplitBlock>
-  <div data-tid="content-test-start-slot" slot="start" />
-  <div data-tid="content-test-end-slot" slot="end" />
+  <div data-tid="content-test-start-slot" slot="start"></div>
+  <div data-tid="content-test-end-slot" slot="end"></div>
 </SplitBlock>

--- a/src/tests/lib/components/SplitContentTest.svelte
+++ b/src/tests/lib/components/SplitContentTest.svelte
@@ -7,8 +7,8 @@
 </script>
 
 <SplitContent bind:this={originalComponent}>
-  <div data-tid="content-test-start-slot" slot="start" />
-  <div data-tid="content-test-end-slot" slot="end" />
-  <div data-tid="content-test-title-slot" slot="title" />
-  <div data-tid="content-test-toolbar-end-slot" slot="toolbar-end" />
+  <div data-tid="content-test-start-slot" slot="start"></div>
+  <div data-tid="content-test-end-slot" slot="end"></div>
+  <div data-tid="content-test-title-slot" slot="title"></div>
+  <div data-tid="content-test-toolbar-end-slot" slot="toolbar-end"></div>
 </SplitContent>

--- a/src/tests/lib/components/SplitPaneTest.svelte
+++ b/src/tests/lib/components/SplitPaneTest.svelte
@@ -3,6 +3,6 @@
 </script>
 
 <SplitPane>
-  <div data-tid="split-pane-test-slot" />
-  <div data-tid="split-pane-test-menu-slot" slot="menu" />
+  <div data-tid="split-pane-test-slot"></div>
+  <div data-tid="split-pane-test-menu-slot" slot="menu"></div>
 </SplitPane>

--- a/src/tests/lib/components/StretchPaneTest.svelte
+++ b/src/tests/lib/components/StretchPaneTest.svelte
@@ -3,6 +3,6 @@
 </script>
 
 <StretchPane>
-  <div data-tid="stretch-pane-test-slot" />
-  <div data-tid="stretch-pane-test-menu-slot" slot="menu" />
+  <div data-tid="stretch-pane-test-slot"></div>
+  <div data-tid="stretch-pane-test-menu-slot" slot="menu"></div>
 </StretchPane>

--- a/src/tests/lib/components/TestIdWrapperTest.svelte
+++ b/src/tests/lib/components/TestIdWrapperTest.svelte
@@ -6,5 +6,5 @@
 </script>
 
 <TestIdWrapper {testId}>
-  <div data-tid={childTestId} />
+  <div data-tid={childTestId}></div>
 </TestIdWrapper>

--- a/src/tests/lib/components/ToolbarTest.svelte
+++ b/src/tests/lib/components/ToolbarTest.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <Toolbar>
-  <div data-tid="toolbar-test-start-slot" />
-  <div data-tid="toolbar-test-slot" />
-  <div data-tid="toolbar-test-end-slot" />
+  <div data-tid="toolbar-test-start-slot"></div>
+  <div data-tid="toolbar-test-slot"></div>
+  <div data-tid="toolbar-test-end-slot"></div>
 </Toolbar>


### PR DESCRIPTION
# Motivation

Fix a linter error reported by latest Svelte v5 linter in https://github.com/dfinity/gix-components/pull/541:

> Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`(element_invalid_self_closing_tag)  svelte/valid-compile

# Changes

- Replace self closing tags. e.g. `<div />` -> `<div></div>`