### PR TITLE
feat(icons): add size prop for launchpad and token icons

### DIFF
--- a/src/lib/icons/IconLaunchpad.svelte
+++ b/src/lib/icons/IconLaunchpad.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
+<script lang="ts">
+  const DEFAULT_SIZE = 40;
+  export let size = `${DEFAULT_SIZE}px`;
+</script>
+
 <svg
-  width="40"
-  height="40"
+  width={size}
+  height={size}
   viewBox="0 0 20 20"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/icons/IconLaunchpad.svelte
+++ b/src/lib/icons/IconLaunchpad.svelte
@@ -1,6 +1,7 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   const DEFAULT_SIZE = 40;
+
   export let size = `${DEFAULT_SIZE}px`;
 </script>
 

--- a/src/lib/icons/IconTokens.svelte
+++ b/src/lib/icons/IconTokens.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
+<script lang="ts">
+  const DEFAULT_SIZE = 40;
+  export let size = `${DEFAULT_SIZE}px`;
+</script>
+
 <svg
-  width="40"
-  height="40"
+  width={size}
+  height={size}
   viewBox="0 0 20 20"
   fill="none"
   stroke="currentColor"

--- a/src/lib/icons/IconTokens.svelte
+++ b/src/lib/icons/IconTokens.svelte
@@ -1,6 +1,7 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   const DEFAULT_SIZE = 40;
+
   export let size = `${DEFAULT_SIZE}px`;
 </script>
 


### PR DESCRIPTION
# Motivation

The nns-dapp wants to use the `IconLaunchpad` and `IconTokens` in different sizes. This PR introduces a `size` prop, similar to the approach used for other icons. To maintain backward compatibility, it does not use `DEFAULT_ICON_SIZE`; instead, it employs a local variable to set the size to 40 px.

# Changes

- Expose the new `size` prop in `IconLaunchpad` and `IconTokens`

# Screenshots

Not necessary.
