### PR TITLE
feat: refresh method in themeStore

### DIFF
--- a/src/lib/stores/theme.store.ts
+++ b/src/lib/stores/theme.store.ts
@@ -1,19 +1,24 @@
 import type { Theme } from "$lib/types/theme";
-import { applyTheme, initTheme } from "$lib/utils/theme.utils";
+import { applyTheme, getCurrentTheme, initTheme } from "$lib/utils/theme.utils";
+import { nonNullish } from "@dfinity/utils";
 import { writable } from "svelte/store";
 
-const initialTheme: Theme | undefined = initTheme();
-
 export const initThemeStore = () => {
-  const { subscribe, set } = writable<Theme | undefined>(initialTheme);
+  const { subscribe, set } = writable<Theme | undefined>(initTheme());
+
+  const setTheme = (theme: Theme | undefined) => {
+    if (nonNullish(theme)) {
+      applyTheme({ theme, preserve: true });
+    }
+    set(theme);
+  };
 
   return {
     subscribe,
 
-    select: (theme: Theme) => {
-      applyTheme({ theme, preserve: true });
-      set(theme);
-    },
+    select: (theme: Theme) => setTheme(theme),
+
+    reset: () => setTheme(getCurrentTheme()),
   };
 };
 

--- a/src/lib/utils/theme.utils.ts
+++ b/src/lib/utils/theme.utils.ts
@@ -1,27 +1,17 @@
 import { Theme } from "$lib/types/theme";
 import { isNode } from "$lib/utils/env.utils";
+import { nonNullish } from "@dfinity/utils";
 import { enumFromStringExists } from "./enum.utils";
 
 export const THEME_ATTRIBUTE = "theme";
 export const LOCALSTORAGE_THEME_KEY = "nnsTheme";
 
 export const initTheme = (): Theme | undefined => {
-  // No DOM therefore cannot guess the theme
-  if (isNode()) {
-    return undefined;
+  const initialTheme: Theme | undefined = getCurrentTheme();
+
+  if (nonNullish(initialTheme)) {
+    applyTheme({ theme: initialTheme, preserve: false });
   }
-
-  const theme: string | null =
-    document.documentElement.getAttribute(THEME_ATTRIBUTE);
-
-  const initialTheme: Theme = enumFromStringExists({
-    obj: Theme,
-    value: theme,
-  })
-    ? (theme as Theme)
-    : Theme.DARK;
-
-  applyTheme({ theme: initialTheme, preserve: false });
 
   return initialTheme;
 };
@@ -49,4 +39,21 @@ export const applyTheme = ({
   if (preserve) {
     localStorage.setItem(LOCALSTORAGE_THEME_KEY, JSON.stringify(theme));
   }
+};
+
+export const getCurrentTheme = (): Theme | undefined => {
+  // No DOM therefore cannot guess the theme
+  if (isNode()) {
+    return undefined;
+  }
+
+  const theme: string | null =
+    document.documentElement.getAttribute(THEME_ATTRIBUTE);
+
+  return enumFromStringExists({
+    obj: Theme,
+    value: theme,
+  })
+    ? (theme as Theme)
+    : Theme.DARK;
 };

--- a/src/tests/lib/stores/theme.store.spec.ts
+++ b/src/tests/lib/stores/theme.store.spec.ts
@@ -1,0 +1,100 @@
+import { initThemeStore, themeStore } from "$lib";
+import { Theme } from "$lib/types/theme";
+import * as envUtils from "$lib/utils/env.utils";
+import * as themeUtils from "$lib/utils/theme.utils";
+import { THEME_ATTRIBUTE } from "$lib/utils/theme.utils";
+import { get } from "svelte/store";
+
+describe("theme-store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+
+    window.document.documentElement.removeAttribute(THEME_ATTRIBUTE);
+
+    vi.spyOn(envUtils, "isNode").mockReturnValue(false);
+  });
+
+  it("should initialise with the no theme if the theme is not set", () => {
+    expect(get(themeStore)).toBeUndefined();
+  });
+
+  it.each(Object.values(Theme))(
+    "should initialise with the current '%s' theme",
+    (theme) => {
+      window.document.documentElement.setAttribute(THEME_ATTRIBUTE, theme);
+
+      const spy = vi.spyOn(themeUtils, "initTheme");
+
+      const mockThemeStore = initThemeStore();
+
+      expect(get(mockThemeStore)).toBe(theme);
+      expect(spy).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("should apply and store the selected theme", () => {
+    const spy = vi.spyOn(themeUtils, "applyTheme");
+
+    themeStore.select(Theme.LIGHT);
+
+    expect(get(themeStore)).toBe(Theme.LIGHT);
+    expect(spy).toHaveBeenCalledWith({ theme: Theme.LIGHT, preserve: true });
+    expect(document.documentElement.getAttribute(THEME_ATTRIBUTE)).toBe(
+      Theme.LIGHT,
+    );
+
+    themeStore.select(Theme.DARK);
+
+    expect(get(themeStore)).toBe(Theme.DARK);
+    expect(spy).toHaveBeenCalledWith({ theme: Theme.DARK, preserve: true });
+    expect(document.documentElement.getAttribute(THEME_ATTRIBUTE)).toBe(
+      Theme.DARK,
+    );
+
+    // Just to double-check, we set it to light once more
+    themeStore.select(Theme.LIGHT);
+
+    expect(get(themeStore)).toBe(Theme.LIGHT);
+    expect(spy).toHaveBeenCalledWith({ theme: Theme.LIGHT, preserve: true });
+    expect(document.documentElement.getAttribute(THEME_ATTRIBUTE)).toBe(
+      Theme.LIGHT,
+    );
+  });
+
+  it("should reset to the current theme", () => {
+    const spy = vi.spyOn(themeUtils, "applyTheme");
+
+    // We first set the store, then we mock that the attribute may be changed in a different way
+    themeStore.select(Theme.LIGHT);
+    expect(document.documentElement.getAttribute(THEME_ATTRIBUTE)).toBe(
+      Theme.LIGHT,
+    );
+    window.document.documentElement.setAttribute(THEME_ATTRIBUTE, Theme.DARK);
+
+    themeStore.reset();
+
+    expect(get(themeStore)).toBe(Theme.DARK);
+    expect(spy).toHaveBeenCalledWith({ theme: Theme.DARK, preserve: true });
+  });
+
+  it("should handle gracefully when the theme is not set", () => {
+    window.document.documentElement.removeAttribute(THEME_ATTRIBUTE);
+
+    const mockThemeStore = initThemeStore();
+
+    expect(get(mockThemeStore)).toBe(Theme.DARK);
+  });
+
+  it("should handle gracefully when the theme is not correctly set", () => {
+    window.document.documentElement.setAttribute(
+      THEME_ATTRIBUTE,
+      "invalid-theme",
+    );
+
+    const mockThemeStore = initThemeStore();
+
+    expect(get(mockThemeStore)).toBe(Theme.DARK);
+  });
+});


### PR DESCRIPTION
# Motivation

We would like to have a `refresh` method in the `themeStore`. It is useful for example, if the theme is changed in the local storage and we need to "refresh" the store: for example, we have the case in OISY where we "set" the theme to `SYSTEM`, basically deleting the theme in local storage.

# Changes

- Extract an util `getCurrentTheme` to get the current theme set in the store: this code is already inside `initTheme`.
- Create sub-function `setTheme` inside `initialTheme` that is re-using the code of the `select` function.
- Reusing the sub-function above for the method `refresh` in combination with `getCurrentTheme`.

# Screenshots

Added a few tests for `themeStore` and `initThemeStore`.
