### PR TITLE
feat: Bulk-migrate icons to Svelte 5 - part 5

### DIFF
--- a/src/lib/icons/IconCheck.svelte
+++ b/src/lib/icons/IconCheck.svelte
@@ -1,6 +1,10 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size = `24px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = "24px" }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconCheckCircle.svelte
+++ b/src/lib/icons/IconCheckCircle.svelte
@@ -1,6 +1,10 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size = `24px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = "24px" }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/icons/IconClock.svelte
+++ b/src/lib/icons/IconClock.svelte
@@ -1,6 +1,10 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-  export let size = `24px`;
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = "24px" }: Props = $props();
 </script>
 
 <svg


### PR DESCRIPTION
# Motivation

Migrating icons to Svelte 5. In this fifth part we focus on icons with the same type of parameters, to facilitate the review.
