### PR TITLE
feat: option to reset theme to system settings

### DIFF
--- a/src/lib/stores/theme.store.ts
+++ b/src/lib/stores/theme.store.ts
@@ -1,5 +1,10 @@
 import type { Theme } from "$lib/types/theme";
-import { applyTheme, initTheme } from "$lib/utils/theme.utils";
+import {
+  applyTheme,
+  getThemeFromSystemSettings,
+  initTheme,
+  resetTheme,
+} from "$lib/utils/theme.utils";
 import { writable } from "svelte/store";
 
 const initialTheme: Theme | undefined = initTheme();
@@ -12,6 +17,12 @@ export const initThemeStore = () => {
 
     select: (theme: Theme) => {
       applyTheme({ theme, preserve: true });
+      set(theme);
+    },
+
+    resetToSystemSettings: () => {
+      const theme = getThemeFromSystemSettings();
+      resetTheme(theme);
       set(theme);
     },
   };

--- a/src/lib/utils/theme.utils.ts
+++ b/src/lib/utils/theme.utils.ts
@@ -50,3 +50,17 @@ export const applyTheme = ({
     localStorage.setItem(LOCALSTORAGE_THEME_KEY, JSON.stringify(theme));
   }
 };
+
+export const getThemeFromSystemSettings = (): Theme => {
+  const isDarkPreferred = window.matchMedia(
+    "(prefers-color-scheme: dark)",
+  ).matches;
+
+  return isDarkPreferred ? Theme.DARK : Theme.LIGHT;
+};
+
+export const resetTheme = (theme: Theme) => {
+  applyTheme({ theme, preserve: false });
+
+  localStorage.removeItem(LOCALSTORAGE_THEME_KEY);
+};


### PR DESCRIPTION
# Motivation

In OISY, we would like to offer users the ability to select "System" in addition to Dark or Light. Technically, this means reverting the theme to its original value—removing it from local storage and deriving the theme store value from the system settings.

# Changes

- Add a function to get the theme from the system settings (`matchMedia`).
-  Add a function to `applyTheme` but, delete the item in the `localStorage`.
- Add function `resetToSystemSettings` to store.
