### PR TITLE
fix(frontend): Generalize the event type for all event modifiers

### DIFF
--- a/src/lib/types/event-modifiers.ts
+++ b/src/lib/types/event-modifiers.ts
@@ -1,7 +1,11 @@
-export type OnEventParam<T extends EventTarget = EventTarget> = MouseEvent & {
+export type OnEventParam<
+  E extends Event = Event,
+  T extends EventTarget = EventTarget,
+> = E & {
   currentTarget: EventTarget & T;
 };
 
-export type OnEventCallback<T extends EventTarget = EventTarget> = (
-  $event: OnEventParam<T>,
-) => void | Promise<void>;
+export type OnEventCallback<
+  E extends Event = Event,
+  T extends EventTarget = EventTarget,
+> = ($event: OnEventParam<E, T>) => void | Promise<void>;

--- a/src/lib/utils/event-modifiers.utils.ts
+++ b/src/lib/utils/event-modifiers.utils.ts
@@ -6,18 +6,20 @@
  */
 
 import type { OnEventCallback, OnEventParam } from "$lib/types/event-modifiers";
-import type { MouseEventHandler } from "svelte/elements";
+import type { EventHandler } from "svelte/elements";
 
 /**
  * A wrapper function to stop event propagation of a mouse event before executing a callback function.
  *
- * @param {OnEventCallback<T extends EventTarget>} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
+ * @param {OnEventCallback<E extends Event = Event, T extends EventTarget = EventTarget>} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
  *
- * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
+ * @returns {EventHandler<E extends Event = Event, T extends EventTarget = EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
  */
 export const stopPropagation =
-  <T extends EventTarget>(fn: OnEventCallback<T>): MouseEventHandler<T> =>
-  async ($event: OnEventParam<T>) => {
+  <E extends Event = Event, T extends EventTarget = EventTarget>(
+    fn: OnEventCallback<E, T>,
+  ): EventHandler<E, T> =>
+  async ($event: OnEventParam<E, T>) => {
     $event?.stopPropagation();
     await fn($event);
   };
@@ -25,13 +27,15 @@ export const stopPropagation =
 /**
  * A wrapper function to prevent the default action of a mouse event before executing a callback function.
  *
- * @param {OnEventCallback<T extends EventTarget>} fn - The function to be executed after preventing the default action. It can be a synchronous or asynchronous function.
+ * @param {OnEventCallback<E extends Event = Event, T extends EventTarget = EventTarget>} fn - The function to be executed after preventing the default action. It can be a synchronous or asynchronous function.
  *
- * @returns {MouseEventHandler<T extends EventTarget>} - A function that takes an event and prevents its default action, before executing the provided function.
+ * @returns {EventHandler<E extends Event = Event, T extends EventTarget = EventTarget>} - A function that takes an event and prevents its default action, before executing the provided function.
  */
 export const preventDefault =
-  <T extends EventTarget>(fn: OnEventCallback<T>): MouseEventHandler<T> =>
-  async ($event: OnEventParam<T>) => {
+  <E extends Event = Event, T extends EventTarget = EventTarget>(
+    fn: OnEventCallback<E, T>,
+  ): EventHandler<E, T> =>
+  async ($event: OnEventParam<E, T>) => {
     $event?.preventDefault();
     await fn($event);
   };

--- a/src/routes/(page)/utility-functions/+page.md
+++ b/src/routes/(page)/utility-functions/+page.md
@@ -13,17 +13,17 @@ A collection of handy JavaScript/TypeScript utility functions you can use alongs
 
 A wrapper function to stop event propagation of a mouse event before executing a callback function.
 
-| Function          | Type                                                                      |
-| ----------------- | ------------------------------------------------------------------------- |
-| `stopPropagation` | `<T extends EventTarget>(fn: OnEventCallback<T>) => MouseEventHandler<T>` |
+| Function          | Type                                                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `stopPropagation` | `<E extends Event = Event, T extends EventTarget = EventTarget>(fn: OnEventCallback<E, T>) => EventHandler<E, T>` |
 
 Parameters:
 
-- `fn`: - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
+- `Event`: , T extends EventTarget = EventTarget>} fn - The function to be executed after stopping the event propagation. It can be a synchronous or asynchronous function.
 
 Returns:
 
-- A function that takes an event and stop its propagation, before executing the provided function.
+Event, T extends EventTarget = EventTarget>} - A function that takes an event and stop its propagation, before executing the provided function.
 
 [Source](https://github.com/dfinity/gix-components/tree/main/src/lib/utils/event-modifiers.utils.ts#L18)
 
@@ -31,19 +31,19 @@ Returns:
 
 A wrapper function to prevent the default action of a mouse event before executing a callback function.
 
-| Function         | Type                                                                      |
-| ---------------- | ------------------------------------------------------------------------- |
-| `preventDefault` | `<T extends EventTarget>(fn: OnEventCallback<T>) => MouseEventHandler<T>` |
+| Function         | Type                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `preventDefault` | `<E extends Event = Event, T extends EventTarget = EventTarget>(fn: OnEventCallback<E, T>) => EventHandler<E, T>` |
 
 Parameters:
 
-- `fn`: - The function to be executed after preventing the default action. It can be a synchronous or asynchronous function.
+- `Event`: , T extends EventTarget = EventTarget>} fn - The function to be executed after preventing the default action. It can be a synchronous or asynchronous function.
 
 Returns:
 
-- A function that takes an event and prevents its default action, before executing the provided function.
+Event, T extends EventTarget = EventTarget>} - A function that takes an event and prevents its default action, before executing the provided function.
 
-[Source](https://github.com/dfinity/gix-components/tree/main/src/lib/utils/event-modifiers.utils.ts#L32)
+[Source](https://github.com/dfinity/gix-components/tree/main/src/lib/utils/event-modifiers.utils.ts#L34)
 
 <!-- TSDOC_END -->
 


### PR DESCRIPTION
# Motivation

Up until now, the event modifiers could be used type-safely only with Mouse events. However, we may have other scopes (for example, using modifiers in the submit event of a form). In these cases, we need to generalize the type and adapt it to the context.

# Changes

- Add generic type for the event in all the modifiers utils.

