### PR TITLE
feat!: Migrate `SplitContent` to Svelte 5

### DIFF
--- a/src/lib/components/SplitContent.svelte
+++ b/src/lib/components/SplitContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, type Snippet } from "svelte";
   import {
     layoutBottomOffset,
     layoutContentScrollY,
@@ -8,15 +8,33 @@
   import Header from "$lib/components/Header.svelte";
   import ContentBackdrop from "$lib/components/ContentBackdrop.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
+  import type { OnEventCallback } from "$lib/types/event-modifiers";
 
-  export let back = false;
+  interface Props {
+    title?: Snippet;
+    toolbarEnd?: Snippet;
+    start: Snippet;
+    end: Snippet;
+    back?: boolean;
+    onBack?: OnEventCallback;
+  }
+
+  let {
+    title,
+    toolbarEnd,
+    start,
+    end,
+    back = false,
+    onBack = () => {},
+  }: Props = $props();
+
   export const resetScrollPosition = () => {
     if (scrollableElement) {
       scrollableElement.scrollTop = 0;
     }
   };
 
-  let scrollableElement: HTMLElement | undefined;
+  let scrollableElement = $state<HTMLElement | undefined>();
 
   // Same as in <Content />
   onDestroy(() => ($layoutBottomOffset = 0));
@@ -30,22 +48,24 @@
   <div class="start">
     <div class="scrollable-content-start">
       <ContentBackdrop />
-      <slot name="start" />
+      {@render start()}
     </div>
   </div>
 
   <div class="end">
-    <Header {back} on:nnsBack>
-      <slot name="title" slot="title" />
+    <Header {back} on:nnsBack={onBack}>
+      <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
 
-      <slot name="toolbar-end" slot="toolbar-end" />
+      <svelte:fragment slot="toolbar-end"
+        >{@render toolbarEnd?.()}</svelte:fragment
+      >
     </Header>
 
     <div class="scrollable-content-end" bind:this={scrollableElement}>
       <ContentBackdrop />
 
       <ScrollSentinel scrollContainer={scrollableElement} />
-      <slot name="end" />
+      {@render end()}
     </div>
   </div>
 </div>

--- a/src/lib/components/SplitContent.svelte
+++ b/src/lib/components/SplitContent.svelte
@@ -9,24 +9,17 @@
   import ContentBackdrop from "$lib/components/ContentBackdrop.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
   import type { OnEventCallback } from "$lib/types/event-modifiers";
+  import { nonNullish } from "@dfinity/utils";
 
   interface Props {
     title?: Snippet;
     toolbarEnd?: Snippet;
     start: Snippet;
     end: Snippet;
-    back?: boolean;
     onBack?: OnEventCallback;
   }
 
-  let {
-    title,
-    toolbarEnd,
-    start,
-    end,
-    back = false,
-    onBack = () => {},
-  }: Props = $props();
+  let { title, toolbarEnd, start, end, onBack }: Props = $props();
 
   export const resetScrollPosition = () => {
     if (scrollableElement) {
@@ -53,7 +46,7 @@
   </div>
 
   <div class="end">
-    <Header {back} on:nnsBack={onBack}>
+    <Header back={nonNullish(onBack)} on:nnsBack={() => onBack?.()}>
       <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
 
       <svelte:fragment slot="toolbar-end"

--- a/src/routes/(split)/+layout.svelte
+++ b/src/routes/(split)/+layout.svelte
@@ -5,11 +5,13 @@
 </script>
 
 <SplitContent>
-  <DocsComponentsNav slot="start" />
+  {#snippet start()}<DocsComponentsNav />{/snippet}
 
-  <DocsAccountMenu slot="toolbar-end" />
+  {#snippet toolbarEnd()}<DocsAccountMenu />{/snippet}
 
-  <main slot="end">
-    <slot />
-  </main>
+  {#snippet end()}
+    <main>
+      <slot />
+    </main>
+  {/snippet}
 </SplitContent>

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -20,11 +20,10 @@ A component that renders a header, a column and your content.
 
 ## Properties
 
-| Property              | Description                                                     | Type       | Default         |
-| --------------------- | --------------------------------------------------------------- | ---------- | --------------- |
-| `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`         |
-| `onBack`              | A function to call when the back button is clicked.             | `function` | `noop function` |
-| `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function`      |
+| Property              | Description                                                                                | Type                      | Default     |
+| --------------------- | ------------------------------------------------------------------------------------------ | ------------------------- | ----------- |
+| `onBack`              | When provided, the `Back` button will be shown and it will call the function when clicked. | `function` or `undefined` | `undefined` |
+| `resetScrollPosition` | A function to reset the scrollable content scroll position.                                | `function`                | `function`  |
 
 ## Snippets
 

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -29,7 +29,7 @@ A component that renders a header, a column and your content.
 ## Snippets
 
 | Snippet name | Description                                                                |
-|--------------| -------------------------------------------------------------------------- |
+| ------------ | -------------------------------------------------------------------------- |
 | `start`      | A column displayed next to the menu.                                       |
 | `end`        | The content of the page.                                                   |
 | `title`      | The title of the page displayed centered in the toolbar of the `end` slot. |

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -21,9 +21,9 @@ A component that renders a header, a column and your content.
 ## Properties
 
 | Property              | Description                                                     | Type       | Default    |
-| --------------------- | --------------------------------------------------------------- | ---------- | ---------- |
+| --------------------- | --------------------------------------------------------------- | ---------- |------------|
 | `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`    |
-| `onBack`              | A function to call when the back button is clicked.             | `function` | () => {}   |
+| `onBack`              | A function to call when the back button is clicked.             | `function` | `function` |
 | `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function` |
 
 ## Snippets

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -19,7 +19,7 @@ A component that renders a header, a column and your content.
 ## Properties
 
 | Property              | Description                                                     | Type       | Default    |
-|-----------------------|-----------------------------------------------------------------| ---------- |------------|
+| --------------------- | --------------------------------------------------------------- | ---------- | ---------- |
 | `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`    |
 | `onBack`              | A function to call when the back button is clicked.             | `function` | () => {}   |
 | `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function` |

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -20,11 +20,11 @@ A component that renders a header, a column and your content.
 
 ## Properties
 
-| Property              | Description                                                     | Type       | Default       |
-| --------------------- | --------------------------------------------------------------- | ---------- | ------------- |
-| `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`       |
-| `onBack`              | A function to call when the back button is clicked.             | `function` | Void function |
-| `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function`    |
+| Property              | Description                                                     | Type       | Default         |
+| --------------------- | --------------------------------------------------------------- | ---------- | --------------- |
+| `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`         |
+| `onBack`              | A function to call when the back button is clicked.             | `function` | `noop function` |
+| `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function`      |
 
 ## Snippets
 

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -20,11 +20,11 @@ A component that renders a header, a column and your content.
 
 ## Properties
 
-| Property              | Description                                                     | Type       | Default    |
-| --------------------- | --------------------------------------------------------------- | ---------- |------------|
-| `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`    |
-| `onBack`              | A function to call when the back button is clicked.             | `function` | `function` |
-| `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function` |
+| Property              | Description                                                     | Type       | Default       |
+| --------------------- | --------------------------------------------------------------- | ---------- |---------------|
+| `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`       |
+| `onBack`              | A function to call when the back button is clicked.             | `function` | Void function |
+| `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function`    |
 
 ## Snippets
 

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -21,7 +21,7 @@ A component that renders a header, a column and your content.
 ## Properties
 
 | Property              | Description                                                     | Type       | Default       |
-| --------------------- | --------------------------------------------------------------- | ---------- |---------------|
+| --------------------- | --------------------------------------------------------------- | ---------- | ------------- |
 | `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`       |
 | `onBack`              | A function to call when the back button is clicked.             | `function` | Void function |
 | `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function`    |

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -6,13 +6,15 @@ A component that renders a header, a column and your content.
 
 ```javascript
 <SplitContent>
-  <div slot="start">My column details</div>
+  {#snippet start()}<div>My column details</div>{/snippet}
 
-  <Title slot="title">My dapp page</Title>
+  {#snippet title()}<Title>My dapp page</Title>{/snippet}
 
-  <main slot="end">
-    <slot />
-  </main>
+    {#snippet end()}
+      <main>
+        <slot />
+      </main>
+    {/snippet}
 </SplitContent>
 ```
 
@@ -24,11 +26,11 @@ A component that renders a header, a column and your content.
 | `onBack`              | A function to call when the back button is clicked.             | `function` | () => {}   |
 | `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function` |
 
-## Slots
+## Snippets
 
-| Slot name     | Description                                                                |
-| ------------- | -------------------------------------------------------------------------- |
-| `start`       | A column displayed next to the menu.                                       |
-| `end`         | The content of the page.                                                   |
-| `title`       | The title of the page displayed centered in the toolbar of the `end` slot. |
-| `toolbar-end` | An element that can be added to the `end` of the toolbar.                  |
+| Snippet name | Description                                                                |
+|--------------| -------------------------------------------------------------------------- |
+| `start`      | A column displayed next to the menu.                                       |
+| `end`        | The content of the page.                                                   |
+| `title`      | The title of the page displayed centered in the toolbar of the `end` slot. |
+| `toolbarEnd` | An element that can be added to the `end` of the toolbar.                  |

--- a/src/routes/(split)/components/split-content/+page.md
+++ b/src/routes/(split)/components/split-content/+page.md
@@ -19,8 +19,9 @@ A component that renders a header, a column and your content.
 ## Properties
 
 | Property              | Description                                                     | Type       | Default    |
-| --------------------- | --------------------------------------------------------------- | ---------- | ---------- |
+|-----------------------|-----------------------------------------------------------------| ---------- |------------|
 | `back`                | Display an arrowed `back` button instead of the hamburger menu. | `boolean`  | `false`    |
+| `onBack`              | A function to call when the back button is clicked.             | `function` | () => {}   |
 | `resetScrollPosition` | A function to reset the scrollable content scroll position.     | `function` | `function` |
 
 ## Slots

--- a/src/tests/lib/components/SplitContentTest.svelte
+++ b/src/tests/lib/components/SplitContentTest.svelte
@@ -7,8 +7,8 @@
 </script>
 
 <SplitContent bind:this={originalComponent}>
-  <div data-tid="content-test-start-slot" slot="start"></div>
-  <div data-tid="content-test-end-slot" slot="end"></div>
-  <div data-tid="content-test-title-slot" slot="title"></div>
-  <div data-tid="content-test-toolbar-end-slot" slot="toolbar-end"></div>
+  {#snippet  start()}<div data-tid="content-test-start-slot" ></div>{/snippet}
+  {#snippet  end()}<div data-tid="content-test-end-slot" ></div>{/snippet}
+  {#snippet  title()}<div data-tid="content-test-title-slot" ></div>{/snippet}
+  {#snippet  toolbarEnd()}<div data-tid="content-test-toolbar-end-slot" ></div>{/snippet}
 </SplitContent>

--- a/src/tests/lib/components/SplitContentTest.svelte
+++ b/src/tests/lib/components/SplitContentTest.svelte
@@ -7,8 +7,10 @@
 </script>
 
 <SplitContent bind:this={originalComponent}>
-  {#snippet  start()}<div data-tid="content-test-start-slot" ></div>{/snippet}
-  {#snippet  end()}<div data-tid="content-test-end-slot" ></div>{/snippet}
-  {#snippet  title()}<div data-tid="content-test-title-slot" ></div>{/snippet}
-  {#snippet  toolbarEnd()}<div data-tid="content-test-toolbar-end-slot" ></div>{/snippet}
+  {#snippet start()}<div data-tid="content-test-start-slot"></div>{/snippet}
+  {#snippet end()}<div data-tid="content-test-end-slot"></div>{/snippet}
+  {#snippet title()}<div data-tid="content-test-title-slot"></div>{/snippet}
+  {#snippet toolbarEnd()}<div
+      data-tid="content-test-toolbar-end-slot"
+    ></div>{/snippet}
 </SplitContent>


### PR DESCRIPTION
# Motivation

Migrating component `SplitContent` button to Svelte 5.

# Breaking Changes

The interface changes:

- The slots `title`, `toolbar-end`, `start` and `end` are migrated to Snippets.
- No event `nnsBack` bubbling up anymore, use the prop `onBack` that receives the callback function.
- The prop `back` is deprecated, the nullish check of `onBack` callback will replace it.