### PR TITLE
feat(icons): add close-circle-fill icon

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -13,6 +13,7 @@ export { default as IconCheckCircleFill } from "./icons/IconCheckCircleFill.svel
 export { default as IconClock } from "./icons/IconClock.svelte";
 export { default as IconClockNoFill } from "./icons/IconClockNoFill.svelte";
 export { default as IconClose } from "./icons/IconClose.svelte";
+export { default as IconCloseCircleFill } from "./icons/IconCloseCircleFill.svelte";
 export { default as IconCollapseAll } from "./icons/IconCollapseAll.svelte";
 export { default as IconCopy } from "./icons/IconCopy.svelte";
 export { default as IconDarkMode } from "./icons/IconDarkMode.svelte";

--- a/src/lib/icons/IconCloseCircleFill.svelte
+++ b/src/lib/icons/IconCloseCircleFill.svelte
@@ -1,0 +1,18 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
+
+  export let size = DEFAULT_ICON_SIZE;
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 20 20"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M10 2.32a8.25 8.25 0 1 1 0 16.5 8.25 8.25 0 0 1 0-16.5Zm3.337 4.72a.75.75 0 0 0-1.06 0L9.89 9.427 7.503 7.04a.75.75 0 0 0-1.06 1.06l2.386 2.387-2.387 2.387a.75.75 0 0 0 1.06 1.06l2.388-2.386 2.386 2.386a.75.75 0 0 0 1.06-1.06l-2.386-2.387L13.337 8.1a.75.75 0 0 0 0-1.06Z"
+  /></svg
+>


### PR DESCRIPTION
# Motivation

We need a new icon in the nns-dapp, `IconCloseCircleFill`.

# Changes

- Add new icon

# Screenshots

<img width="375" alt="Screenshot 2025-05-26 at 11 09 32" src="https://github.com/user-attachments/assets/298b1ce3-a0d2-4540-802c-d2371400becb" />
