### PR TITLE
feat: Util for event modifier `stopPropagation`

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,3 +15,4 @@ export * from "./types/theme";
 export type { ToastLevel, ToastMsg } from "./types/toast";
 export type { WizardStep, WizardSteps } from "./types/wizard";
 export * from "./utils/wizard.utils";
+export * from "./utils/event-modifiers.utils";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,5 +14,5 @@ export type { ProgressStep, ProgressStepState } from "./types/progress-step";
 export * from "./types/theme";
 export type { ToastLevel, ToastMsg } from "./types/toast";
 export type { WizardStep, WizardSteps } from "./types/wizard";
-export * from "./utils/wizard.utils";
 export * from "./utils/event-modifiers.utils";
+export * from "./utils/wizard.utils";

--- a/src/lib/types/event-modifiers.ts
+++ b/src/lib/types/event-modifiers.ts
@@ -1,5 +1,1 @@
 export type OnEventCallback = () => void | Promise<void>;
-
-export type OnMouseEventHandler = (
-  $event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
-) => Promise<void>;

--- a/src/lib/types/event-modifiers.ts
+++ b/src/lib/types/event-modifiers.ts
@@ -1,5 +1,5 @@
 export type OnEventCallback = () => void | Promise<void>;
 
 export type OnMouseEventHandler = (
-  event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+  $event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
 ) => Promise<void>;

--- a/src/lib/types/event-modifiers.ts
+++ b/src/lib/types/event-modifiers.ts
@@ -1,0 +1,5 @@
+export type OnEventCallback = () => void | Promise<void>;
+
+export type OnMouseEventHandler = (
+  event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+) => Promise<void>;

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -1,3 +1,7 @@
+// In Svelte 5 the events do not have modifiers anymore.
+// This module contains wrapper functions of event modifiers for Svelte 5.
+// Documentation: https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers
+
 import type { OnEventCallback } from "$lib/types/event-modifiers";
 import type { MouseEventHandler } from "svelte/elements";
 

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -8,6 +8,13 @@
 import type { OnEventCallback } from "$lib/types/event-modifiers";
 import type { MouseEventHandler } from "svelte/elements";
 
+/**
+ * A wrapper function to stop event propagation of a mouse event before executing a callback function.
+ *
+ * @param {OnEventCallback} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
+ *
+ * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
+ */
 export const stopPropagation = <T extends EventTarget>(
   fn: OnEventCallback,
 ): MouseEventHandler<T> => {

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -10,11 +10,11 @@ import type { MouseEventHandler } from "svelte/elements";
  *
  * @param {OnEventCallback} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
  *
- * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
+ * @returns {MouseEventHandler<T extends EventTarget> | undefined | null} - A function that takes an event and stop its propagation, before executing the provided function.
  */
 export const stopPropagation = <T extends EventTarget>(
   fn: OnEventCallback,
-): MouseEventHandler<T> => {
+): MouseEventHandler<T> | undefined | null => {
   return async ($event?: MouseEvent & { currentTarget: EventTarget & T }) => {
     $event?.stopPropagation();
     await fn();

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -1,0 +1,13 @@
+import type {
+  OnEventCallback,
+  OnMouseEventHandler,
+} from "$lib/types/event-modifiers";
+
+export const stopPropagation = (fn: OnEventCallback): OnMouseEventHandler => {
+  return async (
+    event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+  ) => {
+    event?.stopPropagation();
+    await fn();
+  };
+};

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -1,6 +1,6 @@
 // In Svelte 5 the events do not have modifiers anymore.
 // This module contains wrapper functions of event modifiers for Svelte 5.
-// Documentation: https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers
+// Documentation: {@link https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers}
 
 import type { OnEventCallback } from "$lib/types/event-modifiers";
 import type { MouseEventHandler } from "svelte/elements";

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -1,9 +1,6 @@
-/**
- * In Svelte 5 the events do not have modifiers anymore.
- * This module contains wrapper functions of event modifiers for Svelte 5.
- *
- * Documentation: https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers
- */
+// In Svelte 5 the events do not have modifiers anymore.
+// This module contains wrapper functions of event modifiers for Svelte 5.
+// Documentation: https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers
 
 import type { OnEventCallback } from "$lib/types/event-modifiers";
 import type { MouseEventHandler } from "svelte/elements";

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -5,9 +5,9 @@ import type {
 
 export const stopPropagation = (fn: OnEventCallback): OnMouseEventHandler => {
   return async (
-    event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+    $event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
   ) => {
-    event?.stopPropagation();
+    $event?.stopPropagation();
     await fn();
   };
 };

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -1,6 +1,9 @@
-// In Svelte 5 the events do not have modifiers anymore.
-// This module contains wrapper functions of event modifiers for Svelte 5.
-// Documentation: https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers
+/**
+ * In Svelte 5 the events do not have modifiers anymore.
+ * This module contains wrapper functions of event modifiers for Svelte 5.
+ *
+ * Documentation: https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers
+ */
 
 import type { OnEventCallback } from "$lib/types/event-modifiers";
 import type { MouseEventHandler } from "svelte/elements";

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -1,12 +1,10 @@
-import type {
-  OnEventCallback,
-  OnMouseEventHandler,
-} from "$lib/types/event-modifiers";
+import type { OnEventCallback } from "$lib/types/event-modifiers";
+import type { MouseEventHandler } from "svelte/elements";
 
-export const stopPropagation = (fn: OnEventCallback): OnMouseEventHandler => {
-  return async (
-    $event?: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
-  ) => {
+export const stopPropagation = <T extends EventTarget>(
+  fn: OnEventCallback,
+): MouseEventHandler<T> => {
+  return async ($event?: MouseEvent & { currentTarget: EventTarget & T }) => {
     $event?.stopPropagation();
     await fn();
   };

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -10,11 +10,11 @@ import type { MouseEventHandler } from "svelte/elements";
  *
  * @param {OnEventCallback} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
  *
- * @returns {MouseEventHandler<T extends EventTarget> | undefined | null} - A function that takes an event and stop its propagation, before executing the provided function.
+ * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
  */
 export const stopPropagation = <T extends EventTarget>(
   fn: OnEventCallback,
-): MouseEventHandler<T> | undefined | null => {
+): MouseEventHandler<T> => {
   return async ($event?: MouseEvent & { currentTarget: EventTarget & T }) => {
     $event?.stopPropagation();
     await fn();

--- a/src/tests/lib/utils/StopPropagationTest.svelte
+++ b/src/tests/lib/utils/StopPropagationTest.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { stopPropagation } from "$lib/utils/event-modifiers.utils";
+  import type { OnEventCallback } from "$lib/types/event-modifiers";
+
+  interface Props {
+    onParentClick?: OnEventCallback;
+    onChildClick?: OnEventCallback;
+    childTestId?: string;
+  }
+
+  let { onParentClick = () => {}, onChildClick = () => {}, childTestId }: Props = $props();
+</script>
+
+<div role="button" tabindex="-1" onkeypress={() => {}} onclick={onParentClick}>
+  <button onclick={stopPropagation(onChildClick)} data-tid={childTestId}>Click Me</button>
+</div>

--- a/src/tests/lib/utils/StopPropagationTest.svelte
+++ b/src/tests/lib/utils/StopPropagationTest.svelte
@@ -8,9 +8,15 @@
     childTestId?: string;
   }
 
-  let { onParentClick = () => {}, onChildClick = () => {}, childTestId }: Props = $props();
+  let {
+    onParentClick = () => {},
+    onChildClick = () => {},
+    childTestId,
+  }: Props = $props();
 </script>
 
 <div role="button" tabindex="-1" onkeypress={() => {}} onclick={onParentClick}>
-  <button onclick={stopPropagation(onChildClick)} data-tid={childTestId}>Click Me</button>
+  <button onclick={stopPropagation(onChildClick)} data-tid={childTestId}
+    >Click Me</button
+  >
 </div>

--- a/src/tests/lib/utils/StopPropagationTest.svelte
+++ b/src/tests/lib/utils/StopPropagationTest.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <div role="button" tabindex="-1" onkeypress={() => {}} onclick={onParentClick}>
-  <button onclick={stopPropagation(onChildClick)} data-tid={childTestId}
-    >Click Me</button
-  >
+  <button onclick={stopPropagation(onChildClick)} data-tid={childTestId}>
+    Click Me
+  </button>
 </div>

--- a/src/tests/lib/utils/event-modifiers.utils.spec.ts
+++ b/src/tests/lib/utils/event-modifiers.utils.spec.ts
@@ -1,5 +1,7 @@
 import { stopPropagation } from "$lib/utils/event-modifiers.utils";
+import { fireEvent, render } from "@testing-library/svelte";
 import { describe } from "vitest";
+import StopPropagationTest from "./StopPropagationTest.svelte";
 
 describe("event-modifiers-utils", () => {
   describe("stopPropagation", () => {
@@ -57,6 +59,22 @@ describe("event-modifiers-utils", () => {
       await expect(handler(mockEvent)).rejects.toThrow(
         new TypeError("fn is not a function"),
       );
+    });
+
+    it('should call only the child handler and stop propagation to parent', async () => {
+      const onParentClick = vi.fn();
+      const onChildClick = vi.fn();
+      const childTestId = 'child-button';
+
+      const { getByTestId } = render(StopPropagationTest, {
+        props: { onParentClick, onChildClick, childTestId }
+      });
+
+      const button = getByTestId(childTestId);
+      await fireEvent.click(button);
+
+      expect(onChildClick).toHaveBeenCalledOnce();
+      expect(onParentClick).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tests/lib/utils/event-modifiers.utils.spec.ts
+++ b/src/tests/lib/utils/event-modifiers.utils.spec.ts
@@ -61,13 +61,13 @@ describe("event-modifiers-utils", () => {
       );
     });
 
-    it('should call only the child handler and stop propagation to parent', async () => {
+    it("should call only the child handler and stop propagation to parent", async () => {
       const onParentClick = vi.fn();
       const onChildClick = vi.fn();
-      const childTestId = 'child-button';
+      const childTestId = "child-button";
 
       const { getByTestId } = render(StopPropagationTest, {
-        props: { onParentClick, onChildClick, childTestId }
+        props: { onParentClick, onChildClick, childTestId },
       });
 
       const button = getByTestId(childTestId);

--- a/src/tests/lib/utils/event-modifiers.utils.spec.ts
+++ b/src/tests/lib/utils/event-modifiers.utils.spec.ts
@@ -1,0 +1,62 @@
+import { stopPropagation } from "$lib/utils/event-modifiers.utils";
+import { describe } from "vitest";
+
+describe("event-modifiers-utils", () => {
+  describe("stopPropagation", () => {
+    const stopPropagationMock = vi.fn();
+    const callbackMock = vi.fn();
+
+    const mockEvent = {
+      stopPropagation: stopPropagationMock,
+      currentTarget: {} as EventTarget & HTMLButtonElement,
+    } as unknown as MouseEvent & {
+      currentTarget: EventTarget & HTMLButtonElement;
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should stop event propagation", async () => {
+      const handler = stopPropagation(callbackMock);
+
+      await handler(mockEvent);
+
+      expect(stopPropagationMock).toHaveBeenCalledOnce();
+    });
+
+    it("should call the callback", async () => {
+      const handler = stopPropagation(callbackMock);
+
+      await handler(mockEvent);
+
+      expect(callbackMock).toHaveBeenCalledOnce();
+    });
+
+    it("should still call callback even if event is undefined", async () => {
+      const handler = stopPropagation(callbackMock);
+
+      await handler(undefined);
+
+      expect(callbackMock).toHaveBeenCalledOnce();
+    });
+
+    it("should throw if callback throws an error", async () => {
+      const error = new Error("Test error");
+      const handler = stopPropagation(() => {
+        throw error;
+      });
+
+      await expect(handler(mockEvent)).rejects.toThrow(error);
+    });
+
+    it("should throw if callback is not a function", async () => {
+      // @ts-expect-error Testing this on purpose
+      const handler = stopPropagation(undefined);
+
+      await expect(handler(mockEvent)).rejects.toThrow(
+        new TypeError("fn is not a function"),
+      );
+    });
+  });
+});

--- a/src/tests/lib/utils/event-modifiers.utils.spec.ts
+++ b/src/tests/lib/utils/event-modifiers.utils.spec.ts
@@ -1,6 +1,5 @@
 import { stopPropagation } from "$lib/utils/event-modifiers.utils";
 import { fireEvent, render } from "@testing-library/svelte";
-import { describe } from "vitest";
 import StopPropagationTest from "./StopPropagationTest.svelte";
 
 describe("event-modifiers-utils", () => {

--- a/src/tests/lib/utils/event-modifiers.utils.spec.ts
+++ b/src/tests/lib/utils/event-modifiers.utils.spec.ts
@@ -37,6 +37,7 @@ describe("event-modifiers-utils", () => {
     it("should still call callback even if event is undefined", async () => {
       const handler = stopPropagation(callbackMock);
 
+      // @ts-expect-error Testing this on purpose
       await handler(undefined);
 
       expect(callbackMock).toHaveBeenCalledOnce();


### PR DESCRIPTION
# Motivation

According to [Svelte 5 documentation](https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers), with the migration, the event modifiers are deprecated and should be replaced by functions that have the same scope. For example, instead of:

```svelte
<button on:click|preventDefault={handler}>...</button>
```

One should do

```svelte
<script>
	function preventDefault(fn) {
		return function (event) {
			event.preventDefault();
			fn.call(this, event);
		};
	}
</script>

<button onclick={once(preventDefault(handler))}>...</button>
```

In this PR we create the `stopPropagation` util, to help with the migration (it will be used in other PR, like https://github.com/dfinity/gix-components/pull/631).

# Changes

- Creating a new type for event handlers.
- Creating new util for stop propagation, based on the Svelte documentation.
- Export new event-modifiers util modules.

# Screenshots

Created new tests, including a mock component.
