### PR TITLE
feat(input): Add clear button to input component

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { IconClose } from "$lib/icons";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
 
@@ -16,6 +17,7 @@
   export let decimals = 8;
   export let ignore1Password = true;
   export let inputElement: HTMLInputElement | undefined = undefined;
+  export let showClearButton = false;
 
   const dispatch = createEventDispatcher();
 
@@ -156,8 +158,12 @@
     ({ selectionStart, selectionEnd } = inputElement);
   };
 
+  const clear = () => {
+    value = undefined;
+  };
+
   let displayInnerEnd: boolean;
-  $: displayInnerEnd = nonNullish($$slots["inner-end"]);
+  $: displayInnerEnd = nonNullish($$slots["inner-end"]) || showClearButton;
 
   let displayBottom: boolean;
   $: displayBottom = nonNullish($$slots["bottom"]);
@@ -198,6 +204,11 @@
       {#if displayInnerEnd}
         <div class="inner-end-slot">
           <slot name="inner-end" />
+          {#if showClearButton && value}
+            <button class="clear-button" on:click={clear}>
+              <IconClose />
+            </button>
+          {/if}
         </div>
       {/if}
     </div>

--- a/src/routes/(split)/components/input/+page.md
+++ b/src/routes/(split)/components/input/+page.md
@@ -91,4 +91,6 @@ Both slots are displayed `flex` with `space-between`.
         </div>
     </Input>
 
+    <Input placeholder="With clear button" inputType="text" value="" showClearButton={true}/>
+
 </div>

--- a/src/tests/lib/components/Input.svelte.spec.ts
+++ b/src/tests/lib/components/Input.svelte.spec.ts
@@ -554,6 +554,74 @@ describe("Input", () => {
     expect(input === document.activeElement).toBe(true);
   });
 
+  it("should clear input value when clear button is clicked", async () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+        value: "test value",
+        showClearButton: true,
+      },
+    });
+
+    // Verify input has the initial value
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("test value");
+
+    // Verify clear button is rendered
+    const clearButton: HTMLButtonElement | null =
+      container.querySelector(".clear-button");
+    expect(clearButton).not.toBeNull();
+
+    // Click the clear button
+    clearButton && (await fireEvent.click(clearButton));
+
+    // Verify the value is cleared (we can only check the input value, not the bound value)
+    expect(input?.value).toBe("");
+  });
+
+  it("should not show clear button when showClearButton is false", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        inputType: "text",
+        value: "test value",
+        showClearButton: false,
+      },
+    });
+
+    // Verify input has the value
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("test value");
+
+    // Verify clear button is not rendered
+    const clearButton: HTMLButtonElement | null =
+      container.querySelector(".clear-button");
+    expect(clearButton).toBeNull();
+  });
+
+  it("should not show clear button when there is no value even if showClearButton is true", () => {
+    const { container } = render(Input, {
+      props: {
+        ...props,
+        value: undefined,
+        showClearButton: true,
+      },
+    });
+
+    // Verify input has no value
+    const input: HTMLInputElement | null = container.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("");
+
+    // Verify clear button is not rendered
+    const clearButton: HTMLButtonElement | null =
+      container.querySelector(".clear-button");
+    expect(clearButton).toBeNull();
+  });
+
   describe.each(["number"])("inputType=%s", (inputType) => {
     it("should never set autocomplete", () => {
       const { container: container1 } = render(Input, {


### PR DESCRIPTION
# Motivation

In order to easily remove the content of a input field, an optional clear button can be displayed.

# Changes

Adds a clear button when `showClearButton` is set to `true` on the input field.

# Screenshots

Without any value:

![Screenshot_2025-04-22_14-29-38](https://github.com/user-attachments/assets/9f84f1bc-8511-4a1b-853f-4bb725879f5f)

Button is displayed when the input field has some value:

![Screenshot_2025-04-22_14-29-57](https://github.com/user-attachments/assets/2af6487c-3b77-4c21-b27d-abb0d5f3877d)

