### PR TITLE
feat: use an element target in infinite scroll

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -18,14 +18,11 @@
     threshold: 0,
   };
 
-  let container: HTMLUListElement | undefined;
+  let target: HTMLDivElement | undefined;
 
   const dispatch = createEventDispatcher();
 
-  const onIntersection = (
-    entries: IntersectionObserverEntry[],
-    observer: IntersectionObserver,
-  ) => {
+  const onIntersection = (entries: IntersectionObserverEntry[]) => {
     const intersecting: IntersectionObserverEntry | undefined = entries.find(
       ({ isIntersecting }: IntersectionObserverEntry) => isIntersecting,
     );
@@ -33,9 +30,6 @@
     if (isNullish(intersecting)) {
       return;
     }
-
-    // We can disconnect the observer. We have detected an intersection and consumer is going to fetch new elements.
-    observer.disconnect();
 
     dispatch("nnsIntersect");
   };
@@ -54,14 +48,14 @@
       observer.disconnect();
     }
 
-    skipContainerNextUpdate = isNullish(container);
+    skipContainerNextUpdate = isNullish(target);
   });
 
   afterUpdate(() => {
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
-    // If not children, no element to observe
-    if (isNullish(container) || isNullish(container.lastElementChild)) {
+    // If no element to observe
+    if (isNullish(target)) {
       return;
     }
 
@@ -70,20 +64,29 @@
       return;
     }
 
-    observer.observe(container.lastElementChild);
+    observer.observe(target);
   });
 
   onDestroy(() => observer.disconnect());
 </script>
 
-<ul bind:this={container} class:card-grid={layout === "grid"} data-tid={testId}>
+<ul class:card-grid={layout === "grid"} data-tid={testId}>
   <slot />
 </ul>
+
+<div bind:this={target} class="intersection-observer-target"></div>
 
 <style lang="scss">
   ul {
     margin: 0;
     padding: 0;
     list-style: none;
+  }
+
+  .intersection-observer-target {
+    width: 0;
+    height: 0;
+    opacity: 0;
+    visibility: hidden;
   }
 </style>

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -18,7 +18,7 @@
     threshold: 0,
   };
 
-  let target: HTMLDivElement | undefined;
+  let intersectionTarget: HTMLDivElement | undefined;
 
   const dispatch = createEventDispatcher();
 
@@ -48,14 +48,14 @@
       observer.disconnect();
     }
 
-    skipContainerNextUpdate = isNullish(target);
+    skipContainerNextUpdate = isNullish(intersectionTarget);
   });
 
   afterUpdate(() => {
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
     // If no element to observe
-    if (isNullish(target)) {
+    if (isNullish(intersectionTarget)) {
       return;
     }
 
@@ -64,7 +64,7 @@
       return;
     }
 
-    observer.observe(target);
+    observer.observe(intersectionTarget);
   });
 
   onDestroy(() => observer.disconnect());
@@ -74,7 +74,7 @@
   <slot />
 </ul>
 
-<div bind:this={target} class="intersection-observer-target"></div>
+<div bind:this={intersectionTarget} class="intersection-observer-target"></div>
 
 <style lang="scss">
   ul {


### PR DESCRIPTION
# Motivation

As I discovered in Juno (PR [#1092](https://github.com/junobuild/juno/pull/1092)), where I have a similar infinite scroll component to the one in Gix-cmp, the `InfiniteScroll` component no longer works after the migration to Svelte v5. The root cause of the issue is the following breaking change in Svelte:

> beforeUpdate/afterUpdate no longer run when the component contains a and its content is updated.

https://svelte.dev/docs/svelte/v5-migration-guide#Other-breaking-changes-beforeUpdate-afterUpdate-changes

Currently, we observe changes on the container to disconnect and reconnect the intersection observer. However, since there won't be any updates anymore, the observer will not reconnect, and the component will not fetch any new data after the first scroll event.

This issue is confirmed by the E2E test I recently added, which is now failing in the ongoing Svelte v5 PR (see this [job](https://github.com/dfinity/gix-components/actions/runs/12984449192/job/36207364140?pr=548) - `1) [Google Chrome] › e2e/infinite-scroll.e2e.ts:34:1 › should reach end of scroll`).

To resolve and prevent this issue, we can change the approach by using a target element to detect whether the element is intersecting.

# Changes

- Set an intersection observer on a targeted `<div>` to detect intersection.
- Ensure the element is as hidden as possible. Using `content` or `none` styles would prevent the observer from being triggered, as only visible elements trigger the event.
