### PR TITLE
build: bump vite (CVE-2025-31125)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "svelte2tsx": "^0.7.35",
         "typescript": "^5.3.3",
         "user-agent-data-types": "^0.4.2",
-        "vite": "^6.2.3",
+        "vite": "^6.2.4",
         "vitest": "^3.0.9"
       },
       "peerDependencies": {
@@ -5538,9 +5538,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9442,9 +9442,9 @@
       }
     },
     "vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "svelte2tsx": "^0.7.35",
     "typescript": "^5.3.3",
     "user-agent-data-types": "^0.4.2",
-    "vite": "^6.2.3",
+    "vite": "^6.2.4",
     "vitest": "^3.0.9"
   },
   "dependencies": {


### PR DESCRIPTION
# Motivation

Another week, anoter security issue in vite. Similarly to latest incident (#610), we are not affected but, for the state of the art, let's bump vite to resolve [CVE-2025-31125](https://github.com/advisories/GHSA-4r4m-qw57-chr8).

# Changes

- Bump vite v6.2.4
