### PR TITLE
fix(popover): align rtl panel with anchor when a vertical scrollbar is present

### DIFF
--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -29,7 +29,7 @@
 {#if visible}
   <div
     style="--popover-top: {`${bottom}px`}; --popover-left: {`${left}px`}; --popover-right: {`${
-      window.innerWidth - right
+      document.documentElement.clientWidth - right
     }px`}"
     class="popover"
     aria-orientation="vertical"


### PR DESCRIPTION
# Motivation

`--popover-right` is computed from `window.innerWidth - anchor.right`, but
`.popover` is `position: fixed; right: 0` (right edge at the inner viewport,
scrollbar excluded). `window.innerWidth` includes the scrollbar, so the rtl
wrapper lands `scrollbarWidth` left of its anchor whenever a vertical scrollbar
is present.

# Changes

- `Popover.svelte`: use `document.documentElement.clientWidth` for the
  `--popover-right` calc (matches the overlay's actual right edge).