### PR TITLE
feat(ui): add bottom slot to input component

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -171,34 +171,36 @@
       <slot name="end" />
     </div>
   {/if}
-  <div class="input-field" class:withBottom={displayBottom}>
-    <input
-      bind:this={inputElement}
-      data-tid={testId}
-      type={currency ? "text" : inputType}
-      {required}
-      {spellcheck}
-      {name}
-      id={name}
-      {step}
-      {disabled}
-      value={currency ? currencyValue : value}
-      minlength={minLength}
-      {placeholder}
-      {max}
-      {autocomplete}
-      on:blur
-      on:focus
-      on:input={handleInput}
-      on:keydown={handleKeyDown}
-      class:inner-end={displayInnerEnd}
-      data-1p-ignore={ignore1Password}
-    />
-    {#if displayInnerEnd}
-      <div class="inner-end-slot">
-        <slot name="inner-end" />
-      </div>
-    {/if}
+  <div class:with-bottom={displayBottom}>
+    <div class="input-field">
+      <input
+        bind:this={inputElement}
+        data-tid={testId}
+        type={currency ? "text" : inputType}
+        {required}
+        {spellcheck}
+        {name}
+        id={name}
+        {step}
+        {disabled}
+        value={currency ? currencyValue : value}
+        minlength={minLength}
+        {placeholder}
+        {max}
+        {autocomplete}
+        on:blur
+        on:focus
+        on:input={handleInput}
+        on:keydown={handleKeyDown}
+        class:inner-end={displayInnerEnd}
+        data-1p-ignore={ignore1Password}
+      />
+      {#if displayInnerEnd}
+        <div class="inner-end-slot">
+          <slot name="inner-end" />
+        </div>
+      {/if}
+    </div>
 
     {#if displayBottom}
       <div class="bottom-slot">
@@ -269,16 +271,6 @@
     position: relative;
   }
 
-  .withBottom {
-    background-color: var(--input-border-color);
-    border-radius: var(--border-radius);
-
-    input {
-      padding-top: var(--padding-3x);
-      padding-bottom: var(--padding-3x);
-    }
-  }
-
   .inner-end {
     padding-right: var(--input-padding-inner-end, 64px);
   }
@@ -289,5 +281,15 @@
     right: 0;
     transform: translate(0, -50%);
     padding: var(--padding) var(--padding-2x);
+  }
+
+  .with-bottom {
+    background-color: var(--input-border-color);
+    border-radius: var(--border-radius);
+
+    input {
+      padding-top: var(--padding-3x);
+      padding-bottom: var(--padding-3x);
+    }
   }
 </style>

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { isNullish, nonNullish } from "@dfinity/utils";
+  import { createEventDispatcher } from "svelte";
 
   export let name: string;
   export let inputType: "icp" | "number" | "text" | "currency" = "number";
@@ -158,6 +158,9 @@
 
   let displayInnerEnd: boolean;
   $: displayInnerEnd = nonNullish($$slots["inner-end"]);
+
+  let displayBottom: boolean;
+  $: displayBottom = nonNullish($$slots["bottom"]);
 </script>
 
 <div class="input-block" class:disabled>
@@ -168,7 +171,7 @@
       <slot name="end" />
     </div>
   {/if}
-  <div class="input-field">
+  <div class="input-field" class:withBottom={displayBottom}>
     <input
       bind:this={inputElement}
       data-tid={testId}
@@ -194,6 +197,12 @@
     {#if displayInnerEnd}
       <div class="inner-end-slot">
         <slot name="inner-end" />
+      </div>
+    {/if}
+
+    {#if displayBottom}
+      <div class="bottom-slot">
+        <slot name="bottom" />
       </div>
     {/if}
   </div>
@@ -258,6 +267,16 @@
 
   .input-field {
     position: relative;
+  }
+
+  .withBottom {
+    background-color: var(--input-border-color);
+    border-radius: var(--border-radius);
+
+    input {
+      padding-top: var(--padding-3x);
+      padding-bottom: var(--padding-3x);
+    }
   }
 
   .inner-end {

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -48,6 +48,7 @@ If the `inputType` is set to `icp`, the `value` bind by the component is a `numb
 | `label`     | A label related to the input. Need to be activated with the property `showInfo`.                                       |
 | `end`       | An addition after the label (e.g. an action related to the input). Need to be activated with the property `showInfo`.  |
 | `inner-end` | An addition displayed within the input (e.g. an action related to the input).                                          |
+| `bottom`    | An addition below the input field.                                                                                     |
 
 Both slots are displayed `flex` with `space-between`.
 
@@ -74,6 +75,12 @@ Both slots are displayed `flex` with `space-between`.
 
     <Input placeholder="Input text" inputType="text" value="">
         <IconQRCodeScanner slot="inner-end" />
+    </Input>
+
+    <Input placeholder="Input text" inputType="text" value="">
+        <div slot="bottom">
+           <p>A slot to show stuff below the input field</p>
+        </div>
     </Input>
 
 </div>

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -83,4 +83,12 @@ Both slots are displayed `flex` with `space-between`.
         </div>
     </Input>
 
+    <Input placeholder="Input text" inputType="text" value="">
+        <IconQRCodeScanner slot="inner-end" />
+
+        <div slot="bottom">
+           <p>A slot to show stuff below the input field</p>
+        </div>
+    </Input>
+
 </div>


### PR DESCRIPTION
# Motivation

We want to display the USD value in transaction forms within the nns-dapp. To achieve this, we need to extend the input to include a "bottom" section with custom styles.

Example from the nns-dapp:

<img width="599" alt="Screenshot 2025-03-18 at 17 51 34" src="https://github.com/user-attachments/assets/bc79e421-18bb-4e16-83ae-629657507f13" />

# Changes

- Expose a new slot in the `Input` field

# Screenshots

<img width="929" alt="Screenshot 2025-03-18 at 17 47 42" src="https://github.com/user-attachments/assets/33b7518d-4ce1-4229-8169-5627eabdac16" />

<img width="939" alt="Screenshot 2025-03-18 at 17 48 02" src="https://github.com/user-attachments/assets/357aef61-282d-42cc-a718-98cc03627c51" />
