### PR TITLE
docs: mark GIX Components as in maintenance mode (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GIX Components
 
+> [!WARNING]
+> **GIX Components is in maintenance mode.** The library receives critical fixes only — no new features or components are being added. We recommend against adopting it for new projects.
+
 GIX Components is a UI kit developed with [SvelteKit](https://kit.svelte.dev) by the GIX team.
 
 ## Getting Started


### PR DESCRIPTION
# Motivation

GIX Components is moving to maintenance mode: it receives critical fixes only, no new features, and is not recommended for new projects. We want this stated up front in the README. Since the README ships to npm (`files` in `package.json`), the warning will also render on the npm package page on the next published release.

# Changes

- Add a `> [!WARNING]` maintenance-mode callout at the top of `README.md`.

# Screenshots

N/A — README text only. Renders as a GitHub/npm warning callout.