### PR TITLE
fix: Pass event to callback of event modifiers

### DIFF
--- a/src/lib/types/event-modifiers.ts
+++ b/src/lib/types/event-modifiers.ts
@@ -1,1 +1,7 @@
-export type OnEventCallback = () => void | Promise<void>;
+export type OnEventParam<T extends EventTarget> = MouseEvent & {
+  currentTarget: EventTarget & T;
+};
+
+export type OnEventCallback<T extends EventTarget> = (
+  $event: OnEventParam<T>,
+) => void | Promise<void>;

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -5,37 +5,37 @@
  * @see {@link https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers}
  */
 
-import type { OnEventCallback } from "$lib/types/event-modifiers";
+import type { OnEventCallback, OnEventParam } from "$lib/types/event-modifiers";
 import type { MouseEventHandler } from "svelte/elements";
 
 /**
  * A wrapper function to stop event propagation of a mouse event before executing a callback function.
  *
- * @param {OnEventCallback} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
+ * @param {OnEventCallback<T extends EventTarget>} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
  *
  * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
  */
 export const stopPropagation = <T extends EventTarget>(
-  fn: OnEventCallback,
+  fn: OnEventCallback<T>,
 ): MouseEventHandler<T> => {
-  return async ($event?: MouseEvent & { currentTarget: EventTarget & T }) => {
+  return async ($event: OnEventParam<T>) => {
     $event?.stopPropagation();
-    await fn();
+    await fn($event);
   };
 };
 
 /**
  * A wrapper function to prevent the default action of a mouse event before executing a callback function.
  *
- * @param {OnEventCallback} fn - The function to be executed after preventing the default action. It can be a synchronous or asynchronous function.
+ * @param {OnEventCallback<T extends EventTarget>} fn - The function to be executed after preventing the default action. It can be a synchronous or asynchronous function.
  *
  * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and prevents its default action, before executing the provided function.
  */
 export const preventDefault = <T extends EventTarget>(
-  fn: OnEventCallback,
+  fn: OnEventCallback<T>,
 ): MouseEventHandler<T> => {
-  return async ($event?: MouseEvent & { currentTarget: EventTarget & T }) => {
+  return async ($event: OnEventParam<T>) => {
     $event?.preventDefault();
-    await fn();
+    await fn($event);
   };
 };

--- a/src/routes/(page)/utility-functions/+page.md
+++ b/src/routes/(page)/utility-functions/+page.md
@@ -13,9 +13,9 @@ A collection of handy JavaScript/TypeScript utility functions you can use alongs
 
 A wrapper function to stop event propagation of a mouse event before executing a callback function.
 
-| Function          | Type                                                                   |
-| ----------------- | ---------------------------------------------------------------------- |
-| `stopPropagation` | `<T extends EventTarget>(fn: OnEventCallback) => MouseEventHandler<T>` |
+| Function          | Type                                                                      |
+| ----------------- | ------------------------------------------------------------------------- |
+| `stopPropagation` | `<T extends EventTarget>(fn: OnEventCallback<T>) => MouseEventHandler<T>` |
 
 Parameters:
 
@@ -27,9 +27,9 @@ Parameters:
 
 A wrapper function to prevent the default action of a mouse event before executing a callback function.
 
-| Function         | Type                                                                   |
-| ---------------- | ---------------------------------------------------------------------- |
-| `preventDefault` | `<T extends EventTarget>(fn: OnEventCallback) => MouseEventHandler<T>` |
+| Function         | Type                                                                      |
+| ---------------- | ------------------------------------------------------------------------- |
+| `preventDefault` | `<T extends EventTarget>(fn: OnEventCallback<T>) => MouseEventHandler<T>` |
 
 Parameters:
 

--- a/src/tests/lib/utils/event-modifiers.utils.spec.ts
+++ b/src/tests/lib/utils/event-modifiers.utils.spec.ts
@@ -35,16 +35,16 @@ describe("event-modifiers-utils", () => {
 
       await handler(mockEvent);
 
-      expect(callbackMock).toHaveBeenCalledOnce();
+      expect(callbackMock).toHaveBeenCalledExactlyOnceWith(mockEvent);
     });
 
-    it("should still call callback even if event is undefined", async () => {
+    it("should handle nullish events", async () => {
       const handler = stopPropagation(callbackMock);
 
       // @ts-expect-error Testing this on purpose
       await handler(undefined);
 
-      expect(callbackMock).toHaveBeenCalledOnce();
+      expect(callbackMock).toHaveBeenCalledExactlyOnceWith(undefined);
     });
 
     it("should throw if callback throws an error", async () => {
@@ -110,16 +110,16 @@ describe("event-modifiers-utils", () => {
 
       await handler(mockEvent);
 
-      expect(callbackMock).toHaveBeenCalledOnce();
+      expect(callbackMock).toHaveBeenCalledExactlyOnceWith(mockEvent);
     });
 
-    it("should still call callback even if event is undefined", async () => {
+    it("should handle nullish events", async () => {
       const handler = preventDefault(callbackMock);
 
       // @ts-expect-error Testing this on purpose
       await handler(undefined);
 
-      expect(callbackMock).toHaveBeenCalledOnce();
+      expect(callbackMock).toHaveBeenCalledExactlyOnceWith(undefined);
     });
 
     it("should throw if callback throws an error", async () => {


### PR DESCRIPTION
# Motivation

We should pass the event to the event modifiers callback. That is what is suggested in the official documentation too (see https://svelte.dev/docs/svelte/v5-migration-guide#Event-changes-Event-modifiers), but in general, it makes sense. Especially, if we use the modifiers concatenated.

# Changes

- Create simplified type for event parameter.
- Pass the event to the call back function in both exiting modifiers.
- Removing optionality of events, since it is not necessary.

# Screenshots

Current tests were adapted to test this new change. The unchanged tests must work as usual.
