### PR TITLE
chore: bump version number for releasing Svelte v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/gix-components",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/gix-components",
-      "version": "5.2.0",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dfinity/gix-components",
   "description": "A UI kit developed by the GIX team",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "npm run i18n && vite dev",


### PR DESCRIPTION
# Motivation

We want to release a major version to rollout the migration to Svelte v5 (#548).

# Changes

- Bump `v6.0.0`
