### PR TITLE
refactor(popover): extract PopoverDirection into src/lib/types and re-export

### DIFF
--- a/src/lib/components/Popover.svelte
+++ b/src/lib/components/Popover.svelte
@@ -5,10 +5,11 @@
   import Backdrop from "./Backdrop.svelte";
   import IconClose from "$lib/icons/IconClose.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { PopoverDirection } from "$lib/types/popover";
 
   export let anchor: HTMLElement | undefined = undefined;
   export let visible = false;
-  export let direction: "ltr" | "rtl" = "ltr";
+  export let direction: PopoverDirection = "ltr";
   export let closeButton = false;
   export let invisibleBackdrop = false;
   export let testId = "gix-cmp-popover-component";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,6 +12,7 @@ export type { BusyState } from "./types/busy";
 export type { ChipGroupItem } from "./types/chip-group";
 export type { InputProps } from "./types/input";
 export type { ModalProps } from "./types/modal";
+export type { PopoverDirection } from "./types/popover";
 export type { ProgressBarSegment } from "./types/progress-bar";
 export type { ProgressStep, ProgressStepState } from "./types/progress-step";
 export * from "./types/theme";

--- a/src/lib/types/popover.ts
+++ b/src/lib/types/popover.ts
@@ -1,0 +1,1 @@
+export type PopoverDirection = "ltr" | "rtl";


### PR DESCRIPTION
## Motivation

Component-level types in this repo live under `src/lib/types/<name>.ts` and are re-exported from `src/lib/index.ts` (e.g. `ModalProps`, `InputProps`, `WizardStep`, `ToastLevel`). The literal type of `Popover`'s `direction` prop is currently inlined in `Popover.svelte`, which makes it inconsistent with the rest of the public API surface and prevents consumers from referring to it by name.
