### PR TITLE
Update checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,7 +131,7 @@ jobs:
         run: npm ci
       - name: Run Playwright tests
         run: npm run e2e:ci
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-report


### PR DESCRIPTION
actions/upload-artifact@v3 to v4


# Motivation

Github checks fails with:
`Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/`

https://github.com/dfinity/gix-components/actions/runs/12695076227/job/35386237271?pr=558

# Changes

- Update the artifact-actions to v4.

# Tests

- Applied same changes to a branch to test that it's green again - https://github.com/dfinity/gix-components/pull/558