### PR TITLE
feat(icons): add eye-closed icon 

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -27,6 +27,7 @@ export { default as IconExpandAll } from "./icons/IconExpandAll.svelte";
 export { default as IconExpandCircleDown } from "./icons/IconExpandCircleDown.svelte";
 export { default as IconExpandMore } from "./icons/IconExpandMore.svelte";
 export { default as IconExplore } from "./icons/IconExplore.svelte";
+export { default as IconEyeClosed } from "./icons/IconEyeClosed.svelte";
 export { default as IconEyeOpen } from "./icons/IconEyeOpen.svelte";
 export { default as IconFilter } from "./icons/IconFilter.svelte";
 export { default as IconGitHub } from "./icons/IconGitHub.svelte";

--- a/src/lib/icons/IconEyeClosed.svelte
+++ b/src/lib/icons/IconEyeClosed.svelte
@@ -1,0 +1,21 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = `${DEFAULT_ICON_SIZE}px`;
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  fill="none"
+  viewBox="0 0 20 20"
+  ><path
+    stroke="#3D4D99"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.5"
+    d="m15.71 9.945 1.79 3.086M12.047 11.664l.555 3.149M7.945 11.656l-.554 3.156M4.281 9.945l-1.789 3.102M2.5 8.195c1.313 1.625 3.719 3.68 7.5 3.68s6.188-2.055 7.5-3.68"
+  /></svg
+>

--- a/src/lib/icons/IconEyeClosed.svelte
+++ b/src/lib/icons/IconEyeClosed.svelte
@@ -12,7 +12,7 @@
   fill="none"
   viewBox="0 0 20 20"
   ><path
-    stroke="#3D4D99"
+    stroke="currentColor"
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="1.5"


### PR DESCRIPTION
# Motivation

Introduces a new icon, `IconEyeClosed`, for use in the nns-dapp during the hide/show balance flow.

<img width="299" alt="Screenshot 2025-05-19 at 15 51 28" src="https://github.com/user-attachments/assets/a227a9ca-bfc2-4e88-bae4-ac025a7b9fbf" />

# Changes

- Adds new icon