### PR TITLE
chore: remove redundant statement for autocomplete in Input

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -156,10 +156,6 @@
     ({ selectionStart, selectionEnd } = inputElement);
   };
 
-  $: step = inputType === "number" ? (step ?? "any") : undefined;
-  $: autocomplete =
-    inputType !== "number" && !currency ? (autocomplete ?? "off") : undefined;
-
   let displayInnerEnd: boolean;
   $: displayInnerEnd = nonNullish($$slots["inner-end"]);
 </script>

--- a/src/tests/lib/components/Input.spec.ts
+++ b/src/tests/lib/components/Input.spec.ts
@@ -7,6 +7,9 @@ import InputTest from "./InputTest.svelte";
 import InputValueTest from "./InputValueTest.svelte";
 
 describe("Input", () => {
+  type InputType = "icp" | "number" | "text" | "currency";
+  type AutoComplete = "on" | "off" | undefined;
+
   const props = { name: "name", placeholder: "test.placeholder" };
 
   it("should render an input", () => {
@@ -34,7 +37,7 @@ describe("Input", () => {
     container,
   }: {
     attribute: string;
-    expected: string;
+    expected: string | null | undefined;
     container: HTMLElement;
   }) => {
     const input: HTMLInputElement | null = container.querySelector("input");
@@ -552,5 +555,60 @@ describe("Input", () => {
     testBind && testBind.click();
 
     expect(input === document.activeElement).toBe(true);
+  });
+
+  describe.each(["number"])("inputType=%s", (inputType) => {
+    it("should never set autocomplete", () => {
+      const { container: container1 } = render(Input, {
+        props: {
+          ...props,
+          inputType: inputType as InputType,
+          autocomplete: "off",
+        },
+      });
+
+      testGetAttribute({
+        container: container1,
+        attribute: "autocomplete",
+        expected: null,
+      });
+
+      const { container: container2 } = render(Input, {
+        props: {
+          ...props,
+          inputType: inputType as InputType,
+          autocomplete: "on",
+        },
+      });
+
+      testGetAttribute({
+        container: container2,
+        attribute: "autocomplete",
+        expected: null,
+      });
+    });
+  });
+
+  describe.each(["icp", "text", "currency"])("inputType='%s'", (inputType) => {
+    describe.each([["on"], ["off"], [undefined, "off"]])(
+      "autocomplete='%s'",
+      (autocomplete, expected = undefined) => {
+        it(`should set autocomplete to '${expected}' for inputType='${inputType}' and autocomplete='${autocomplete}'`, () => {
+          const { container } = render(Input, {
+            props: {
+              ...props,
+              inputType: inputType as InputType,
+              autocomplete: autocomplete as AutoComplete,
+            },
+          });
+
+          testGetAttribute({
+            container,
+            attribute: "autocomplete",
+            expected: autocomplete ?? expected,
+          });
+        });
+      },
+    );
   });
 });


### PR DESCRIPTION
# Motivation

There are two reactive statements that define `step` and `autocomplete`.

For step, they are identical, so we can remove them.

For `autocomplete`, one of the two ignores the prop `autocomplete` for currency input type. I think that the objective is to have this ONLY for type `number`.
