### PR TITLE
feat(frontend): change the modal centalization style

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -121,6 +121,9 @@
 
   .modal {
     position: fixed;
+    display: flex;
+    justify-content: center;
+    align-items:    center;
     @include display.inset;
 
     z-index: var(--modal-z-index);
@@ -130,9 +133,9 @@
 
   .wrapper {
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    left: 0;
+    right: 0;
+    margin: auto;
 
     display: flex;
     flex-direction: column;

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -123,7 +123,7 @@
     position: fixed;
     display: flex;
     justify-content: center;
-    align-items:    center;
+    align-items: center;
     @include display.inset;
 
     z-index: var(--modal-z-index);


### PR DESCRIPTION
# Motivation

The current modal centering uses a transform-based hack which complicates responsive adjustments and theming. Switching to a flex‐based centering approach will simplify the CSS, make the overlay consistently centered across different viewport sizes, and improve maintainability.

# Changes

Modal container
Removed: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
Added display: flex; justify-content: center; align-items: center; on the modal wrapper

# Screenshots
<img width="1165" alt="Screenshot 2025-07-09 at 19 35 38" src="https://github.com/user-attachments/assets/8079d79b-5796-472a-9fe9-c3346f6230e5" />

Verified centering on desktop and mobile viewports in Chrome, Firefox, Safari, and Edge
Tested with varying modal content heights (short alerts vs. long forms)
Confirmed scroll behavior and that focus management still works
