### PR TITLE
fix: Component `WizardModal` is back to correct working

### DIFF
--- a/src/lib/components/WizardModal.svelte
+++ b/src/lib/components/WizardModal.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script lang="ts" generics="T extends string">
-  import type { Snippet } from "svelte";
+  import { type Snippet } from "svelte";
   import WizardTransition from "./WizardTransition.svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { WizardStepsState } from "$lib/stores/wizard.state";
@@ -33,13 +33,25 @@
 
   let transition = $derived({ diff: stepState.diff });
 
-  $effect(() => {
+  const updateCurrentStep = (stepState: WizardStepsState<T>) =>
     ({ currentStep } = stepState);
+
+  $effect(() => {
+    updateCurrentStep(stepState);
   });
 
-  export const next = () => (stepState = stepState.next());
-  export const back = () => (stepState = stepState.back());
-  export const set = (step: number) => (stepState = stepState.set(step));
+  export const next = () => {
+    stepState = stepState.next();
+    updateCurrentStep(stepState);
+  };
+  export const back = () => {
+    stepState = stepState.back();
+    updateCurrentStep(stepState);
+  };
+  export const set = (step: number) => {
+    stepState = stepState.set(step);
+    updateCurrentStep(stepState);
+  };
 
   // onDestroy is not always called when repetitively opened/closed in NNS-dapp.
   // This might be linked to Svelte issue https://github.com/sveltejs/svelte/issues/5268.

--- a/src/routes/(split)/components/wizard-modal/+page.md
+++ b/src/routes/(split)/components/wizard-modal/+page.md
@@ -16,7 +16,7 @@
         ];
     
     let currentStep: WizardStep | undefined;
-    let modal: WizardModal;
+    let modal: WizardModal<string>;
 </script>
 
 # Wizard Modal
@@ -39,7 +39,7 @@ A wizard that finds place within a modal to guide the user through miscellaneous
     ];
 
     let currentStep: WizardStep | undefined;
-    let modal: WizardModal;
+    let modal: WizardModal<string>;
 
     const next = () => modal.next();
 </script>

--- a/src/tests/lib/components/WizardModal.spec.ts
+++ b/src/tests/lib/components/WizardModal.spec.ts
@@ -1,8 +1,9 @@
 import WizardModal from "$lib/components/WizardModal.svelte";
 import type { WizardStep, WizardSteps } from "$lib/types/wizard";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import type { Snippet } from "svelte";
 import { mockSnippet } from "../mocks/snippet.mocks";
+import WizardModalTest from "./WizardModalTest.svelte";
 
 describe("WizardModal", () => {
   const steps: WizardSteps = [
@@ -62,5 +63,61 @@ describe("WizardModal", () => {
     const div = container.querySelector("div.transition");
 
     expect(div).not.toBeNull();
+  });
+
+  it("should trigger the next step when modal.next is called", async () => {
+    const { getByTestId } = render(WizardModalTest);
+
+    const nextButton = getByTestId("next-button");
+
+    expect(nextButton).toBeInTheDocument();
+
+    await fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      const backButton = getByTestId("back-button");
+
+      expect(nextButton).not.toBeInTheDocument();
+      expect(backButton).toBeInTheDocument();
+    });
+  });
+
+  it("should trigger the back step when modal.back is called", async () => {
+    const { getByTestId } = render(WizardModalTest);
+
+    const nextButton = getByTestId("next-button");
+
+    await fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      const backButton = getByTestId("back-button");
+
+      expect(nextButton).not.toBeInTheDocument();
+      expect(backButton).toBeInTheDocument();
+    });
+
+    const backButton = getByTestId("back-button");
+
+    await fireEvent.click(backButton);
+
+    await waitFor(() => {
+      const nextButton = getByTestId("next-button");
+
+      expect(nextButton).toBeInTheDocument();
+      expect(backButton).not.toBeInTheDocument();
+    });
+  });
+
+  it("should set a custom step when modal.set is called", async () => {
+    const { getByTestId } = render(WizardModalTest);
+
+    const stepButton = getByTestId("hidden-step-button");
+
+    await fireEvent.click(stepButton);
+
+    await waitFor(() => {
+      expect(stepButton).not.toBeInTheDocument();
+      expect(getByTestId("hidden-step")).toBeInTheDocument();
+    });
   });
 });

--- a/src/tests/lib/components/WizardModalTest.svelte
+++ b/src/tests/lib/components/WizardModalTest.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import WizardModal from "$lib/components/WizardModal.svelte";
+  import type { WizardStep, WizardSteps } from "$lib/types/wizard";
+
+  const steps: WizardSteps = [
+    {
+      name: "EnterController",
+      title: "Enter a controller",
+    },
+    {
+      name: "ConfirmController",
+      title: "Confirm the controller",
+    },
+    {
+      name: "HiddenStep",
+      title: "This step is hidden",
+    },
+  ];
+
+  let currentStep: WizardStep | undefined;
+  let modal: WizardModal<string>;
+</script>
+
+<WizardModal {steps} bind:currentStep bind:this={modal}>
+  {#snippet title()}My title{/snippet}
+
+  {#if currentStep?.name === "EnterController"}
+    <p>Step to enter the controller</p>
+
+    <div class="toolbar">
+      <button class="primary" data-tid="next-button" onclick={modal.next}>
+        Next
+      </button>
+      <button
+        class="primary"
+        data-tid="hidden-step-button"
+        onclick={() => modal.set(2)}
+      >
+        Hidden Step
+      </button>
+    </div>
+  {:else if currentStep?.name === "ConfirmController"}
+    <p>Step to confirm the controller</p>
+
+    <div class="toolbar">
+      <button class="secondary" data-tid="back-button" onclick={modal.back}>
+        Back
+      </button>
+    </div>
+  {:else if currentStep?.name === "HiddenStep"}
+    <p data-tid="hidden-step">
+      This step is hidden and should not be displayed.
+    </p>
+  {/if}
+</WizardModal>


### PR DESCRIPTION
# Motivation

After migrating `WizardModal` to Svelte 5 in https://github.com/dfinity/gix-components/pull/689 , it is not working anymore using function `modal.next()`, `modal.back()` and `modal.set()`.

https://github.com/user-attachments/assets/ea0854ae-b0e5-486e-bcb3-d8605c1bcaf3

That is because the reactivity of `$effect` works different in the following snippet:

```svelte
// Svelte v4
$: ({ currentStep } = stepState)

// Svelte v5
$effect(() => {
  ({ currentStep } = stepState);
});
```
  
In Svelte 5, this reactivity is in fact triggered only when the entire reference of `stepState` changes. However, if only its properties change (like when we call functions `next`, `back` and `set`), then it does not trigger a reaction, causing a stale component.

A possible solution is to directly trigger the update of `currentStep` in each function.

We keep the $effect rune, just because it should be triggered on assigning any value to `stepState` in any case.

# Changes

- Create small function to update the `currentStep` variable, taking `stepState` as input.
- Use it both in the $effect rune and in all the exported functions: `next`, `back`, `set`.

# Screenshots

I created new tests (with a test component). They work now, but it can be easily verified that they were not working before this PR.

At the same here is a local manual test:


https://github.com/user-attachments/assets/072695c4-8219-44f9-99ce-886327592eb0


