### PR TITLE
test: adapt tooltip text checks

### DIFF
--- a/src/tests/lib/components/Tooltip.spec.ts
+++ b/src/tests/lib/components/Tooltip.spec.ts
@@ -33,7 +33,7 @@ describe("Tooltip", () => {
     const tooltipElement = baseElement.querySelector(".tooltip");
     expect(tooltipElement).toBeInTheDocument();
     expect(tooltipElement?.classList).not.toContain("not-rendered");
-    expect(tooltipElement?.innerHTML).toBe("text");
+    expect(tooltipElement?.textContent).toBe("text");
   });
 
   it("should render tooltip slot content", () => {
@@ -42,9 +42,13 @@ describe("Tooltip", () => {
     const tooltipElement = baseElement.querySelector(".tooltip");
     expect(tooltipElement).toBeInTheDocument();
     expect(tooltipElement?.classList).not.toContain("not-rendered");
-    expect(tooltipElement?.innerHTML).toBe(
-      '<div slot="tooltip-content">slot text</div>',
+
+    const tooltipSlot = tooltipElement?.querySelector(
+      "[slot='tooltip-content']",
     );
+    expect(tooltipSlot).toBeInTheDocument();
+    expect(tooltipSlot?.nodeName.toLowerCase()).toEqual("div");
+    expect(tooltipSlot?.textContent).toBe("slot text");
   });
 
   it("should render aria-describedby and relevant id", () => {


### PR DESCRIPTION
# Motivation

Svelte v5 appears to add `<!---->` comments in the DOM when rendering deprecated `slot` elements. As a result, the tooltip tests that read HTML to compare text would not be compatible.

# Notes

Related to PR #548.

# Changes

- Replace usage of `innerHTML` to compare text in the `Tooltip` test.
