### PR TITLE
chore: update CI deploy to Juno to latest

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,24 +6,17 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
+      - name: Prepare
+        uses: ./.github/actions/prepare
 
       - name: Deploy to Juno
-        uses: buildwithjuno/juno-action@main
+        uses: junobuild/juno-action@main
         with:
           args: deploy
         env:

--- a/juno.config.ts
+++ b/juno.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "@junobuild/config";
 
 export default defineConfig({
   satellite: {
-    id: "nbyi7-6aaaa-aaaal-acjtq-cai",
+    ids: {
+      production: "nbyi7-6aaaa-aaaal-acjtq-cai",
+    },
     source: "build",
+    predeploy: ["npm run build"],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "qr-creator": "^1.0.0"
       },
       "devDependencies": {
-        "@junobuild/config": "^0.0.14",
+        "@junobuild/config": "^0.1.8",
         "@playwright/test": "^1.51.0",
         "@sveltejs/adapter-static": "^3.0.8",
         "@sveltejs/kit": "^2.20.7",
@@ -910,11 +910,14 @@
       }
     },
     "node_modules/@junobuild/config": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.0.14.tgz",
-      "integrity": "sha512-LMhPpXW3X1c+XyNREMrfhi4mEk/AkLX0RxEbi6uKuyXd0/IsTHSB/sfFEgsTAvt4W4KmjrELcNyI1SFbpQEDAA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.1.8.tgz",
+      "integrity": "sha512-25FN9nh0X4cauAQx9JlnUAbC4ZIdAoAtqBhYLBORrGXybFRT+48ber7LoXpws4BF5N8//tH4PwCuvl+aRaOWAQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^3"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.5.0",
@@ -6003,6 +6006,17 @@
       "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -6494,10 +6508,11 @@
       }
     },
     "@junobuild/config": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.0.14.tgz",
-      "integrity": "sha512-LMhPpXW3X1c+XyNREMrfhi4mEk/AkLX0RxEbi6uKuyXd0/IsTHSB/sfFEgsTAvt4W4KmjrELcNyI1SFbpQEDAA==",
-      "dev": true
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.1.8.tgz",
+      "integrity": "sha512-25FN9nh0X4cauAQx9JlnUAbC4ZIdAoAtqBhYLBORrGXybFRT+48ber7LoXpws4BF5N8//tH4PwCuvl+aRaOWAQ==",
+      "dev": true,
+      "requires": {}
     },
     "@noble/curves": {
       "version": "1.5.0",
@@ -9762,6 +9777,13 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
       "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+      "peer": true
+    },
+    "zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "dev": true,
       "peer": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@junobuild/config": "^0.0.14",
+    "@junobuild/config": "^0.1.8",
     "@playwright/test": "^1.51.0",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.20.7",


### PR DESCRIPTION
# Motivation

The deploy to Juno script was still using Node v18. The action also supports new cool features, such as supporting pre/post deploy scripts in the configuration. So this PR update script and config to latest standards.
