### PR TITLE
fix: Avoid loss of precision in Input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "decimal.js": "^10.6.0",
         "dompurify": "^3.2.4",
         "html5-qrcode": "^2.3.8",
         "marked": "^9.1.0",
@@ -2608,10 +2609,10 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/dedent-js": {
       "version": "1.0.1",
@@ -7579,10 +7580,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
     },
     "dedent-js": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "vitest": "^3.1.1"
   },
   "dependencies": {
+    "decimal.js": "^10.6.0",
     "dompurify": "^3.2.4",
     "html5-qrcode": "^2.3.8",
     "marked": "^9.1.0",

--- a/src/tests/lib/components/Input.svelte.spec.ts
+++ b/src/tests/lib/components/Input.svelte.spec.ts
@@ -2,6 +2,7 @@ import Input from "$lib/components/Input.svelte";
 import { assertNonNullish, isNullish, nonNullish } from "@dfinity/utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
+import InputCurrencyTest from "./InputCurrencyTest.svelte";
 import InputElementTest from "./InputElementTest.svelte";
 import InputTest from "./InputTest.svelte";
 import InputValueTest from "./InputValueTest.svelte";
@@ -515,6 +516,32 @@ describe("Input", () => {
 
       fireEvent.input(input, { target: { value: "0.0000000112312321219" } });
       expect(input.value).toBe("0.000000011231232121");
+    });
+
+    it("should not trim below given decimals", async () => {
+      const { container, getByTestId } = render(InputCurrencyTest, {
+        props: {
+          ...props,
+          decimals: 18,
+        },
+      });
+
+      const input: HTMLInputElement | null = container.querySelector("input");
+      assertNonNullish(input);
+
+      const testValue = getByTestId("amount-decimals-output");
+
+      fireEvent.input(input, { target: { value: "0.999999999999999843" } });
+
+      await tick();
+
+      expect(testValue.textContent).toBe("0.999999999999999843");
+
+      fireEvent.input(input, { target: { value: "0.100000000000000843" } });
+
+      await tick();
+
+      expect(testValue.textContent).toBe("0.100000000000000843");
     });
 
     it("should not round custom decimals with JS imprecision", () => {

--- a/src/tests/lib/components/InputCurrencyTest.svelte
+++ b/src/tests/lib/components/InputCurrencyTest.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Input from "$lib/components/Input.svelte";
+  import { onMount } from "svelte";
+
+  interface Props {
+    decimals?: number;
+    value?: string | undefined;
+  }
+
+  let { decimals = 8, value = $bindable() }: Props = $props();
+</script>
+
+<Input bind:value inputType="currency" {decimals} />
+<p>Amount: <output data-tid="amount-decimals-output">{value ?? ""}</output></p>


### PR DESCRIPTION
# Motivation

The Input component uses `Number()` when it is a currency type. However, due to floating-point limitations of this method, the value that the user inputs is different from the rendered ones sometimes. For example:

![Screenshot 2025-07-08 at 16 19 13](https://github.com/user-attachments/assets/90c612fa-0524-44e6-b44b-7c3b6ed041d3)


Unfortunately there is no real solution unless we create our own `Number(value).toLocaleString()` method. Or if we use a common library like [decimals.js](https://www.npmjs.com/package/decimal.js?activeTab=readme).

We will opt for the second one, with a caveat: `Decimals` raises an error for empty strings, or non-number strings, while `Number` would just create the object `NaN`.

So, we make a safe-parsing of `Decimals`, and fallback to the "old" method if it fails.

# Changes

- Install `decimals.js`.
- Change Input component to use Decimals but in a safe way (as explained above).

# Screenshots

Added tests and tested manually:

![Screenshot 2025-07-08 at 16 24 00](https://github.com/user-attachments/assets/f60b7b94-3d4b-491a-afd0-917325ebb6c3)

