### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
           echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -29,14 +29,14 @@ jobs:
 
       - name: Checkout
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Checkout
         if: steps.check_can_add_commit.outputs.can_add_commit == 'false'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt
@@ -58,7 +58,7 @@ jobs:
           fi
       - name: Commit Formatting changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_format.outputs.formatting_needed == 'true'
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           add: .
           default_author: github_actions
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Check
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
@@ -125,13 +125,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print chrome version
         run: |
           echo "google-chrome --version"
           google-chrome --version
       - name: Cache and restore samples
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: samples
         with:
           path: ./samples/
@@ -142,7 +142,7 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Run Playwright tests
         run: npm run e2e:ci
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,12 +12,12 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare
         uses: ./.github/actions/prepare
 
       - name: Deploy to Juno
-        uses: junobuild/juno-action@main
+        uses: junobuild/juno-action@c6a23bc5159ae0676f5ed8b375fdfb5e844fa1b8 # main
         with:
           args: hosting deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
           echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -31,14 +31,14 @@ jobs:
 
       - name: Checkout with token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Checkout without token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'false'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -50,7 +50,7 @@ jobs:
         run: npm run docs
 
       - name: Commit docs
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         # We don't want to commit documentation changes to main
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
@@ -68,7 +68,7 @@ jobs:
           fi
       - name: Commit docs changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_docs.outputs.docs_needed == 'true'
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           add: .
           default_author: github_actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Package next

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -14,14 +14,14 @@ jobs:
           exit 1
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Prepare
@@ -29,7 +29,7 @@ jobs:
       - name: Run Playwright tests
         run: npm run e2e:snapshots
       - name: Commit Playwright updated snapshots
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
           add: e2e


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 26d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - Version: v6.0.2 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd

- `EndBug/add-and-commit@v9.1.4` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 17d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `actions/cache@v4` -> `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`
  - Version: v4.3.0 | Latest: v5.0.4 | Release age: 21d
  - Commit: https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830

- `actions/upload-artifact@v7` -> `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7`
  - Version: v7 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

- `junobuild/juno-action@main` -> `junobuild/juno-action@c6a23bc5159ae0676f5ed8b375fdfb5e844fa1b8 # main`
  - Version: main | Latest: v0.7.0 | Release age: 21d
  - Commit: https://github.com/junobuild/juno-action/commit/c6a23bc5159ae0676f5ed8b375fdfb5e844fa1b8
  - Warnings: Latest release v0.7.0 is only 2 day(s) old (< 7 days). Using previous safe release.

- `EndBug/add-and-commit@v9` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 17d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5


### Files modified

- `.github/workflows/checks.yml`
- `.github/workflows/deploy.yaml`
- `.github/workflows/docs.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/snapshots.yml`

### Security warnings

- Latest release v0.7.0 is only 2 day(s) old (< 7 days). Using previous safe release.