### PR TITLE
chore: tell Vitest to use the `browser` entry points in `package.json`

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import { resolve } from "path";
 const config = {
   plugins: [sveltekit(), juno()],
   resolve: {
+    ...(process.env.VITEST && { conditions: ["browser"] }),
     alias: {
       $docs: resolve("./src/docs"),
     },


### PR DESCRIPTION
# Motivation

I'm not sure we realy needs it but Svelte is advising to tell Vitest to use the `browser` entry points in `package.json` for the configuration of the test. Since I'm reviewing the configuration of the repo while migrating to Svelte v5, I think it's good to align this as well.

Source: https://svelte.dev/docs/svelte/testing#Unit-and-integration-testing-using-Vitest-Component-testing

# Changes

- Set `condition` equals to `browser` in `resolve` for Vitest.
