### PR TITLE
Export type ChipGroupItem

### DIFF
--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -5,7 +5,10 @@ export { default as BusyScreen } from "./components/BusyScreen.svelte";
 export { default as Card } from "./components/Card.svelte";
 export { default as Checkbox } from "./components/Checkbox.svelte";
 export { default as Chip } from "./components/Chip.svelte";
-export { default as ChipGroup } from "./components/ChipGroup.svelte";
+export {
+  default as ChipGroup,
+  type ChipData,
+} from "./components/ChipGroup.svelte";
 export { default as Collapsible } from "./components/Collapsible.svelte";
 export { default as Content } from "./components/Content.svelte";
 export { default as ContentBackdrop } from "./components/ContentBackdrop.svelte";

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -5,10 +5,7 @@ export { default as BusyScreen } from "./components/BusyScreen.svelte";
 export { default as Card } from "./components/Card.svelte";
 export { default as Checkbox } from "./components/Checkbox.svelte";
 export { default as Chip } from "./components/Chip.svelte";
-export {
-  default as ChipGroup,
-  type ChipData,
-} from "./components/ChipGroup.svelte";
+export { default as ChipGroup } from "./components/ChipGroup.svelte";
 export { default as Collapsible } from "./components/Collapsible.svelte";
 export { default as Content } from "./components/Content.svelte";
 export { default as ContentBackdrop } from "./components/ContentBackdrop.svelte";

--- a/src/lib/components/ChipGroup.svelte
+++ b/src/lib/components/ChipGroup.svelte
@@ -1,16 +1,9 @@
-<script lang="ts" context="module">
-  export interface ChipData {
-    label: string;
-    id: string;
-    selected: boolean;
-  }
-</script>
-
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import Chip from "./Chip.svelte";
+  import type { ChipGroupItem } from "../types/chip-group";
 
-  export let chips: ChipData[] = [];
+  export let chips: ChipGroupItem[] = [];
   export let testId: string = "chip-group-component";
 
   const dispatch = createEventDispatcher();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,6 +8,7 @@ export * from "./stores/theme.store";
 export * from "./stores/toasts.store";
 export * from "./stores/wizard.state";
 export type { BusyState } from "./types/busy";
+export type { ChipGroupItem } from "./types/chip-group";
 export type { ProgressBarSegment } from "./types/progress-bar";
 export type { ProgressStep, ProgressStepState } from "./types/progress-step";
 export * from "./types/theme";

--- a/src/lib/types/chip-group.ts
+++ b/src/lib/types/chip-group.ts
@@ -1,0 +1,5 @@
+export interface ChipGroupItem {
+  label: string;
+  id: string;
+  selected: boolean;
+}

--- a/src/routes/(split)/components/chip-group/+page.md
+++ b/src/routes/(split)/components/chip-group/+page.md
@@ -28,10 +28,10 @@
 
 ChipGroup allows users to choose from multiple options. It’s possible to listen for the nnsSelect event (where the selected ID is provided in the event detail) or, alternatively, bind the chip property. The current implementation does not support multiple selections.
 
-### ChipData interface
+### ChipGroupItem interface
 
 ```typescript
-export interface ChipData {
+export interface ChipGroupItem {
   label: string;
   id: string;
   selected: boolean;
@@ -42,7 +42,7 @@ export interface ChipData {
 
 ```javascript
 <script>
-  // Items of ChipData
+  // Items of ChipGroupItem
   let chips = [
     {
       id: "jan",
@@ -60,16 +60,16 @@ export interface ChipData {
 
 ## Properties
 
-| Property | Description                | Type              | Default                |
-| -------- | -------------------------- | ----------------- | ---------------------- |
-| `chips`  | ChipData items to display. | `Array<ChipData>` |                        |
-| `testId` | Optional data-tid value.   | `string`          | `chip-group-component` |
+| Property | Description                     | Type                   | Default                |
+| -------- | ------------------------------- | ---------------------- | ---------------------- |
+| `chips`  | ChipGroupItem items to display. | `Array<ChipGroupItem>` |                        |
+| `testId` | Optional data-tid value.        | `string`               | `chip-group-component` |
 
 ## Events
 
-| Event       | Description                             | Detail      |
-| ----------- | --------------------------------------- | ----------- |
-| `nnsSelect` | Triggered when a user clicks on a Chip. | ChipData.id |
+| Event       | Description                             | Detail           |
+| ----------- | --------------------------------------- | ---------------- |
+| `nnsSelect` | Triggered when a user clicks on a Chip. | ChipGroupItem.id |
 
 ## Showcase
 


### PR DESCRIPTION
# Motivation

To make the ChipData type available, it needs to be explicitly exported.

# Changes

- Rename ChipData to ChipGroupItem.
- Move it to a separate file under types.
- Explicitly export it.

# Screenshots

No changes.
