### PR TITLE
chore: use CI prepare action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Format shell scripts
         run: ./scripts/fmt-sh
 
-      - name: Install ts dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Format ts
         run: npm run format
 
@@ -79,8 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Build
         run: npm run build
 
@@ -90,8 +90,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Lint
         run: npm run lint -- --max-warnings 0
 
@@ -101,8 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Build
         run: npm run build
       - name: Test
@@ -127,8 +127,8 @@ jobs:
           key: ${{ runner.os }}-samples-${{ hashFiles('**/scripts/download-samples.sh') }}
           restore-keys: |
             ${{ runner.os }}-samples-
-      - name: Install dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Run Playwright tests
         run: npm run e2e:ci
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Build
         run: npm run package
       - name: Set up npm

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-      - name: Install dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Run Playwright tests
         run: npm run e2e:snapshots
       - name: Commit Playwright updated snapshots


### PR DESCRIPTION
# Motivation

We want to use the "prepare" action recently introduced (cloned from ic-js and other repo) to setup Node LTS and install dependencies in every CI jobs.
