### PR TITLE
fix(icons): remove hardcoded stroke from close circle icon

### DIFF
--- a/src/lib/icons/IconCheckCircleV2.svelte
+++ b/src/lib/icons/IconCheckCircleV2.svelte
@@ -14,13 +14,11 @@
   fill="none"
 >
   <path
-    stroke="#BEC2D6"
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="1.5"
     d="M13.438 8.125 8.851 12.5l-2.29-2.188"
   /><path
-    stroke="#BEC2D6"
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="1.5"


### PR DESCRIPTION
# Motivation

#652 adds a new icon but it has the `stroke` property hardcoded. We want to use the color defined by the consumer. This PR fixes this by removing the hardcoded values.

# Changes

- Remove stroke properties from the svg.

# Screenshots

![Screenshot 2025-05-27 at 07 59 47](https://github.com/user-attachments/assets/72e77a19-a9a7-422b-8d49-7349d5c46be2)

