### PR TITLE
feat(icons): add EyeOpen component

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -27,6 +27,7 @@ export { default as IconExpandAll } from "./icons/IconExpandAll.svelte";
 export { default as IconExpandCircleDown } from "./icons/IconExpandCircleDown.svelte";
 export { default as IconExpandMore } from "./icons/IconExpandMore.svelte";
 export { default as IconExplore } from "./icons/IconExplore.svelte";
+export { default as IconEyeOpen } from "./icons/IconEyeOpen.svelte";
 export { default as IconFilter } from "./icons/IconFilter.svelte";
 export { default as IconGitHub } from "./icons/IconGitHub.svelte";
 export { default as IconHeldTokens } from "./icons/IconHeldTokens.svelte";

--- a/src/lib/icons/IconEyeOpen.svelte
+++ b/src/lib/icons/IconEyeOpen.svelte
@@ -1,0 +1,25 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  ><path
+    stroke="currentColor"
+    stroke-width="1.5"
+    d="M4.316 6.38C5.758 5.272 7.763 4.374 10 4.374s4.242.898 5.684 2.004c.722.555 1.319 1.173 1.74 1.78.41.59.701 1.239.701 1.841 0 .602-.291 1.25-.7 1.84-.422.608-1.019 1.226-1.741 1.78-1.442 1.107-3.447 2.005-5.684 2.005s-4.242-.898-5.684-2.004c-.722-.555-1.319-1.173-1.74-1.78-.41-.59-.701-1.239-.701-1.841 0-.602.291-1.25.7-1.84.422-.608 1.019-1.226 1.741-1.78Z"
+    clip-rule="evenodd"
+  /><path
+    stroke="currentColor"
+    stroke-width="1.5"
+    d="M6.875 10a3.125 3.125 0 1 1 6.25 0 3.125 3.125 0 0 1-6.25 0Z"
+    clip-rule="evenodd"
+  /></svg
+>


### PR DESCRIPTION
# Motivation

The nns-dapp needs a new icon to be displayed in a `Highlight` component.

# Changes

- Adds new icon 

# Screenshots

![Screenshot 2025-04-28 at 10 38 37](https://github.com/user-attachments/assets/0ba9ce09-7420-48e3-a69f-5c74316d8fcf)