### PR TITLE
build: bump vite (CVE-2025-30208)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "svelte2tsx": "^0.7.35",
         "typescript": "^5.3.3",
         "user-agent-data-types": "^0.4.2",
-        "vite": "^6.2.2",
+        "vite": "^6.2.3",
         "vitest": "^3.0.9"
       },
       "peerDependencies": {
@@ -5538,9 +5538,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9442,9 +9442,9 @@
       }
     },
     "vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "svelte2tsx": "^0.7.35",
     "typescript": "^5.3.3",
     "user-agent-data-types": "^0.4.2",
-    "vite": "^6.2.2",
+    "vite": "^6.2.3",
     "vitest": "^3.0.9"
   },
   "dependencies": {


### PR DESCRIPTION
# Motivation

We are not affected but, for the state of the art, let's bump vite to resolve https://github.com/advisories/GHSA-x574-m823-4x7w

# Notes

This version of vite is already used in OISY and NNS dapp. ✅

# Changes

- Bump vite v6.2.3
