### PR TITLE
feat: Add support for typed step names in `WizardStep` types

### DIFF
--- a/src/lib/types/wizard.ts
+++ b/src/lib/types/wizard.ts
@@ -1,6 +1,6 @@
-export interface WizardStep {
-  readonly name: string;
+export interface WizardStep<T extends string = string> {
+  readonly name: T;
   readonly title: string;
 }
 
-export type WizardSteps = [WizardStep, ...WizardStep[]];
+export type WizardSteps<T extends string = string> = [WizardStep<T>, ...WizardStep<T>[]];


### PR DESCRIPTION
# Motivation

Most of the times we use the `WizardStep` types providing specific enums for the name field (useful when you have limited pre-designed steps). For example, OISY repo [uses it like that mostly](https://github.com/dfinity/oisy-wallet/blob/3814fd67e4ab6ae60ec3dcb3c0c82ec25ea8fe7a/src/frontend/src/lib/config/send.config.ts#L9).

To allow the consumer to be more type-safe, I would like to propose the use of generics types for `WizardStep`. But to avoid breaking changes, we default to `string` (same behaviour as now).

