### PR TITLE
fix: Default generic for Event types

### DIFF
--- a/src/lib/types/event-modifiers.ts
+++ b/src/lib/types/event-modifiers.ts
@@ -1,7 +1,7 @@
-export type OnEventParam<T extends EventTarget> = MouseEvent & {
+export type OnEventParam<T extends EventTarget = EventTarget> = MouseEvent & {
   currentTarget: EventTarget & T;
 };
 
-export type OnEventCallback<T extends EventTarget> = (
+export type OnEventCallback<T extends EventTarget = EventTarget> = (
   $event: OnEventParam<T>,
 ) => void | Promise<void>;


### PR DESCRIPTION
# Motivation

The events types `OnEventParam` and  `OnEventCallback` don't really require a generic type as input, we can default to `EventTarget`, since it's the base for the other type extensions.
