### PR TITLE
fix(deps): upgrade sveltekit to resolve icons page serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@junobuild/config": "^0.0.14",
         "@playwright/test": "^1.51.0",
         "@sveltejs/adapter-static": "^3.0.8",
-        "@sveltejs/kit": "^2.20.4",
+        "@sveltejs/kit": "^2.20.7",
         "@sveltejs/package": "^2.3.10",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@testing-library/jest-dom": "^6.6.3",
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.20.6",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.6.tgz",
-      "integrity": "sha512-ImUkSQ//Xf4N9r0HHAe5vRA7RyQ7U1Ue1YUT235Ig+IiIqbsixEulHTHrP5LtBiC8xOkJoPZQ1VZ/nWHNOaGGw==",
+      "version": "2.20.7",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.7.tgz",
+      "integrity": "sha512-dVbLMubpJJSLI4OYB+yWYNHGAhgc2bVevWuBjDj8jFUXIJOAnLwYP3vsmtcgoxNGUXoq0rHS5f7MFCsryb6nzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6644,9 +6644,9 @@
       "requires": {}
     },
     "@sveltejs/kit": {
-      "version": "2.20.6",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.6.tgz",
-      "integrity": "sha512-ImUkSQ//Xf4N9r0HHAe5vRA7RyQ7U1Ue1YUT235Ig+IiIqbsixEulHTHrP5LtBiC8xOkJoPZQ1VZ/nWHNOaGGw==",
+      "version": "2.20.7",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.7.tgz",
+      "integrity": "sha512-dVbLMubpJJSLI4OYB+yWYNHGAhgc2bVevWuBjDj8jFUXIJOAnLwYP3vsmtcgoxNGUXoq0rHS5f7MFCsryb6nzg==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@junobuild/config": "^0.0.14",
     "@playwright/test": "^1.51.0",
     "@sveltejs/adapter-static": "^3.0.8",
-    "@sveltejs/kit": "^2.20.4",
+    "@sveltejs/kit": "^2.20.7",
     "@sveltejs/package": "^2.3.10",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
# Motivation

The upgrade to Svelte 5 broke the [icons page](https://gix.design/icons) due to a regression issue caused by Svelte Kit deserializing the payload from the backend file.

Svelte Kit has addressed this issue in the [latest version](https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fkit%402.20.7).

# Changes

- Upgrade SvelteKit to the latest version.