### PR TITLE
chore: remove explicit modern-compiler

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,13 +13,6 @@ const config = {
   define: {
     "process.env.VITE_BUILD_TIME": JSON.stringify(new Date().toISOString()),
   },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: "modern-compiler",
-      },
-    },
-  },
 };
 
 export default config;


### PR DESCRIPTION
# Motivation

Looks like the option to opt-in the modern sass compilet as been removed. 

See CI check: https://github.com/dfinity/gix-components/actions/runs/16214233455/job/45779977677?pr=682

So we can remove it from our config.