### PR TITLE
fix: reverted progressSteps component and added new IconCloseCircle for failed step

### DIFF
--- a/src/lib/components/ProgressSteps.svelte
+++ b/src/lib/components/ProgressSteps.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Spinner from "$lib/components/Spinner.svelte";
-  import IconCheckCircleFill from "$lib/icons/IconCheckCircleFill.svelte";
-  import IconCloseCircleFill from "$lib/icons/IconCloseCircleFill.svelte";
+  import IconCheckCircle from "$lib/icons/IconCheckCircle.svelte";
+  import IconCloseCircle from "$lib/icons/IconCloseCircle.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { ProgressStep } from "$lib/types/progress-step";
 
@@ -16,9 +16,9 @@
   {@const last = i === steps.length - 1}
   <div class={`step ${state} ${last ? "last" : ""}`}>
     {#if state === "completed"}
-      <IconCheckCircleFill size="26" />
+      <IconCheckCircle />
     {:else if state === "failed"}
-      <IconCloseCircleFill size="26" />
+      <IconCloseCircle />
     {:else if state === "in_progress"}
       <div class="spinner">
         <span class="checkmark">{i + 1}</span>
@@ -60,6 +60,7 @@
     padding: 0 0 var(--padding);
 
     --icon-check-circle-background: var(--positive-emphasis);
+    --icon-check-circle-color: white;
 
     color: var(--value-color);
     transition: color var(--animation-time-normal) ease-out;
@@ -77,14 +78,26 @@
     }
   }
 
-  .completed {
-    --icon-check-circle-fill-background: var(--positive-emphasis);
+  .in_progress {
+    color: var(--progress-color);
+
+    --icon-check-circle-background: var(--progress-color);
+    --icon-check-circle-color: var(--progress-color-contrast);
+
+    .state {
+      color: var(--progress-color);
+      background: rgba(var(--progress-color-rgb), 0.3);
+    }
+
+    .checkmark {
+      --checkmark-color: var(--progress-color);
+    }
   }
 
   .failed {
     color: var(--negative-emphasis);
-
-    --icon-check-circle-background: var(--negative-emphasis);
+    --icon-close-circle-background: var(--negative-emphasis);
+    --icon-close-circle-color: white;
 
     .line {
       --line-color: var(--negative-emphasis);
@@ -100,25 +113,12 @@
     }
   }
 
-  .in_progress {
-    color: var(--progress-color);
-
-    --icon-check-circle-background: var(--progress-color);
-
-    .state {
-      color: var(--progress-color);
-      background: rgba(var(--progress-color-rgb), 0.3);
-    }
-
-    .checkmark {
-      --checkmark-color: var(--progress-color);
-    }
-  }
-
   .next {
     color: var(--tertiary);
 
     --icon-check-circle-background: transparent;
+    --icon-check-circle-color: var(--tertiary);
+    --icon-check-circle-border-color: var(--tertiary);
   }
 
   .state {
@@ -165,10 +165,8 @@
   }
 
   .round {
-    width: 20px;
-    height: 20px;
-
-    margin: 2px;
+    width: 22px;
+    height: 22px;
 
     border-radius: 50%;
 

--- a/src/lib/icons/IconCheckCircleFill.svelte
+++ b/src/lib/icons/IconCheckCircleFill.svelte
@@ -13,7 +13,7 @@
   width={size}
   height={size}
   viewBox="0 0 20 20"
-  fill="var(--icon-check-circle-fill-background, transparent)"
+  fill="currentColor"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/src/lib/icons/IconCloseCircle.svelte
+++ b/src/lib/icons/IconCloseCircle.svelte
@@ -1,0 +1,38 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+  interface Props {
+    size?: string | number;
+  }
+
+  let { size = "24px" }: Props = $props();
+</script>
+
+<svg
+  height={size}
+  width={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect
+    x="1.25"
+    y="1.25"
+    width="21.5"
+    height="21.5"
+    rx="10.75"
+    fill="var(--icon-close-circle-background, transparent)"
+  />
+  <path
+    fill="var(--icon-close-circle-color, currentColor)"
+    d="M14.808 8.22a.75.75 0 1 1 1.06 1.06l-2.764 2.764 2.645 2.644a.75.75 0 0 1-1.06 1.061l-2.645-2.645-2.645 2.645a.75.75 0 0 1-1.06-1.06l2.644-2.645L8.22 9.28a.75.75 0 1 1 1.06-1.06l2.764 2.763 2.764-2.763Z"
+  />
+  <rect
+    x="1.25"
+    y="1.25"
+    width="21.5"
+    height="21.5"
+    rx="10.75"
+    stroke="var(--icon-close-circle-background, currentColor)"
+    stroke-width="1.5"
+  />
+</svg>


### PR DESCRIPTION
# Motivation

Refer to [PR #700:](https://github.com/dfinity/gix-components/pull/700)
The changes introduced in this PR caused some style issues. It was decided to revert to the previous implementation and introduce a new IconCloseCircle that matches the size of IconCheckCircle.

# Changes
- Reverted styles and IconCheckCircle to the previous version
- Added new IconCloseCircle with matching dimensions

# Screenshots

<img width="269" height="338" alt="image" src="https://github.com/user-attachments/assets/9fc7a34e-1949-4e27-906f-534e228109b1" />

<img width="274" height="353" alt="image" src="https://github.com/user-attachments/assets/abc5c2c4-df9c-4600-9a35-cead6fafb828" />

