### PR TITLE
feat: Migrate `Header` to Svelte 5

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -9,7 +9,6 @@
   import Header from "$lib/components/Header.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
   import type { OnEventCallback } from "$lib/types/event-modifiers";
-  import { nonNullish } from "@dfinity/utils";
 
   interface Props {
     title?: Snippet;
@@ -31,13 +30,7 @@
   class:open={$layoutMenuOpen}
   style={`--layout-bottom-offset: calc(${$layoutBottomOffset}px - var(--content-margin)); --content-overflow-y: ${$layoutContentScrollY}`}
 >
-  <Header back={nonNullish(onBack)} on:nnsBack={() => onBack?.()}>
-    <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
-
-    <svelte:fragment slot="toolbar-end"
-      >{@render toolbarEnd?.()}</svelte:fragment
-    >
-  </Header>
+  <Header {title} {toolbarEnd} {onBack} />
 
   <div
     class="scrollable-content"

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,32 +1,36 @@
 <script lang="ts">
   import Toolbar from "$lib/components/Toolbar.svelte";
+  import { type Snippet } from "svelte";
+  import type { OnEventCallback } from "$lib/types/event-modifiers";
   import MenuButton from "$lib/components/MenuButton.svelte";
   import Back from "$lib/components/Back.svelte";
   import { layoutContentTopHidden } from "$lib/stores/layout.store";
-  import { createEventDispatcher } from "svelte";
+  import { nonNullish } from "@dfinity/utils";
 
-  export let back = false;
+  interface Props {
+    title?: Snippet;
+    toolbarEnd?: Snippet;
+    onBack?: OnEventCallback;
+  }
 
-  const dispatch = createEventDispatcher();
-
-  const onBack = () => {
-    dispatch("nnsBack");
-  };
+  let { title, toolbarEnd, onBack }: Props = $props();
 </script>
 
 <header data-tid="header-component" class:hidden={$layoutContentTopHidden}>
   <Toolbar>
     <svelte:fragment slot="start">
-      {#if back}
+      {#if nonNullish(onBack)}
         <Back {onBack} />
       {:else}
         <MenuButton />
       {/if}
     </svelte:fragment>
 
-    <slot name="title" />
+    {@render title?.()}
 
-    <slot name="toolbar-end" slot="end" />
+    <svelte:fragment slot="end">
+      {@render toolbarEnd?.()}
+    </svelte:fragment>
   </Toolbar>
 </header>
 

--- a/src/lib/components/SplitContent.svelte
+++ b/src/lib/components/SplitContent.svelte
@@ -9,7 +9,6 @@
   import ContentBackdrop from "$lib/components/ContentBackdrop.svelte";
   import ScrollSentinel from "$lib/components/ScrollSentinel.svelte";
   import type { OnEventCallback } from "$lib/types/event-modifiers";
-  import { nonNullish } from "@dfinity/utils";
 
   interface Props {
     title?: Snippet;
@@ -46,13 +45,7 @@
   </div>
 
   <div class="end">
-    <Header back={nonNullish(onBack)} on:nnsBack={() => onBack?.()}>
-      <svelte:fragment slot="title">{@render title?.()}</svelte:fragment>
-
-      <svelte:fragment slot="toolbar-end"
-        >{@render toolbarEnd?.()}</svelte:fragment
-      >
-    </Header>
+    <Header {title} {toolbarEnd} {onBack} />
 
     <div class="scrollable-content-end" bind:this={scrollableElement}>
       <ContentBackdrop />


### PR DESCRIPTION
# Motivation

Migrating component `Header` button to Svelte 5.

# Breaking Changes

The interface changes:

- The slots `title` and `toolbar-end` are migrated to Snippets.
- No event `nnsBack` bubbling up anymore, use the prop `onBack` that receives the callback function.
- The prop `back` is deprecated, the nullish check of `onBack` callback will replace it.