### PR TITLE
feat: transition slide wrapper and params

### DIFF
--- a/src/lib/directives/transition.directives.ts
+++ b/src/lib/directives/transition.directives.ts
@@ -2,7 +2,11 @@ import {
   fade as svelteFade,
   fly as svelteFly,
   scale as svelteScale,
+  slide as svelteSlide,
   type FadeParams,
+  type FlyParams,
+  type ScaleParams,
+  type SlideParams,
   type TransitionConfig,
 } from "svelte/transition";
 
@@ -37,7 +41,7 @@ export const testSafeFade = (
  */
 export const testSafeFly = (
   node: HTMLElement,
-  params?: FadeParams | undefined,
+  params?: FlyParams | undefined,
 ): TransitionConfig => {
   if (process.env.NODE_ENV === "test") {
     return {};
@@ -57,11 +61,31 @@ export const testSafeFly = (
  */
 export const testSafeScale = (
   node: HTMLElement,
-  params?: FadeParams | undefined,
+  params?: ScaleParams | undefined,
 ): TransitionConfig => {
   if (process.env.NODE_ENV === "test") {
     return {};
   }
 
   return svelteScale(node, params);
+};
+
+/**
+ * A wrapper around Svelte's `slide` transition that disables itself in test mode.
+ *
+ * Prevents the test error "Cannot set properties of undefined (setting 'onfinish')".
+ *
+ * @param {HTMLElement} node - The HTML element to apply the transition to.
+ * @param {SlideParams} [params] - Optional parameters for the slide transition.
+ * @returns {TransitionConfig} The transition configuration, or an empty object in test mode.
+ */
+export const testSafeSlide = (
+  node: HTMLElement,
+  params?: SlideParams | undefined,
+): TransitionConfig => {
+  if (process.env.NODE_ENV === "test") {
+    return {};
+  }
+
+  return svelteSlide(node, params);
 };

--- a/src/lib/directives/transition.directives.ts
+++ b/src/lib/directives/transition.directives.ts
@@ -4,8 +4,6 @@ import {
   scale as svelteScale,
   slide as svelteSlide,
   type FadeParams,
-  type FlyParams,
-  type ScaleParams,
   type SlideParams,
   type TransitionConfig,
 } from "svelte/transition";
@@ -41,7 +39,7 @@ export const testSafeFade = (
  */
 export const testSafeFly = (
   node: HTMLElement,
-  params?: FlyParams | undefined,
+  params?: FadeParams | undefined,
 ): TransitionConfig => {
   if (process.env.NODE_ENV === "test") {
     return {};
@@ -61,7 +59,7 @@ export const testSafeFly = (
  */
 export const testSafeScale = (
   node: HTMLElement,
-  params?: ScaleParams | undefined,
+  params?: FadeParams | undefined,
 ): TransitionConfig => {
   if (process.env.NODE_ENV === "test") {
     return {};


### PR DESCRIPTION
# Motivation

Provide a wrapper for the "slide" transition, similarly as those which were provided in #573.

Needed in OISY for Svelte v5 - i.e. looks like we will have to use those wrappers in consuming dApps as well.

The PR also 

# Changes

- Add `testSafeSlide`.
