### PR TITLE
feat: Bulk-migrate icons to Svelte 5 - part 3

### DIFF
--- a/src/lib/icons/IconLaunchpad.svelte
+++ b/src/lib/icons/IconLaunchpad.svelte
@@ -1,8 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
+  interface Props {
+    size?: string | number;
+  }
+
   const DEFAULT_SIZE = 40;
 
-  export let size = `${DEFAULT_SIZE}px`;
+  let { size = `${DEFAULT_SIZE}px` }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconTokens.svelte
+++ b/src/lib/icons/IconTokens.svelte
@@ -1,8 +1,12 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
+  interface Props {
+    size?: string | number;
+  }
+
   const DEFAULT_SIZE = 40;
 
-  export let size = `${DEFAULT_SIZE}px`;
+  let { size = `${DEFAULT_SIZE}px` }: Props = $props();
 </script>
 
 <svg


### PR DESCRIPTION
# Motivation

Migrating icons to Svelte 5. In this third part we focus on icons with the same type of parameters, to facilitate the review.
