### PR TITLE
feat: transition directive wrapper for test purpose

### DIFF
--- a/src/lib/directives/transition.directives.ts
+++ b/src/lib/directives/transition.directives.ts
@@ -1,0 +1,67 @@
+import {
+  fade as svelteFade,
+  fly as svelteFly,
+  scale as svelteScale,
+  type FadeParams,
+  type TransitionConfig,
+} from "svelte/transition";
+
+/**
+ * A wrapper around Svelte's `fade` transition that disables itself in test mode.
+ *
+ * Prevents the test error "Cannot set properties of undefined (setting 'onfinish')".
+ *
+ * @param {HTMLElement} node - The HTML element to apply the transition to.
+ * @param {FadeParams} [params] - Optional parameters for the fade transition.
+ * @returns {TransitionConfig} The transition configuration, or an empty object in test mode.
+ */
+export const testSafeFade = (
+  node: HTMLElement,
+  params?: FadeParams | undefined,
+): TransitionConfig => {
+  if (process.env.NODE_ENV === "test") {
+    return {};
+  }
+
+  return svelteFade(node, params);
+};
+
+/**
+ * A wrapper around Svelte's `fly` transition that disables itself in test mode.
+ *
+ * Prevents the test error "Cannot set properties of undefined (setting 'onfinish')".
+ *
+ * @param {HTMLElement} node - The HTML element to apply the transition to.
+ * @param {FlyParams} [params] - Optional parameters for the fly transition.
+ * @returns {TransitionConfig} The transition configuration, or an empty object in test mode.
+ */
+export const testSafeFly = (
+  node: HTMLElement,
+  params?: FadeParams | undefined,
+): TransitionConfig => {
+  if (process.env.NODE_ENV === "test") {
+    return {};
+  }
+
+  return svelteFly(node, params);
+};
+
+/**
+ * A wrapper around Svelte's `scale` transition that disables itself in test mode.
+ *
+ * Prevents the test error "Cannot set properties of undefined (setting 'onfinish')".
+ *
+ * @param {HTMLElement} node - The HTML element to apply the transition to.
+ * @param {ScaleParams} [params] - Optional parameters for the scale transition.
+ * @returns {TransitionConfig} The transition configuration, or an empty object in test mode.
+ */
+export const testSafeScale = (
+  node: HTMLElement,
+  params?: FadeParams | undefined,
+): TransitionConfig => {
+  if (process.env.NODE_ENV === "test") {
+    return {};
+  }
+
+  return svelteScale(node, params);
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,3 +12,4 @@ export type { ProgressStep, ProgressStepState } from "./types/progress-step";
 export type { ToastLevel, ToastMsg } from "./types/toast";
 export type { WizardStep, WizardSteps } from "./types/wizard";
 export * from "./utils/wizard.utils";
+export * from "./directives/transition.directives";


### PR DESCRIPTION
# Motivation

Svelte requires require the [web animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API), and neither [jsdom](https://github.com/jsdom/jsdom) nor [happy-dom](https://github.com/capricorn86/happy-dom) implements it.

While in Gix-cmp or OISY we are able to apply some mocks in the configuration, this is insuffisent for the existing large test suite of NNS dapp for which many tests fail, when migrating to Svelte v5, with the error:

> TypeError: Cannot set properties of undefined (setting 'onfinish')

As suggested in one of the related issues (see linked below), we can overcome the problem by disabling animations in test mode.

# References

- https://github.com/testing-library/svelte-testing-library/issues/284#issuecomment-2633120453
- https://github.com/testing-library/svelte-testing-library/issues/416

# CI issues

- https://github.com/dfinity/nns-dapp/actions/runs/13129931873/job/36632946426

# Changes

- Implement utils for fade, fly and scale that returns an empty transition configuration for test mode

# Tests

Errors do not happen anymore in NNS dapp - Svelte v5 wip branch running in the CI.

- https://github.com/dfinity/nns-dapp/actions/runs/13131104521/job/36636304026?pr=6020
