### PR TITLE
feat!: migrating `InfiniteScroll` to Svelte 5

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -3,7 +3,7 @@
   import { isNullish } from "@dfinity/utils";
 
   interface Props {
-    onintersect: () => Promise<void>;
+    onIntersect: () => Promise<void>;
     layout?: "list" | "grid";
     disabled?: boolean;
     testId?: string;
@@ -14,7 +14,7 @@
   }
 
   let {
-    onintersect,
+    onIntersect,
     layout = "list",
     disabled = false,
     testId,
@@ -36,7 +36,7 @@
       return;
     }
 
-    await onintersect();
+    await onIntersect();
   };
 
   const observer: IntersectionObserver = new IntersectionObserver(

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -1,26 +1,31 @@
 <script lang="ts">
-  import {
-    afterUpdate,
-    beforeUpdate,
-    createEventDispatcher,
-    onDestroy,
-  } from "svelte";
+  import { onDestroy, type Snippet } from "svelte";
   import { isNullish } from "@dfinity/utils";
 
-  export let layout: "list" | "grid" = "list";
-  export let disabled = false;
-  export let testId: string | undefined = undefined;
+  interface Props {
+    onintersect: () => void;
+    layout?: "list" | "grid";
+    disabled?: boolean;
+    testId?: string;
+    // IntersectionObserverInit is not recognized by the linter
+    // eslint-disable-next-line no-undef
+    options?: IntersectionObserverInit;
+    children: Snippet;
+  }
 
-  // IntersectionObserverInit is not recognized by the linter
-  // eslint-disable-next-line no-undef
-  export let options: IntersectionObserverInit = {
-    rootMargin: "300px",
-    threshold: 0,
-  };
+  let {
+    onintersect,
+    layout = "list",
+    disabled = false,
+    testId,
+    options = {
+      rootMargin: "300px",
+      threshold: 0,
+    },
+    children,
+  }: Props = $props();
 
   let intersectionTarget: HTMLDivElement | undefined;
-
-  const dispatch = createEventDispatcher();
 
   const onIntersection = (entries: IntersectionObserverEntry[]) => {
     const intersecting: IntersectionObserverEntry | undefined = entries.find(
@@ -31,7 +36,7 @@
       return;
     }
 
-    dispatch("nnsIntersect");
+    onintersect();
   };
 
   const observer: IntersectionObserver = new IntersectionObserver(
@@ -43,7 +48,7 @@
   let skipContainerNextUpdate = false;
 
   // We disconnect previous observer before any update. We do want to trigger an intersection in case of layout shifting.
-  beforeUpdate(() => {
+  $effect.pre(() => {
     if (!skipContainerNextUpdate) {
       observer.disconnect();
     }
@@ -51,7 +56,7 @@
     skipContainerNextUpdate = isNullish(intersectionTarget);
   });
 
-  afterUpdate(() => {
+  $effect(() => {
     // The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
     // If no element to observe
@@ -71,7 +76,7 @@
 </script>
 
 <ul class:card-grid={layout === "grid"} data-tid={testId}>
-  <slot />
+  {@render children()}
 </ul>
 
 <div bind:this={intersectionTarget} class="intersection-observer-target"></div>

--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -3,7 +3,7 @@
   import { isNullish } from "@dfinity/utils";
 
   interface Props {
-    onintersect: () => void;
+    onintersect: () => Promise<void>;
     layout?: "list" | "grid";
     disabled?: boolean;
     testId?: string;
@@ -27,7 +27,7 @@
 
   let intersectionTarget: HTMLDivElement | undefined;
 
-  const onIntersection = (entries: IntersectionObserverEntry[]) => {
+  const onIntersection = async (entries: IntersectionObserverEntry[]) => {
     const intersecting: IntersectionObserverEntry | undefined = entries.find(
       ({ isIntersecting }: IntersectionObserverEntry) => isIntersecting,
     );
@@ -36,7 +36,7 @@
       return;
     }
 
-    onintersect();
+    await onintersect();
   };
 
   const observer: IntersectionObserver = new IntersectionObserver(

--- a/src/routes/(split)/components/infinite-scroll/+page.md
+++ b/src/routes/(split)/components/infinite-scroll/+page.md
@@ -36,11 +36,11 @@ It sets the reference to the last element of the list after each re-render. **Pa
 
 ## Properties
 
-| Property      | Description                                                                                                                  | Type                  | Default     |
-|---------------|------------------------------------------------------------------------------------------------------------------------------|-----------------------|-------------|
-| `onIntersect` | Triggered each time the next observed item is intersecting. The event that can be use to call your action.                   | `() => Promise<void>` |             |
-| `layout`      | Display of the rendered items. Defined by a class set on `ul` container.                                                     | `list` or `grid`      | `list`      |
-| `disabled`    | If `true`, the infinite scroll stops observing for intersection and therefore, will stop calling the action to be performed. | `boolean`             | `false`     |
+| Property      | Description                                                                                                                  | Type                  | Default |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------- | ------- |
+| `onIntersect` | Triggered each time the next observed item is intersecting. The event that can be use to call your action.                   | `() => Promise<void>` |         |
+| `layout`      | Display of the rendered items. Defined by a class set on `ul` container.                                                     | `list` or `grid`      | `list`  |
+| `disabled`    | If `true`, the infinite scroll stops observing for intersection and therefore, will stop calling the action to be performed. | `boolean`             | `false` |
 
 ## Slots
 

--- a/src/routes/(split)/components/infinite-scroll/+page.md
+++ b/src/routes/(split)/components/infinite-scroll/+page.md
@@ -22,7 +22,7 @@
 The Infinite Scroll component calls an action to be performed when the user scrolls a specified distance of the list presented in the page.
 
 ```javascript
-<InfiniteScroll onintersect={onIntersect}>
+<InfiniteScroll onIntersect={onIntersect}>
   {#each array as data}
     <li>{data}</li>
   {/each}
@@ -55,7 +55,7 @@ It sets the reference to the last element of the list after each re-render. **Pa
 
 ## Showcase
 
-<InfiniteScroll onintersect={onIntersect} disabled={scrollDisabled} testId="showcase-infinite-scroll">
+<InfiniteScroll onIntersect={onIntersect} disabled={scrollDisabled} testId="showcase-infinite-scroll">
     {#each elements as _element, i}
         <li><Tag>Element {i}</Tag></li>
     {/each}

--- a/src/routes/(split)/components/infinite-scroll/+page.md
+++ b/src/routes/(split)/components/infinite-scroll/+page.md
@@ -22,7 +22,7 @@
 The Infinite Scroll component calls an action to be performed when the user scrolls a specified distance of the list presented in the page.
 
 ```javascript
-<InfiniteScroll>
+<InfiniteScroll onintersect={onIntersect}>
   {#each array as data}
     <li>{data}</li>
   {/each}

--- a/src/routes/(split)/components/infinite-scroll/+page.md
+++ b/src/routes/(split)/components/infinite-scroll/+page.md
@@ -55,7 +55,7 @@ It sets the reference to the last element of the list after each re-render. **Pa
 
 ## Showcase
 
-<InfiniteScroll on:nnsIntersect={onIntersect} disabled={scrollDisabled} testId="showcase-infinite-scroll">
+<InfiniteScroll onintersect={onIntersect} disabled={scrollDisabled} testId="showcase-infinite-scroll">
     {#each elements as _element, i}
         <li><Tag>Element {i}</Tag></li>
     {/each}

--- a/src/routes/(split)/components/infinite-scroll/+page.md
+++ b/src/routes/(split)/components/infinite-scroll/+page.md
@@ -36,22 +36,17 @@ It sets the reference to the last element of the list after each re-render. **Pa
 
 ## Properties
 
-| Property   | Description                                                                                                                  | Type             | Default |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
-| `layout`   | Display of the rendered items. Defined by a class set on `ul` container.                                                     | `list` or `grid` | `list`  |
-| `disabled` | If `true`, the infinite scroll stops observing for intersection and therefore, will stop calling the action to be performed. | `boolean`        | `false` |
+| Property      | Description                                                                                                                  | Type                  | Default     |
+|---------------|------------------------------------------------------------------------------------------------------------------------------|-----------------------|-------------|
+| `onIntersect` | Triggered each time the next observed item is intersecting. The event that can be use to call your action.                   | `() => Promise<void>` |             |
+| `layout`      | Display of the rendered items. Defined by a class set on `ul` container.                                                     | `list` or `grid`      | `list`      |
+| `disabled`    | If `true`, the infinite scroll stops observing for intersection and therefore, will stop calling the action to be performed. | `boolean`             | `false`     |
 
 ## Slots
 
 | Slot name    | Description                                 |
 | ------------ | ------------------------------------------- |
 | Default slot | The list of elements. Should be `li` nodes. |
-
-## Events
-
-| Event          | Description                                                                                                | Detail    |
-| -------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
-| `nnsIntersect` | Triggered each time the next observed item is intersecting. The event that can be use to call your action. | No detail |
 
 ## Showcase
 

--- a/src/tests/lib/components/InfiniteScroll.spec.ts
+++ b/src/tests/lib/components/InfiniteScroll.spec.ts
@@ -1,5 +1,6 @@
 import InfiniteScroll from "$lib/components/InfiniteScroll.svelte";
 import { render } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
 import {
   IntersectionObserverActive,
   IntersectionObserverPassive,
@@ -18,7 +19,16 @@ describe("InfiniteScroll", () => {
   afterAll(() => (global.IntersectionObserver = IntersectionObserverPassive));
 
   it("should render a container", () => {
-    const { container } = render(InfiniteScroll);
+    const mockSnippet = createRawSnippet(() => ({
+      render: () => `<span>Mock Snippet</span>`,
+    }));
+
+    const { container } = render(InfiniteScroll, {
+      props: {
+        onintersect: () => {},
+        children: mockSnippet,
+      },
+    });
 
     expect(container.querySelector("ul")).not.toBeNull();
   });

--- a/src/tests/lib/components/InfiniteScroll.spec.ts
+++ b/src/tests/lib/components/InfiniteScroll.spec.ts
@@ -25,7 +25,7 @@ describe("InfiniteScroll", () => {
 
     const { container } = render(InfiniteScroll, {
       props: {
-        onintersect: () => {},
+        onIntersect: () => Promise.resolve(),
         children: mockSnippet,
       },
     });

--- a/src/tests/lib/components/InfiniteScrollTest.svelte
+++ b/src/tests/lib/components/InfiniteScrollTest.svelte
@@ -6,7 +6,7 @@
   export let spy: () => void;
 </script>
 
-<InfiniteScroll on:nnsIntersect={spy} {disabled}>
+<InfiniteScroll onintersect={spy} {disabled}>
   {#each elements as _element, i}
     <div>Test {i}</div>
   {/each}

--- a/src/tests/lib/components/InfiniteScrollTest.svelte
+++ b/src/tests/lib/components/InfiniteScrollTest.svelte
@@ -6,7 +6,7 @@
   export let spy: () => void;
 </script>
 
-<InfiniteScroll onintersect={spy} {disabled}>
+<InfiniteScroll onIntersect={spy} {disabled}>
   {#each elements as _element, i}
     <div>Test {i}</div>
   {/each}


### PR DESCRIPTION
# Motivation

We start the Svelte 5 migration with component InfiniteScroll, that is more prone to cause incompatibility issues with projects that already use Svelte 5 components.

Note that I am explicitly set the prop `children` as non-optional, since I imagine that this component shall be used only with children.

BREAKING CHANGE: the interface changes.

Credits to @peterpeterparker from [Juno's component `InfiniteScroll`](https://github.com/junobuild/juno/blob/cd44adace1ff530cc8c2f544bfbc77b25aace88a/src/frontend/src/lib/components/ui/InfiniteScroll.svelte#L5)
