### PR TITLE
Avoid margin when no title

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,7 +131,7 @@ jobs:
         run: npm ci
       - name: Run Playwright tests
         run: npm run e2e:ci
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-report

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -3,10 +3,12 @@
 
   let noDescription = false;
   $: noDescription = $$slots.description === undefined;
+  let noTitle = false;
+  $: noTitle = $$slots.title === undefined && $$slots.end === undefined;
 </script>
 
 <div class="container" data-tid={testId}>
-  <div class="section-title" class:noDescription>
+  <div class="section-title" class:noTitle class:noDescription>
     <slot name="title" />
     <slot name="end" />
   </div>
@@ -28,7 +30,7 @@
     align-items: center;
     justify-content: space-between;
 
-    &:not(.noDescription) {
+    &:not(.noDescription):not(.noTitle) {
       margin-bottom: var(--padding);
     }
   }


### PR DESCRIPTION
# Motivation

On the neuron details page, the voting power block needs to be displayed within a collapsible section. To achieve this, we can’t use the section’s title slot and must instead rely on a custom title (within the KeyValuePairInfo) placed in the section’s description block. Currently, if the title slot is left empty, an extra margin is added, which is undesirable.

<img width="815" alt="image" src="https://github.com/user-attachments/assets/a9df8a95-14fb-42fd-a827-71429ef07071" />

# Changes

- Do not add the margin, when no title provided.

- Tested locally against nns-dapp.

# Screenshots

<img width="611" alt="image" src="https://github.com/user-attachments/assets/027ef210-cb82-4707-8757-4517f7ad6627" />
