### PR TITLE
Fix scss warning

### DIFF
--- a/src/lib/components/Chip.svelte
+++ b/src/lib/components/Chip.svelte
@@ -23,7 +23,7 @@
   @use "../styles/mixins/button";
 
   .chip {
-    @include button.base;
+    @include button.base(false);
     @include fonts.small(true);
 
     // Override default button styles

--- a/src/lib/styles/mixins/_button.scss
+++ b/src/lib/styles/mixins/_button.scss
@@ -1,6 +1,6 @@
 @use "./fonts";
 
-@mixin base {
+@mixin base($hasDisabled: true) {
   padding: var(--padding) var(--padding-2x);
 
   border-radius: var(--border-radius);
@@ -12,12 +12,14 @@
 
   font-weight: var(--font-weight-bold);
 
-  &[disabled],
-  &[disabled]:hover {
-    background: var(--button-disable-background);
-    color: var(--button-disable-color);
-    cursor: default;
-    box-shadow: none;
+  @if $hasDisabled {
+    &[disabled],
+    &[disabled]:hover {
+      background: var(--button-disable-background);
+      color: var(--button-disable-color);
+      cursor: default;
+      box-shadow: none;
+    }
   }
 
   &:focus {


### PR DESCRIPTION
# Motivation

Currently, when the _button SCSS mixin is applied, the disabled states are always added. Because of this, in cases where they are not needed (e.g., in the Chip component), the linter produces warnings:
```
Warn: Unused CSS selector ".chip[disabled]" (svelte)

<style lang="scss">
  @use "../styles/mixins/effect";
```

# Changes

- Add flag to the _button mixin to skip disable styles.
- Use the flag in the Chip to avoid warnings.

# Screenshots

No visual or logical changes.
