### PR TITLE
fix: resolve CI lint errors

### DIFF
--- a/src/routes/(page)/resources/+page.svelte
+++ b/src/routes/(page)/resources/+page.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  import { resolve } from "$app/paths";
+</script>
+
 <h1>Resources</h1>
 
 <p>Useful resources and links.</p>
@@ -65,7 +69,7 @@
 
 <ul>
   <li>
-    <a href="/browser">Browser detection</a>
+    <a href={resolve("/browser")}>Browser detection</a>
   </li>
   <li>
     Source code on <a

--- a/src/tests/lib/components/ChipGroup.spec.ts
+++ b/src/tests/lib/components/ChipGroup.spec.ts
@@ -36,11 +36,7 @@ describe("ChipGroup", () => {
     });
     const chipElements = getAllByTestId("chip-component");
     chipElements.forEach((chip, index) => {
-      if (index === selectedIndex) {
-        expect(chip).toHaveClass("selected");
-      } else {
-        expect(chip).not.toHaveClass("selected");
-      }
+      expect(chip.classList.contains("selected")).toBe(index === selectedIndex);
     });
   });
 
@@ -56,11 +52,7 @@ describe("ChipGroup", () => {
     fireEvent.click(chipElements[selectedIndex]);
     await tick();
     chipElements.forEach((chip, index) => {
-      if (index === selectedIndex) {
-        expect(chip).toHaveClass("selected");
-      } else {
-        expect(chip).not.toHaveClass("selected");
-      }
+      expect(chip.classList.contains("selected")).toBe(index === selectedIndex);
     });
   });
 

--- a/src/tests/lib/components/Dropdown.spec.ts
+++ b/src/tests/lib/components/Dropdown.spec.ts
@@ -1,3 +1,4 @@
+import { assertNonNullish } from "@dfinity/utils";
 import { fireEvent, render } from "@testing-library/svelte";
 import { clickByTestId } from "../../utils/utils.test-utils";
 import DropdownTest from "./DropdownTest.svelte";
@@ -26,12 +27,13 @@ describe("Dropdown", () => {
     });
 
     const selectElement = container.querySelector("select");
-    selectElement && expect(selectElement.value).toBe(options[0].value);
+    assertNonNullish(selectElement);
 
-    selectElement &&
-      fireEvent.change(selectElement, { target: { value: options[4].value } });
+    expect(selectElement.value).toBe(options[0].value);
 
-    selectElement && expect(selectElement.value).toBe(options[4].value);
+    fireEvent.change(selectElement, { target: { value: options[4].value } });
+
+    expect(selectElement.value).toBe(options[4].value);
   });
 
   it("should allow setting an initial value", () => {
@@ -42,16 +44,21 @@ describe("Dropdown", () => {
     });
 
     const selectElement = container.querySelector("select");
-    selectElement && expect(selectElement.value).toBe(value);
+    assertNonNullish(selectElement);
+
+    expect(selectElement.value).toBe(value);
   });
 
   it("should bind the value", async () => {
     const { queryByTestId, container } = render(DropdownTest, { props });
 
     const selectElement = container.querySelector("select");
-    selectElement && expect(selectElement.value).toBe("1");
+    assertNonNullish(selectElement);
+
+    expect(selectElement.value).toBe("1");
 
     await clickByTestId(queryByTestId, "test");
-    selectElement && expect(selectElement.value).toBe("3");
+
+    expect(selectElement.value).toBe("3");
   });
 });

--- a/src/tests/lib/components/Input.svelte.spec.ts
+++ b/src/tests/lib/components/Input.svelte.spec.ts
@@ -202,17 +202,15 @@ describe("Input", () => {
 
     const input: HTMLInputElement | null = container.querySelector("input");
 
-    expect(input).not.toBeNull();
+    assertNonNullish(input);
 
-    if (input) {
-      fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.change(input, { target: { value: "test" } });
 
-      expect(input.value).toBe("");
+    expect(input.value).toBe("");
 
-      fireEvent.change(input, { target: { value: "123" } });
+    fireEvent.change(input, { target: { value: "123" } });
 
-      expect(input.value).toBe("123");
-    }
+    expect(input.value).toBe("123");
   });
 
   it("should accept text as input", () => {
@@ -225,21 +223,19 @@ describe("Input", () => {
 
     const input: HTMLInputElement | null = container.querySelector("input");
 
-    expect(input).not.toBeNull();
+    assertNonNullish(input);
 
-    if (input) {
-      fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.change(input, { target: { value: "test" } });
 
-      expect(input.value).toBe("test");
+    expect(input.value).toBe("test");
 
-      fireEvent.change(input, { target: { value: "123" } });
+    fireEvent.change(input, { target: { value: "123" } });
 
-      expect(input.value).toBe("123");
+    expect(input.value).toBe("123");
 
-      fireEvent.change(input, { target: { value: "test123" } });
+    fireEvent.change(input, { target: { value: "test123" } });
 
-      expect(input.value).toBe("test123");
-    }
+    expect(input.value).toBe("test123");
   });
 
   it("should render the button slot", () => {

--- a/src/tests/lib/components/ProgressBar.spec.ts
+++ b/src/tests/lib/components/ProgressBar.spec.ts
@@ -1,4 +1,5 @@
 import ProgressBar from "$lib/components/ProgressBar.svelte";
+import { assertNonNullish } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import ProgressBarTest from "./ProgressBarTest.svelte";
 
@@ -11,9 +12,9 @@ describe("ProgressBar", () => {
 
     const progressElement = container.querySelector("progress");
 
-    expect(progressElement).not.toBeNull();
+    assertNonNullish(progressElement);
 
-    progressElement && expect(progressElement.value).toBe(value);
+    expect(progressElement.value).toBe(value);
   });
 
   it("should render a progress element with max value", () => {
@@ -25,9 +26,9 @@ describe("ProgressBar", () => {
 
     const progressElement = container.querySelector("progress");
 
-    expect(progressElement).not.toBeNull();
+    assertNonNullish(progressElement);
 
-    progressElement && expect(progressElement.max).toBe(max);
+    expect(progressElement.max).toBe(max);
   });
 
   it("should use segment prop to calculate the prop", () => {
@@ -43,10 +44,10 @@ describe("ProgressBar", () => {
 
     const progressElement = container.querySelector("progress");
 
-    expect(progressElement).not.toBeNull();
+    assertNonNullish(progressElement);
 
     // 40 is the sum of the segments
-    progressElement && expect(progressElement.value).toBe(40);
+    expect(progressElement.value).toBe(40);
   });
 
   it("should render top and bottom slots", () => {
@@ -58,8 +59,8 @@ describe("ProgressBar", () => {
 
     const progressElement = container.querySelector("progress");
 
-    expect(progressElement).not.toBeNull();
+    assertNonNullish(progressElement);
 
-    progressElement && expect(progressElement.max).toBe(max);
+    expect(progressElement.max).toBe(max);
   });
 });


### PR DESCRIPTION
Fixes the failing CI linters.

- **`svelte/no-navigation-without-resolve`**: wrap the internal `/browser` link in `resolve()` in `resources/+page.svelte`.
- **`vitest/no-conditional-expect`**: remove `expect` calls nested in conditionals/`&&` guards in ChipGroup, Dropdown, ProgressBar and Input specs (narrowing with `assertNonNullish` where needed).

eslint + prettier clean; 64 affected tests pass.