### PR TITLE
test: flaky tooltip e2e test

### DIFF
--- a/e2e/tooltip.e2e.ts
+++ b/e2e/tooltip.e2e.ts
@@ -22,6 +22,6 @@ test("Should render tooltip", async ({ page }) => {
   await expect(tooltip).toBeVisible();
 
   await expect(page).toHaveScreenshot({
-    maxDiffPixelRatio: 0.05
+    maxDiffPixelRatio: 0.05,
   });
 });

--- a/e2e/tooltip.e2e.ts
+++ b/e2e/tooltip.e2e.ts
@@ -21,5 +21,7 @@ test("Should render tooltip", async ({ page }) => {
   const tooltip = await page.locator(`[id="${tooltipId}"]`);
   await expect(tooltip).toBeVisible();
 
-  await expect(page).toHaveScreenshot();
+  await expect(page).toHaveScreenshot({
+    maxDiffPixelRatio: 0.05
+  });
 });


### PR DESCRIPTION
# Motivation

The tootltip e2e test are flaky. This PR tries to relax the screenshot comparison to resolve the issue.

# Example

CI tests in error: https://github.com/dfinity/gix-components/actions/runs/15105337805/job/42452977219?pr=643

![image](https://github.com/user-attachments/assets/972a5924-53c2-4256-981c-eccb871a8a0a)

![image](https://github.com/user-attachments/assets/7eb38a7a-f9fe-48d4-ad3c-75168f75df50)
