### PR TITLE
build: use version to setup build reproducibility

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,11 +1,11 @@
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { mdsvex } from "mdsvex";
-import {fileURLToPath} from "node:url";
-import {readFileSync} from "node:fs";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const file = fileURLToPath(new URL('package.json', import.meta.url));
-const json = readFileSync(file, 'utf8');
+const file = fileURLToPath(new URL("package.json", import.meta.url));
+const json = readFileSync(file, "utf8");
 const { version } = JSON.parse(json);
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -28,8 +28,8 @@ const config = {
       register: false,
     },
     version: {
-      name: version
-    }
+      name: version,
+    },
   },
 };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,6 +1,12 @@
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { mdsvex } from "mdsvex";
+import {fileURLToPath} from "node:url";
+import {readFileSync} from "node:fs";
+
+const file = fileURLToPath(new URL('package.json', import.meta.url));
+const json = readFileSync(file, 'utf8');
+const { version } = JSON.parse(json);
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -21,6 +27,9 @@ const config = {
     serviceWorker: {
       register: false,
     },
+    version: {
+      name: version
+    }
   },
 };
 


### PR DESCRIPTION
# Motivation

We can use the version to setup build reproducibility and save few cycles when deploying to `gix.design`.

# Changes

- Setup version as we do in OISY or NNS Dapp or Juno
