### PR TITLE
fix(e2e): stop per-test Playwright tracing from hanging CI on Chrome 149

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run e2e:snapshots
       - name: Commit Playwright updated snapshots
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ always() && github.ref != 'refs/heads/main' }}
         with:
           add: e2e
           default_author: github_actions

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Run Playwright tests
+        id: playwright
         run: npm run e2e:snapshots
       - name: Commit Playwright updated snapshots
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
-        if: ${{ always() && github.ref != 'refs/heads/main' }}
+        if: ${{ !cancelled() && steps.playwright.outcome != 'skipped' && github.ref != 'refs/heads/main' }}
         with:
           add: e2e
           default_author: github_actions

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
   testMatch: ["**/*.e2e.ts"],
   use: {
     testIdAttribute: "data-tid",
-    trace: "on",
+    trace: "retain-on-failure",
   },
   projects: [
     {


### PR DESCRIPTION
# Motivation

The E2E (Playwright) suite was failing on nearly every PR — almost all tests timing out at 30s ("failing all over").

The trigger was the GitHub Actions runner's Google Chrome auto-updating from **148** to **149**, but **not** in the way it first appears — the screenshots are not stale. With Chrome 149, `playwright test --update-snapshots` rewrites **zero** baselines and the whole suite passes.

The real culprit is **per-test tracing** (`trace: "on"` in `playwright.config.ts`). Playwright finalizes a trace after every test, and on Chrome 149 (+ Playwright 1.56) that finalization blocks the worker ~30s, so the *next* test is killed by the test timeout. The test bodies themselves complete in <2s.

Evidence:
- Clean A/B on this branch — same command, same Chrome, only the trace setting changed: `trace: "on"` → 47 failed in ~15 min; `trace: "off"` → **50 passed in 56s**, 0 baseline changes.
- In the failing run's HTML report, passing tests have a `trace` attachment while timed-out tests have none and burn the full 30s after their last recorded step (all steps green, no assertion error).
- Does not reproduce locally (`trace: "on"` works fine there) — specific to the CI Chrome/Playwright combination.

# Changes

- **`playwright.config.ts`** — `trace: "on"` → `trace: "retain-on-failure"`. Traces are discarded on green runs (so the per-test hang is gone), but still captured for failures, preserving debuggability. Verified on CI: e2e job green, **50 passed in ~1.1 min**.
- **`.github/workflows/snapshots.yml`** — run the "Commit Playwright updated snapshots" step with `if: always()` (still gated off `main`). `playwright test --update-snapshots` exits non-zero whenever it rewrites a baseline, so without this any regenerated snapshots are never committed. Latent bug surfaced while debugging; harmless when nothing changed.

# Caveat

While Chrome 149 + Playwright 1.56 has this tracing bug, a *genuinely failing* test may spend up to 30s saving its trace (since `retain-on-failure` writes on failure). Green runs are unaffected. If that becomes annoying, `trace: "off"` avoids it entirely at the cost of failure traces; the proper long-term fix is a Playwright/Chrome upgrade that resolves the tracing hang.

# Screenshots

N/A — no UI or reference-image changes.
