### PR TITLE
feat: Migrate component `TestIdWrapper` to Svelte 5

### DIFF
--- a/src/lib/components/TestIdWrapper.svelte
+++ b/src/lib/components/TestIdWrapper.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-  export let testId: string | undefined = undefined;
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    testId: string;
+    children: Snippet;
+  }
+
+  let { testId, children }: Props = $props();
 </script>
 
 <div class="contents" data-tid={testId}>
-  <slot />
+  {@render children()}
 </div>
 
 <style lang="scss">

--- a/src/tests/lib/components/TestIdWrapperTest.svelte
+++ b/src/tests/lib/components/TestIdWrapperTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/TestIdWrapper.svelte";
 
-  export let testId: string | undefined = undefined;
+  export let testId: string;
   export let childTestId: string | undefined = undefined;
 </script>
 


### PR DESCRIPTION
# Motivation

Migrating component `TestIdWrapper` to Svelte 5.
