### PR TITLE
feat!: Migrate `Content` to Svelte 5

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -8,13 +8,14 @@
   import ContentBackdrop from "$lib/components/ContentBackdrop.svelte";
   import Header from "$lib/components/Header.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
+  import type { OnEventCallback } from "$lib/types/event-modifiers";
 
   interface Props {
     title?: Snippet;
     toolbarEnd?: Snippet;
     children: Snippet;
     back?: boolean;
-    onBack?: () => void;
+    onBack?: OnEventCallback;
   }
 
   let {

--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -4,17 +4,24 @@
     layoutContentScrollY,
     layoutMenuOpen,
   } from "$lib/stores/layout.store";
-  import { onDestroy } from "svelte";
+  import { onDestroy, type Snippet } from "svelte";
   import ContentBackdrop from "$lib/components/ContentBackdrop.svelte";
   import Header from "$lib/components/Header.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
 
-  export let back = false;
+  interface Props {
+    title?: Snippet;
+    toolbarEnd?: Snippet;
+    children: Snippet;
+    back?: boolean;
+  }
+
+  let {title, toolbarEnd, children, back = false }: Props = $props();
 
   // Observed: nested component - bottom sheet - might not call destroy when navigating route and therefore offset might not be reseted which is not the case here
   onDestroy(() => ($layoutBottomOffset = 0));
 
-  let scrollContainer: HTMLDivElement;
+  let scrollContainer = $state<HTMLDivElement | undefined>();
 </script>
 
 <div
@@ -23,9 +30,9 @@
   style={`--layout-bottom-offset: calc(${$layoutBottomOffset}px - var(--content-margin)); --content-overflow-y: ${$layoutContentScrollY}`}
 >
   <Header {back} on:nnsBack>
-    <slot name="title" slot="title" />
+    <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
 
-    <slot name="toolbar-end" slot="toolbar-end" />
+    <svelte:fragment slot="toolbar-end">{@render toolbarEnd?.()}</svelte:fragment>
   </Header>
 
   <div
@@ -35,7 +42,7 @@
   >
     <ContentBackdrop />
     <ScrollSentinel {scrollContainer} />
-    <slot />
+    {@render children()}
   </div>
 </div>
 

--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -9,22 +9,16 @@
   import Header from "$lib/components/Header.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
   import type { OnEventCallback } from "$lib/types/event-modifiers";
+  import { nonNullish } from "@dfinity/utils";
 
   interface Props {
     title?: Snippet;
     toolbarEnd?: Snippet;
     children: Snippet;
-    back?: boolean;
     onBack?: OnEventCallback;
   }
 
-  let {
-    title,
-    toolbarEnd,
-    children,
-    back = false,
-    onBack = () => {},
-  }: Props = $props();
+  let { title, toolbarEnd, children, onBack }: Props = $props();
 
   // Observed: nested component - bottom sheet - might not call destroy when navigating route and therefore offset might not be reseted which is not the case here
   onDestroy(() => ($layoutBottomOffset = 0));
@@ -37,7 +31,7 @@
   class:open={$layoutMenuOpen}
   style={`--layout-bottom-offset: calc(${$layoutBottomOffset}px - var(--content-margin)); --content-overflow-y: ${$layoutContentScrollY}`}
 >
-  <Header {back} on:nnsBack={onBack}>
+  <Header back={nonNullish(onBack)} on:nnsBack={() => onBack?.()}>
     <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
 
     <svelte:fragment slot="toolbar-end"

--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -14,9 +14,16 @@
     toolbarEnd?: Snippet;
     children: Snippet;
     back?: boolean;
+    onBack?: () => void;
   }
 
-  let {title, toolbarEnd, children, back = false }: Props = $props();
+  let {
+    title,
+    toolbarEnd,
+    children,
+    back = false,
+    onBack = () => {},
+  }: Props = $props();
 
   // Observed: nested component - bottom sheet - might not call destroy when navigating route and therefore offset might not be reseted which is not the case here
   onDestroy(() => ($layoutBottomOffset = 0));
@@ -29,10 +36,12 @@
   class:open={$layoutMenuOpen}
   style={`--layout-bottom-offset: calc(${$layoutBottomOffset}px - var(--content-margin)); --content-overflow-y: ${$layoutContentScrollY}`}
 >
-  <Header {back} on:nnsBack>
+  <Header {back} on:nnsBack={onBack}>
     <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
 
-    <svelte:fragment slot="toolbar-end">{@render toolbarEnd?.()}</svelte:fragment>
+    <svelte:fragment slot="toolbar-end"
+      >{@render toolbarEnd?.()}</svelte:fragment
+    >
   </Header>
 
   <div

--- a/src/routes/(page)/+layout.svelte
+++ b/src/routes/(page)/+layout.svelte
@@ -7,14 +7,13 @@
   import { canGoBack, goBack } from "$docs/utils/docs.utils";
 
   let navHistory: AfterNavigate[] = [];
-  let back = false;
 
   afterNavigate((navigation) => (navHistory = [navigation, ...navHistory]));
 
-  $: back = canGoBack($page.route.id);
+  $: onBack =canGoBack($page.route.id) ? async () => await goBack({ navHistory }) : undefined;
 </script>
 
-<Content {back} onBack={async () => await goBack({ navHistory })}>
+<Content {onBack}>
   {#snippet toolbarEnd()}
     <DocsAccountMenu />
   {/snippet}

--- a/src/routes/(page)/+layout.svelte
+++ b/src/routes/(page)/+layout.svelte
@@ -14,8 +14,10 @@
   $: back = canGoBack($page.route.id);
 </script>
 
-<Content {back} on:nnsBack={async () => await goBack({ navHistory })}>
-  <DocsAccountMenu slot="toolbar-end" />
+<Content {back} onBack={async () => await goBack({ navHistory })}>
+  {#snippet toolbarEnd()}
+    <DocsAccountMenu />
+  {/snippet}
 
   <main>
     <slot />

--- a/src/routes/(page)/+layout.svelte
+++ b/src/routes/(page)/+layout.svelte
@@ -10,7 +10,9 @@
 
   afterNavigate((navigation) => (navHistory = [navigation, ...navHistory]));
 
-  $: onBack =canGoBack($page.route.id) ? async () => await goBack({ navHistory }) : undefined;
+  $: onBack = canGoBack($page.route.id)
+    ? async () => await goBack({ navHistory })
+    : undefined;
 </script>
 
 <Content {onBack}>

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -14,10 +14,10 @@ A component that renders a header and your content.
 
 ## Properties
 
-| Property | Description                                                     | Type       | Default  |
-| -------- | --------------------------------------------------------------- | ---------- | -------- |
-| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`  |
-| `onBack` | A function to call when the back button is clicked.             | `function` | () => {} |
+| Property | Description                                                     | Type       | Default         |
+| -------- | --------------------------------------------------------------- | ---------- | --------------- |
+| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`         |
+| `onBack` | A function to call when the back button is clicked.             | `function` | `noop funciton` |
 
 ## Snippets
 

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -14,9 +14,10 @@ A component that renders a header and your content.
 
 ## Properties
 
-| Property | Description                                                     | Type      | Default |
-| -------- | --------------------------------------------------------------- | --------- | ------- |
-| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false` |
+| Property | Description                                                     | Type      | Default  |
+| -------- | --------------------------------------------------------------- | --------- |----------|
+| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false`  |
+| `onBack` | A function to call when the back button is clicked.             | `function`| () => {} |
 
 ## Slots
 

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -17,7 +17,7 @@ A component that renders a header and your content.
 | Property | Description                                                     | Type       | Default         |
 | -------- | --------------------------------------------------------------- | ---------- | --------------- |
 | `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`         |
-| `onBack` | A function to call when the back button is clicked.             | `function` | `noop funciton` |
+| `onBack` | A function to call when the back button is clicked.             | `function` | `noop function` |
 
 ## Snippets
 

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -4,7 +4,7 @@ A component that renders a header and your content.
 
 ```javascript
 <Content>
-  <Title slot="title">My dapp page</Title>
+  {#snippet title()}<Title >My dapp page</Title>{/snippet}
 
   <main>
     <slot />
@@ -19,10 +19,10 @@ A component that renders a header and your content.
 | `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false`  |
 | `onBack` | A function to call when the back button is clicked.             | `function`| () => {} |
 
-## Slots
+## Snippets
 
-| Slot name     | Description                                               |
-| ------------- | --------------------------------------------------------- |
-| Default slot  | The content of the page.                                  |
-| `title`       | The title of the page displayed centered in the toolbar.  |
-| `toolbar-end` | An element that can be added to the `end` of the toolbar. |
+| Snippet name    | Description                                               |
+|-----------------| --------------------------------------------------------- |
+| Default snippet | The content of the page.                                  |
+| `title`         | The title of the page displayed centered in the toolbar.  |
+| `toolbarEnd`    | An element that can be added to the `end` of the toolbar. |

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -14,15 +14,15 @@ A component that renders a header and your content.
 
 ## Properties
 
-| Property | Description                                                     | Type      | Default  |
-| -------- | --------------------------------------------------------------- | --------- |----------|
-| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean` | `false`  |
-| `onBack` | A function to call when the back button is clicked.             | `function`| () => {} |
+| Property | Description                                                     | Type       | Default  |
+| -------- | --------------------------------------------------------------- | ---------- | -------- |
+| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`  |
+| `onBack` | A function to call when the back button is clicked.             | `function` | () => {} |
 
 ## Snippets
 
 | Snippet name    | Description                                               |
-|-----------------| --------------------------------------------------------- |
+| --------------- | --------------------------------------------------------- |
 | Default snippet | The content of the page.                                  |
 | `title`         | The title of the page displayed centered in the toolbar.  |
 | `toolbarEnd`    | An element that can be added to the `end` of the toolbar. |

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -4,7 +4,7 @@ A component that renders a header and your content.
 
 ```javascript
 <Content>
-  {#snippet title()}<Title >My dapp page</Title>{/snippet}
+  {#snippet title()}<Title>My dapp page</Title>{/snippet}
 
   <main>
     <slot />

--- a/src/routes/(split)/components/content/+page.md
+++ b/src/routes/(split)/components/content/+page.md
@@ -14,10 +14,9 @@ A component that renders a header and your content.
 
 ## Properties
 
-| Property | Description                                                     | Type       | Default         |
-| -------- | --------------------------------------------------------------- | ---------- | --------------- |
-| `back`   | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`         |
-| `onBack` | A function to call when the back button is clicked.             | `function` | `noop function` |
+| Property | Description                                                                                | Type                      | Default     |
+| -------- | ------------------------------------------------------------------------------------------ | ------------------------- | ----------- |
+| `onBack` | When provided, the `Back` button will be shown and it will call the function when clicked. | `function` or `undefined` | `undefined` |
 
 ## Snippets
 

--- a/src/tests/lib/components/ContentTest.svelte
+++ b/src/tests/lib/components/ContentTest.svelte
@@ -4,6 +4,8 @@
 
 <Content>
   <div data-tid="content-test-slot"></div>
-  <div data-tid="content-test-title-slot" slot="title"></div>
-  <div data-tid="content-test-toolbar-end-slot" slot="toolbar-end"></div>
+  {#snippet title()}<div data-tid="content-test-title-slot"></div>{/snippet}
+  {#snippet toolbarEnd()}<div
+      data-tid="content-test-toolbar-end-slot"
+    ></div>{/snippet}
 </Content>


### PR DESCRIPTION
# Motivation

Migrating component `Content` button to Svelte 5.

# Breaking Changes

The interface changes:

- The slots `title` and `toolbar-end` are migrated to Snippets.
- No event `nnsBack` bubbling up anymore, use the prop `onBack` that receives the callback function.
- The prop `back` is deprecated, the nullish check of `onBack` callback will replace it.
