### PR TITLE
feat: Bulk-migrate icons to Svelte 5 - part 1

### DIFF
--- a/src/lib/icons/IconAccountBalance.svelte
+++ b/src/lib/icons/IconAccountBalance.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconAdd.svelte
+++ b/src/lib/icons/IconAdd.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconAddCircle.svelte
+++ b/src/lib/icons/IconAddCircle.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconArrowsSwitch.svelte
+++ b/src/lib/icons/IconArrowsSwitch.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconBin.svelte
+++ b/src/lib/icons/IconBin.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconChat.svelte
+++ b/src/lib/icons/IconChat.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconClockNoFill.svelte
+++ b/src/lib/icons/IconClockNoFill.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconClose.svelte
+++ b/src/lib/icons/IconClose.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconCoin.svelte
+++ b/src/lib/icons/IconCoin.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconCollapseAll.svelte
+++ b/src/lib/icons/IconCollapseAll.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconCopy.svelte
+++ b/src/lib/icons/IconCopy.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconDarkMode.svelte
+++ b/src/lib/icons/IconDarkMode.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconDissolving.svelte
+++ b/src/lib/icons/IconDissolving.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconDocument.svelte
+++ b/src/lib/icons/IconDocument.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconDots.svelte
+++ b/src/lib/icons/IconDots.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconDown.svelte
+++ b/src/lib/icons/IconDown.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconError.svelte
+++ b/src/lib/icons/IconError.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconErrorOutline.svelte
+++ b/src/lib/icons/IconErrorOutline.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconExpandAll.svelte
+++ b/src/lib/icons/IconExpandAll.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconExpandCircleDown.svelte
+++ b/src/lib/icons/IconExpandCircleDown.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconExpandMore.svelte
+++ b/src/lib/icons/IconExpandMore.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconExplore.svelte
+++ b/src/lib/icons/IconExplore.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconEyeClosed.svelte
+++ b/src/lib/icons/IconEyeClosed.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconEyeOpen.svelte
+++ b/src/lib/icons/IconEyeOpen.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconFilter.svelte
+++ b/src/lib/icons/IconFilter.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconGitHub.svelte
+++ b/src/lib/icons/IconGitHub.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconHistoryToggleOff.svelte
+++ b/src/lib/icons/IconHistoryToggleOff.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconHome.svelte
+++ b/src/lib/icons/IconHome.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconInfo.svelte
+++ b/src/lib/icons/IconInfo.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconKey.svelte
+++ b/src/lib/icons/IconKey.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLedger.svelte
+++ b/src/lib/icons/IconLedger.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLeft.svelte
+++ b/src/lib/icons/IconLeft.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLightMode.svelte
+++ b/src/lib/icons/IconLightMode.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLockClosed.svelte
+++ b/src/lib/icons/IconLockClosed.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLockOpen.svelte
+++ b/src/lib/icons/IconLockOpen.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLogin.svelte
+++ b/src/lib/icons/IconLogin.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconLogout.svelte
+++ b/src/lib/icons/IconLogout.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconMenu.svelte
+++ b/src/lib/icons/IconMenu.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconNorthEast.svelte
+++ b/src/lib/icons/IconNorthEast.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconOpenInNew.svelte
+++ b/src/lib/icons/IconOpenInNew.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconPace.svelte
+++ b/src/lib/icons/IconPace.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconPassword.svelte
+++ b/src/lib/icons/IconPassword.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconPublicBadge.svelte
+++ b/src/lib/icons/IconPublicBadge.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconQRCodeScanner.svelte
+++ b/src/lib/icons/IconQRCodeScanner.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconReimbursed.svelte
+++ b/src/lib/icons/IconReimbursed.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconRight.svelte
+++ b/src/lib/icons/IconRight.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconRocketLaunch.svelte
+++ b/src/lib/icons/IconRocketLaunch.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconSearch.svelte
+++ b/src/lib/icons/IconSearch.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconSettings.svelte
+++ b/src/lib/icons/IconSettings.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconSort.svelte
+++ b/src/lib/icons/IconSort.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconSouth.svelte
+++ b/src/lib/icons/IconSouth.svelte
@@ -5,8 +5,15 @@
     DEFAULT_STROKE_WIDTH,
   } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
-  export let strokeWidth = DEFAULT_STROKE_WIDTH;
+  interface Props {
+    size?: string | number;
+    strokeWidth?: string | number;
+  }
+
+  let {
+    size = `${DEFAULT_ICON_SIZE}px`,
+    strokeWidth = DEFAULT_STROKE_WIDTH,
+  }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconStackedLineChart.svelte
+++ b/src/lib/icons/IconStackedLineChart.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconStakedMaturity.svelte
+++ b/src/lib/icons/IconStakedMaturity.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconStar.svelte
+++ b/src/lib/icons/IconStar.svelte
@@ -1,7 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconSync.svelte
+++ b/src/lib/icons/IconSync.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconThumbDown.svelte
+++ b/src/lib/icons/IconThumbDown.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconThumbUp.svelte
+++ b/src/lib/icons/IconThumbUp.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconUp.svelte
+++ b/src/lib/icons/IconUp.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconUser.svelte
+++ b/src/lib/icons/IconUser.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconUsers.svelte
+++ b/src/lib/icons/IconUsers.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconVote.svelte
+++ b/src/lib/icons/IconVote.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconWallet.svelte
+++ b/src/lib/icons/IconWallet.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconWarning.svelte
+++ b/src/lib/icons/IconWarning.svelte
@@ -2,7 +2,11 @@
 <script lang="ts">
   import { DEFAULT_ICON_SIZE } from "$lib/constants/constants";
 
-  export let size = `${DEFAULT_ICON_SIZE}px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = `${DEFAULT_ICON_SIZE}px` }: Props = $props();
 </script>
 
 <svg


### PR DESCRIPTION
# Motivation

Migrating icons to Svelte 5. In this first part we focus on icons with the same type of parameters, to facilitate the review.
