### PR TITLE
chore(ci): upgrade github actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # In order to trigger other workflows after committing formatting changes, we need
     # to use the PR Automation App. This secret is not available for external
-    # contributors. So on PRs that can't acces the secret, we don't commit changes and instead just 
+    # contributors. So on PRs that can't acces the secret, we don't commit changes and instead just
     # fail if the formatting changes are needed.
     steps:
       - name: Check if commits can be added
@@ -74,7 +74,7 @@ jobs:
           exit 1
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -85,7 +85,7 @@ jobs:
         run: npm run build
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
         run: npm run lint -- --max-warnings 0
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -109,7 +109,7 @@ jobs:
         run: npm run test
 
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:
@@ -140,7 +140,7 @@ jobs:
 
   may-merge:
     needs: ["formatting", "build", "lint", "test", "e2e"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Cleared for merging
         run: echo OK

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   update_snapshots:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Fail if branch is main
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
# Motivation

Gix uses an Ubuntu runner that will be deprecated on April 1st. A Slack [message](https://dfinity.slack.com/archives/CH4CADCJX/p1740558752499169) pointed to some repositories, but gix-components was overlooked.

We have some issues in the pipeline with open PRs. For example: https://github.com/dfinity/gix-components/actions/runs/14200871834

# Changes

- Upgraded the version to `ubuntu-22.04`.

# Tests

- CI should pass

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.