### PR TITLE
fix: Default testId for `Collapsible` component

### DIFF
--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -9,7 +9,7 @@
   export let id: string | undefined = undefined;
   export let initiallyExpanded = false;
   export let maxContentHeight: number | undefined = undefined;
-  export let testId = 'collapsible';
+  export let testId = "collapsible";
 
   export let iconSize: "small" | "medium" = "small";
   export let expandButton = true;

--- a/src/lib/components/Collapsible.svelte
+++ b/src/lib/components/Collapsible.svelte
@@ -9,7 +9,7 @@
   export let id: string | undefined = undefined;
   export let initiallyExpanded = false;
   export let maxContentHeight: number | undefined = undefined;
-  export let testId: string | undefined = undefined;
+  export let testId = 'collapsible';
 
   export let iconSize: "small" | "medium" = "small";
   export let expandButton = true;


### PR DESCRIPTION
# Motivation

The `Collapsible` component renders `TestIdWrapper`. This last component required a non-nullish `testId` (for obvious reasons). So, since this seems to be the intention of the code, we default the `testId` to a value.
