### PR TITLE
fix: transitions wrappers params types

### DIFF
--- a/src/lib/directives/transition.directives.ts
+++ b/src/lib/directives/transition.directives.ts
@@ -3,6 +3,8 @@ import {
   fly as svelteFly,
   scale as svelteScale,
   type FadeParams,
+  type FlyParams,
+  type ScaleParams,
   type TransitionConfig,
 } from "svelte/transition";
 
@@ -37,7 +39,7 @@ export const testSafeFade = (
  */
 export const testSafeFly = (
   node: HTMLElement,
-  params?: FadeParams | undefined,
+  params?: FlyParams | undefined,
 ): TransitionConfig => {
   if (process.env.NODE_ENV === "test") {
     return {};
@@ -57,7 +59,7 @@ export const testSafeFly = (
  */
 export const testSafeScale = (
   node: HTMLElement,
-  params?: FadeParams | undefined,
+  params?: ScaleParams | undefined,
 ): TransitionConfig => {
   if (process.env.NODE_ENV === "test") {
     return {};


### PR DESCRIPTION
# Motivation

Few params types were not correctly inherited in #573.

# Changes

- Use `FlyParams` for "fly" and `ScaleParams` for "scale" instead of `FadeParams`.