### PR TITLE
chore: add sideEffects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "e2e:report": "npx playwright show-report",
     "copy:workers": "node ./scripts/copy-workers.mjs"
   },
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Motivation

I compared our setup with a sample Svelte app and noticed that the `package.json` contained a `sideEffects` field. While we do not necesseraly needs it, according [documentation](https://svelte.dev/docs/kit/packaging#Anatomy-of-a-package.json-sideEffects), it's advised to add it.

# Changes

- Specify a `sideEffect` for `css` in `package.json` to help bundlers tree shake those files when the lib is consumed.