### PR TITLE
feat(input): Adds autofocus property to input component

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -16,6 +16,7 @@
   export let decimals = 8;
   export let ignore1Password = true;
   export let inputElement: HTMLInputElement | undefined = undefined;
+  export let autofocus = false;
 
   const dispatch = createEventDispatcher();
 
@@ -173,6 +174,7 @@
   {/if}
   <div class:with-bottom={displayBottom}>
     <div class="input-field">
+      <!-- svelte-ignore a11y_autofocus -->
       <input
         bind:this={inputElement}
         data-tid={testId}
@@ -188,6 +190,7 @@
         {placeholder}
         {max}
         {autocomplete}
+        {autofocus}
         on:blur
         on:focus
         on:input={handleInput}

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -35,6 +35,7 @@ The input component is a wrapper to the HTML input element with custom styling a
 | `testId`          | Add a `data-tid` attribute to the DOM, useful for test purpose.                                                                                       | `string` or `undefined`                   | `undefined` |
 | `ignore1Password` | Tell 1Password it should ignore the field (Reference: 1Password [documentation](https://developer.1password.com/docs/web/compatible-website-design/)) | `boolean`                                 | `true`      |
 | `inputElement`    | HTML input element                                                                                                                                    | `HTMLInputElement` or `undefined`         | `undefined` |
+| `autofocus`       | HTML input `autofocus` attribute. When set to true, the input will be automatically focused when the component is mounted.                            | `boolean`                                 | `false`     |
 
 ### Notes
 

--- a/src/tests/lib/components/Input.svelte.spec.ts
+++ b/src/tests/lib/components/Input.svelte.spec.ts
@@ -1,7 +1,7 @@
 import Input from "$lib/components/Input.svelte";
 import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
-import { fireEvent, render } from "@testing-library/svelte";
 import { tick } from "svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import InputElementTest from "./InputElementTest.svelte";
 import InputTest from "./InputTest.svelte";
 import InputValueTest from "./InputValueTest.svelte";
@@ -562,11 +562,10 @@ describe("Input", () => {
     const input: HTMLInputElement | null = container.querySelector("input");
     expect(input).not.toBeNull();
 
-    // In testing environments, we need to wait for the DOM to update
-    await tick();
-
-    // Check if the input is the active element
-    expect(input === document.activeElement).toBe(true);
+    await waitFor(() => {
+      // Check if the input is the active element
+      expect(input === document.activeElement).toBe(true);
+    });
   });
 
   it("should not focus by default", async () => {
@@ -577,11 +576,18 @@ describe("Input", () => {
     const input: HTMLInputElement | null = container.querySelector("input");
     expect(input).not.toBeNull();
 
-    // In testing environments, we need to wait for the DOM to update
-    await tick();
+    await waitFor(() => {
+      // Check if the input is the active element
+      expect(input === document.activeElement).toBe(false);
+    });
+  });
 
-    // Check if the input is the active element
-    expect(input === document.activeElement).toBe(false);
+  it("should not render autofocus by default", () => {
+    const { container } = render(Input, {
+      props: { ...props },
+    });
+
+    testHasAttribute({ container, attribute: "autofocus", expected: false });
   });
 
   describe.each(["number"])("inputType=%s", (inputType) => {

--- a/src/tests/lib/components/Input.svelte.spec.ts
+++ b/src/tests/lib/components/Input.svelte.spec.ts
@@ -1,7 +1,7 @@
 import Input from "$lib/components/Input.svelte";
 import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
-import { tick } from "svelte";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import InputElementTest from "./InputElementTest.svelte";
 import InputTest from "./InputTest.svelte";
 import InputValueTest from "./InputValueTest.svelte";

--- a/src/tests/lib/components/Input.svelte.spec.ts
+++ b/src/tests/lib/components/Input.svelte.spec.ts
@@ -554,6 +554,36 @@ describe("Input", () => {
     expect(input === document.activeElement).toBe(true);
   });
 
+  it("should autofocus the input when autofocus is true", async () => {
+    const { container } = render(Input, {
+      props: { ...props, autofocus: true },
+    });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+
+    // In testing environments, we need to wait for the DOM to update
+    await tick();
+
+    // Check if the input is the active element
+    expect(input === document.activeElement).toBe(true);
+  });
+
+  it("should not focus by default", async () => {
+    const { container } = render(Input, {
+      props: { ...props },
+    });
+
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+
+    // In testing environments, we need to wait for the DOM to update
+    await tick();
+
+    // Check if the input is the active element
+    expect(input === document.activeElement).toBe(false);
+  });
+
   describe.each(["number"])("inputType=%s", (inputType) => {
     it("should never set autocomplete", () => {
       const { container: container1 } = render(Input, {


### PR DESCRIPTION
# Motivation

In OISY, the autofocus is used several times with a custom implementation. To be able to use the browsers implementation of autofocus, this PR exposes the `autofocus` property.

Compare: https://github.com/dfinity/oisy-wallet/pull/5901

# Changes

- Exposes the `autofocus` property