### PR TITLE
fix(markdown): preserve SVG tags in code blocks

### DIFF
--- a/src/lib/utils/markdown.utils.ts
+++ b/src/lib/utils/markdown.utils.ts
@@ -127,7 +127,6 @@ const proposalSummaryRenderer = (marked: Marked): Renderer => {
 export const markdownToHTML = async (text: string): Promise<string> => {
   // Replace the SVG elements in the HTML with their escaped versions to improve security.
   // It's not possible to do it with html renderer because the svg consists of multiple tags.
-  // One edge case is not covered: if the svg is inside the <code> tag, it will be rendered as with &lt; & &gt; instead of "<" & ">"
   const escapedText = escapeSvgs(text);
 
   // The dynamic import cannot be analyzed by Vite. As it is intended, we use the /* @vite-ignore */ comment inside the import() call to suppress this warning.

--- a/src/tests/lib/utils/markdown.utils.spec.ts
+++ b/src/tests/lib/utils/markdown.utils.spec.ts
@@ -150,5 +150,38 @@ describe("markdown.utils", () => {
         `<a href="image.png" target="_blank" rel="noopener noreferrer" type="image/png">title</a>`,
       );
     });
+
+    it("should preserve SVGs inside fenced code blocks", async () => {
+      const markdown = `
+   Here's some code:
+   \`\`\`xml
+   <svg width="100" height="100">
+     <circle cx="50" cy="50" r="40" />
+   </svg>
+   \`\`\`
+   And a regular SVG: <svg>test</svg>
+   `;
+
+      const result = await markdownToHTML(markdown);
+
+      // SVG inside code block should be preserved
+      expect(result).toContain('<svg width="100" height="100">');
+      expect(result).toContain('<circle cx="50" cy="50" r="40" />');
+
+      // SVG outside code block should be escaped
+      expect(result).toContain("&lt;svg&gt;test&lt;/svg&gt;");
+    });
+
+    it("should preserve SVGs inside inline code", async () => {
+      const markdown = `Use \`<svg>icon</svg>\` for icons and <svg>other</svg> normally.`;
+
+      const result = await markdownToHTML(markdown);
+
+      // SVG inside inline code should be preserved
+      expect(result).toContain("<code><svg>icon<svg&gt;</code>");
+
+      // SVG outside code should be escaped
+      expect(result).toContain("&lt;svg&gt;other&lt;/svg&gt;");
+    });
   });
 });


### PR DESCRIPTION
# Motivation

The `Markdown` component converts markdown into HTML. For security reasons, the input is sanitized before transformation.

The initial implementation was introduced [here](https://github.com/dfinity/nns-dapp/pull/3399) and acknowledged this edge case.
> It's not possible to use the HTML renderer since the SVG contains multiple tags. 
> One edge case remains unaddressed: if the SVG is inside the `<code>` tag, it will be rendered with &lt; and &gt; instead of "<" and ">."

We need to address this use case now, as there is a mismatch between how the proposal is rendered and how it should be rendered:  
* https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=138188  
* https://dashboard.internetcomputer.org/proposal/138188


# Changes

* Do not escape svg's inside code blocks.

# Screenshots

<img width="1013" height="847" alt="Screenshot 2025-08-27 at 15 42 30" src="https://github.com/user-attachments/assets/0c9ceb4e-1806-491d-bb17-99e68fa9b096" />
