### PR TITLE
chore: tsconfig paths for test - TS2307 Cannot find module in IDE

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,7 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "$docs": ["./src/docs"],
+      "$docs/*": ["./src/docs/*"],
+      "$lib": ["./src/lib"],
+      "$lib/*": ["./src/lib/*"]
+    }
   },
   "exclude": [],
   "include": [


### PR DESCRIPTION
# Motivation

Don't know for VS Code but, Webstorm has issue resolving `*.svelte` component when the import used `$lib/`. It seems it cannot inherits the `path` defined in `"./.svelte-kit/tsconfig.json"` despite the extension of the configs. I would guess the issue is related to Webstorm having issue resolving relative paths.

# Changes

- Add `paths` to `tsconfig.spec.json`.
