### PR TITLE
test(e2e): fix flaky busy-screen spinner snapshot

### DIFF
--- a/e2e/busy-screen.e2e.ts
+++ b/e2e/busy-screen.e2e.ts
@@ -11,8 +11,14 @@ test("Should hide spinner", async ({ page }) => {
   const button = page.getByTestId("busy-display");
   await button.click();
 
-  // Wait for animation
-  await page.waitForTimeout(1500);
+  // The showcase shows the busy screen, then auto-dismisses it after 1s
+  // (plus a fade-out transition). Rather than racing a fixed timeout, wait for
+  // the overlay to appear and then be fully removed from the DOM, so the
+  // screenshot always captures the same settled (spinner-hidden) state.
+  const busy = page.getByTestId("busy");
+
+  await expect(busy).toBeVisible();
+  await expect(busy).toHaveCount(0);
 
   await expect(page).toHaveScreenshot();
 });


### PR DESCRIPTION
## Problem

The `busy-screen.e2e.ts › Should hide spinner` snapshot is flaky. The showcase shows the busy screen on click, then auto-dismisses it after `setTimeout(stopBusy, 1000)` plus a svelte `fade` out-transition (~400ms). The test waited a **fixed `waitForTimeout(1500)`** — only ~100ms of margin after the fade completes (1000 + 400). Under CI load that margin disappears and the spinner is still partially visible, producing an intermittent ~6% pixel diff (`49621 pixels`).

It surfaced repeatedly on the dependency-bump branch ([#849](https://github.com/dfinity/gix-components/pull/849)) — passing on one run and failing on the next with an identical tree — but it's a pre-existing timing fragility, not specific to those bumps.

## Fix

Stop racing a wall-clock timeout. Assert the observable state instead:

```ts
const busy = page.getByTestId("busy");
await expect(busy).toBeVisible();   // overlay appeared
await expect(busy).toHaveCount(0);  // ...then fully removed from the DOM
await expect(page).toHaveScreenshot();
```

`toHaveCount(0)` resolves only after svelte removes the node at the end of the fade-out, so the screenshot always captures the same settled (spinner-hidden) state regardless of CI timing. No production code changes.

## Note

If the existing Linux baseline turns out to be a flaky (spinner-visible) capture, the snapshot may need a one-time regen via the **Update Snapshots** workflow on this branch — will do that if CI's e2e flags a diff.